### PR TITLE
MSBuild Move task creates folders

### DIFF
--- a/docs/msbuild/move-task.md
+++ b/docs/msbuild/move-task.md
@@ -52,7 +52,9 @@ Moves files to a new location.
   
 ## Remarks  
  Either the `DestinationFolder` parameter or the `DestinationFiles` parameter must be specified, but not both. If both are specified, the task fails and an error is logged.  
-  
+
+ The `Move` task will create folders as required to create the desired destination files.
+
  In addition to having the parameters that are listed in the table, this task inherits parameters from the <xref:Microsoft.Build.Tasks.TaskExtension> class, which itself inherits from the <xref:Microsoft.Build.Utilities.Task> class. For a list of these additional parameters and their descriptions, see [TaskExtension Base Class](../msbuild/taskextension-base-class.md).  
   
 ## See Also  

--- a/docs/msbuild/move-task.md
+++ b/docs/msbuild/move-task.md
@@ -53,7 +53,7 @@ Moves files to a new location.
 ## Remarks  
  Either the `DestinationFolder` parameter or the `DestinationFiles` parameter must be specified, but not both. If both are specified, the task fails and an error is logged.  
 
- The `Move` task will create folders as required to create the desired destination files.
+ The `Move` task creates folders as required for the desired destination files.
 
  In addition to having the parameters that are listed in the table, this task inherits parameters from the <xref:Microsoft.Build.Tasks.TaskExtension> class, which itself inherits from the <xref:Microsoft.Build.Utilities.Task> class. For a list of these additional parameters and their descriptions, see [TaskExtension Base Class](../msbuild/taskextension-base-class.md).  
   


### PR DESCRIPTION
This came up in conversation internally, and it should be documented that `Move` [creates folders](https://github.com/Microsoft/msbuild/blob/07c3b3392dc05e0e3aba18bdec235a374aa72301/src/Tasks/Move.cs#L258).