### PR TITLE
corrected typo

### DIFF
--- a/docs/code-quality/code-analysis-rule-set-reference.md
+++ b/docs/code-quality/code-analysis-rule-set-reference.md
@@ -32,7 +32,7 @@ translation.priority.mt:
   - "tr-tr"
 ---
 # Code analysis rule set reference
-When you configure code analysis for managed code projects in [!INCLUDE[vsPreLong](../code-quality/includes/vsprelong_md.md)], [!INCLUDE[vsUltLong](../code-quality/includes/vsultlong_md.md)], or [!INCLUDE[vsPro](../code-quality/includes/vspro_md.md)]you are presented with a list of built-in *rule sets*. You can either use one of the standar rule sets, or you can customize a  rule set to fit your project requirements.  
+When you configure code analysis for managed code projects in [!INCLUDE[vsPreLong](../code-quality/includes/vsprelong_md.md)], [!INCLUDE[vsUltLong](../code-quality/includes/vsultlong_md.md)], or [!INCLUDE[vsPro](../code-quality/includes/vspro_md.md)]you are presented with a list of built-in *rule sets*. You can either use one of the standard rule sets, or you can customize a  rule set to fit your project requirements.  
   
 ## Available Rule Sets  
  The following table lists the default rule sets:  


### PR DESCRIPTION
In docs/code-quality/code-analysis-rule-set-reference.md
standar -> standard 