### PR TITLE
Include link to OSPlatform

### DIFF
--- a/docs/msbuild/property-functions.md
+++ b/docs/msbuild/property-functions.md
@@ -194,7 +194,7 @@ In the .NET Framework versions 4 and 4.5, property functions can be used to eval
 |int BitwiseAnd(int first, int second)|Perform a bitwise `AND` on the first and second (first & second).|  
 |int BitwiseXor(int first, int second)|Perform a bitwise `XOR` on the first and second (first ^ second).|  
 |int BitwiseNot(int first)|Perform a bitwise `NOT` (~first).|  
-|bool IsOsPlatform(string platformString)|Specify whether the current OS platform is `platformString`. `platformString` must be a member of `OSPlatform`.|
+|bool IsOsPlatform(string platformString)|Specify whether the current OS platform is `platformString`. `platformString` must be a member of [OSPlatform](https://docs.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.osplatform).|
 |bool IsOSUnixLike|True if current OS is a Unix system.|
 |string NormalizePath(params string[] path)|Gets the canonicalized full path of the provided path and ensures it contains the correct directory separator characters for the current operating system.|
 |string NormalizeDirectory(params string[] path)|Gets the canonicalized full path of the provided directory and ensures it contains the correct directory separator characters for the current operating system while ensuring it has a trailing slash.|

--- a/docs/msbuild/property-functions.md
+++ b/docs/msbuild/property-functions.md
@@ -194,7 +194,7 @@ In the .NET Framework versions 4 and 4.5, property functions can be used to eval
 |int BitwiseAnd(int first, int second)|Perform a bitwise `AND` on the first and second (first & second).|  
 |int BitwiseXor(int first, int second)|Perform a bitwise `XOR` on the first and second (first ^ second).|  
 |int BitwiseNot(int first)|Perform a bitwise `NOT` (~first).|  
-|bool IsOsPlatform(string platformString)|Specify whether the current OS platform is `platformString`. `platformString` must be a member of [OSPlatform](https://docs.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.osplatform).|
+|bool IsOsPlatform(string platformString)|Specify whether the current OS platform is `platformString`. `platformString` must be a member of <xref:system.runtime.interopservices.osplatform>.|
 |bool IsOSUnixLike|True if current OS is a Unix system.|
 |string NormalizePath(params string[] path)|Gets the canonicalized full path of the provided path and ensures it contains the correct directory separator characters for the current operating system.|
 |string NormalizeDirectory(params string[] path)|Gets the canonicalized full path of the provided directory and ensures it contains the correct directory separator characters for the current operating system while ensuring it has a trailing slash.|


### PR DESCRIPTION
For someone not coming from .NET core, simply saying "the values come from `OSPlatform`" for the explanation of `IsOsPlatform` make little sense. Adding a link instead allows you to see the list of permissible values right away.