### PR TITLE
Fix invalid whitespace in metadata for customize-your-build.md

### DIFF
--- a/docs/msbuild/customize-your-build.md
+++ b/docs/msbuild/customize-your-build.md
@@ -23,7 +23,7 @@ translation.priority.ht:
   - "fr-fr"
   - "it-it"
   - "ja-jp"
-  - "ko-kr"  
+  - "ko-kr"
   - "pl-pl"
   - "pt-br"
   - "ru-ru"


### PR DESCRIPTION
This page doesn't render correctly, I think it was because of the trailing whitespace in the metadata