### PR TITLE
Fix syntax in C++ Core Guidelines MSBuild example

### DIFF
--- a/docs/code-quality/using-the-cpp-core-guidelines-checkers.md
+++ b/docs/code-quality/using-the-cpp-core-guidelines-checkers.md
@@ -183,7 +183,7 @@ You can run the C++ Core Checker only on specified files by using the same appro
     </BuildMacro>
     <BuildMacro Include="Esp_Extensions">
       <EnvironmentVariable>true</EnvironmentVariable>
-      <ValueCppCoreCheck.dll</Value>
+      <Value>CppCoreCheck.dll</Value>
     </BuildMacro>
 </ItemGroup>
 ```


### PR DESCRIPTION
There was an unclosed XML element in the `BuildMacro` example.