### PR TITLE
Added side by side sync settings change

### DIFF
--- a/docs/ide/synchronized-settings-in-visual-studio.md
+++ b/docs/ide/synchronized-settings-in-visual-studio.md
@@ -1,3 +1,4 @@
+
 ---
 title: "Synchronize your settings in Visual Studio | Microsoft Docs"
 ms.custom: ""
@@ -63,6 +64,14 @@ When you sign in to Visual Studio on multiple computers using the same personali
 
 ## Synchronize settings across Visual Studio family products and editions  
  Settings can be synchronized across any edition of Visual Studio, including the Community edition. Settings are also synchronized across Visual Studio family products. However, each of these family products may have its own settings that are not shared with Visual Studio. For example, settings specific to one product on Computer A will be shared with another on Computer B, but not with Visual Studio on Computer A or B.  
+
+## Side-by-side synchronized settings
+In Visual Studio 15.3 and later, we've stopped sharing certain settings, like tool window layout, between different side-by-side installations of Visual Studio 2017 by changing the location of “CurrentSettings.vssettings” file in “%userprofile%\Documents\Visual Studio 2017\Settings” to an installation specific folder that is similar to “%localappdata%\Microsoft\VisualStudio\15.0_xxxxxxxx\Settings”.
+
+**NOTE**: To use the new installation specific settings, you must complete a fresh installation. When you perform an upgrade of an existing Visual Studio 2017 installation to the most current update, it will use the existing shared location. If you currently have side-by-side installations of Visual Studio 2017 and decide to upgrade, and want to use the new installation specific settings file location, follow these steps:
+  1. After the upgrade, use the Import\Export settings wizard to export all our existing settings to some location outside of       “%localappdata%\Microsoft\VisualStudio\15.0_xxxxxxxx” folder.
+  2. Open the developer command prompt of the upgraded Visual Studio installation and run devenv resetuserdata from it.
+  3. Launch Visual Studio and import the saved settings from the exported settings file. 
 
 ## See also  
  [Personalizing the  IDE](../ide/personalizing-the-visual-studio-ide.md)


### PR DESCRIPTION
Added how to ensure settings are using the new settings location. This was a customer ask we addressed in 15.3 and want to ensure users understand how to make VS use the new location in side by side installs.