### PR TITLE
Add docs to clean up failed Visual Studio install

### DIFF
--- a/docs/install/TOC.md
+++ b/docs/install/TOC.md
@@ -5,6 +5,7 @@
 # [Update Visual Studio](update-visual-studio.md)
 # [Modify Visual Studio](modify-visual-studio.md)
 # [Uninstall Visual Studio](uninstall-visual-studio.md)
+## [Clean up Visual Studio](cleanup-visual-studio.md)
 # [Visual Studio Administrator Guide](visual-studio-administrator-guide.md)
 ## [Use command-line parameters to install Visual Studio](use-command-line-parameters-to-install-visual-studio.md)
 ## [Command-line parameter examples](command-line-parameter-examples.md)

--- a/docs/install/cleanup-visual-studio.md
+++ b/docs/install/cleanup-visual-studio.md
@@ -1,0 +1,53 @@
+---
+title: "Clean up Visual Studio 2017 | Microsoft Docs"
+description: "Learn how to clean up Visual Studio, step-by-step."
+ms.custom: ""
+ms.date: "09/12/2017"
+ms.reviewer: ""
+ms.suite: ""
+ms.technology:
+  - "vs-ide-install"
+ms.tgt_pltfrm: ""
+ms.topic: "article"
+f1_keywords:
+  - "uninstall"
+  - "uninstall Visual Studio"
+  - "cleanup"
+  - "cleanup Visual Studio"
+  - "clean up"
+  - "clean up Visual Studio"
+ms.assetid: 9c81a777-9c95-4934-b517-c60c6dc78799
+author: "heaths"
+ms.author: "heaths"
+manager: "erickn"
+---
+
+# Clean up Visual Studio
+
+If you encounter a catastrophic error and cannot repair or uninstall Visual Studio, you can run the `InstallCleanup.exe` tool to remove installation files and product information. This is to be done as a last resort if repair or uninstall fail, and may uninstall features from other Visual Studio installations or other products which will need to be repaired.
+
+In the instructions below, you can run the tool with different command line switches with the following behavior.
+
+| Switch | Behavior |
+| ------ | -------- |
+| `-i`   | This is the default if no other switch is passed and will remove only the main installation directory and product information. This behavior is preferable if you intend to reinstall the same version after you run the `InstallCleanup.exe` tool. |
+| `-f`   | This will remove the main installation directory, product information, and most other features installed outside the installation directory that may be shared with other Visual Studio installations or other products. This behavior is preferable if you intend to remove Visual Studio without reinstalling later. |
+
+1. Close the Visual Studio Installer.
+2. Open an administrator command prompt. To do this, follow these steps:
+   * On the **Start** menu, click **Run** (Start + R).
+   * Type **cmd**.
+   * Right-click **Command Prompt**, and then click **Run as administrator**.
+3. Type the full path of the `InstallCleanup.exe` utility and pass whichever command line switch you desire. By default, the path of the utility is as follows:
+   ```
+   C:\Program Files (x86)\Microsoft Visual Studio\Installer\resources\app\layout\InstallCleanup.exe
+   ```
+
+If you do not find `InstallCleanup.exe` under the Visual Studio Installer directory - always located at `%ProgramFiles(x86)%\Microsoft Visual Studio` - please follow the instructions to [install Visual Studio](install-visual-studio.md) and when the workload selection screen is displayed, close the window and follow the steps above again.
+
+## See also
+* [Install Visual Studio 2017](install-visual-studio.md)
+* [Update Visual Studio 2017](update-visual-studio.md)
+* [Modify Visual Studio 2017](modify-visual-studio.md)
+* [Uninstall Visual Studio 2017](uninstall-visual-studio.md)
+* [How to Report a Problem with Visual Studio 2017](../ide/how-to-report-a-problem-with-visual-studio-2017.md)

--- a/docs/install/install-visual-studio.md
+++ b/docs/install/install-visual-studio.md
@@ -120,11 +120,11 @@ After Visual Studio installation is complete, click the **Launch** button to [Ge
 
 Sometimes, things can go wrong. If your Visual Studio installation fails, see the [Troubleshooting Visual Studio 2017 installation and upgrade issues](troubleshooting-installation-issues.md) page for troubleshooting tips.
 
-## See also  
-* [Modify Visual Studio 2017](modify-visual-studio.md)
+## See also
 * [Update Visual Studio 2017](update-visual-studio.md)
+* [Modify Visual Studio 2017](modify-visual-studio.md)
 * [Uninstall Visual Studio 2017](uninstall-visual-studio.md)
-* [Visual Studio 2017 administrator guide](visual-studio-administrator-guide.md)
+* [Administrator guide for Visual Studio 2017](visual-studio-administrator-guide.md)
   * [Use command-line parameters to install Visual Studio 2017](use-command-line-parameters-to-install-visual-studio.md)
 * [Create an offline installation of Visual Studio 2017](create-an-offline-installation-of-visual-studio.md)
 * [Report a problem with Visual Studio 2017](../ide/how-to-report-a-problem-with-visual-studio-2017.md)

--- a/docs/install/modify-visual-studio.md
+++ b/docs/install/modify-visual-studio.md
@@ -55,8 +55,8 @@ If you don't want to use the handy Workloads feature to customize your Visual St
 ## Get support
 Sometimes, things can go wrong. If your Visual Studio installation fails, see the [Troubleshooting Visual Studio 2017 installation and upgrade issues](troubleshooting-installation-issues.md) page for troubleshooting tips.
 
-## See also  
-* [Install Visual Studio 2017](https://go.microsoft.com/fwlink/?linkid=833223)
-* [Update Visual Studio](update-visual-studio.md)
+## See also
+* [Install Visual Studio 2017](install-visual-studio.md)
+* [Update Visual Studio 2017](update-visual-studio.md)
 * [Uninstall Visual Studio 2017](uninstall-visual-studio.md)
 * [How to Report a Problem with Visual Studio 2017](../ide/how-to-report-a-problem-with-visual-studio-2017.md)

--- a/docs/install/troubleshooting-installation-issues.md
+++ b/docs/install/troubleshooting-installation-issues.md
@@ -36,8 +36,8 @@ The Visual Studio Installer bootstrapper is a minimal light-weight executable th
 **Note:** Performing the following actions reinstalls the Visual Studio Installer files and resets the installation metadata.
 
 1. Close the Visual Studio Installer.
-2. Delete the Visual Studio Installer directory. Typically, the directory is C:\Program Files (x86)\Microsoft Visual Studio\Installer.
-3. Run the Visual Studio Installer bootstrapper. You may find the bootstrapper in your Downloads folder with a file name that follows a ```vs_[Visual Studio edition]__*.exe``` pattern. If you don't find that application, you can download the bootstrapper by going to the [Visual Studio downloads](https://www.visualstudio.com/downloads/) page and clicking **Download** for your edition of Visual Studio. Run the executable to reset your installation metadata.
+2. Delete the Visual Studio Installer directory. Typically, the directory is `C:\Program Files (x86)\Microsoft Visual Studio\Installer`.
+3. Run the Visual Studio Installer bootstrapper. You may find the bootstrapper in your Downloads folder with a file name that follows a `vs_[Visual Studio edition]__*.exe` pattern. If you don't find that application, you can download the bootstrapper by going to the [Visual Studio downloads](https://www.visualstudio.com/downloads/) page and clicking **Download** for your edition of Visual Studio. Run the executable to reset your installation metadata.
 4. Try to install or update Visual Studio again. If the Installer continues to fail, go to the next step.
 
 ### Step 4 - Report a problem
@@ -46,24 +46,16 @@ In some situations, such as those related to corrupted files, the problems may h
 1. Collect your setup logs. See [How to get the Visual Studio installation logs](#how-to-get-the-visual-studio-installation-logs) below for details.
 2. Open the Visual Studio Installer, and then click **Report a problem** to open the Visual Studio Feedback tool.
 ![You can tab to the Provide Feedback button to open the feedback tool](media/report-a-problem.png)
-3. Give your problem report a title, and provide relevant details. Click **Next** to go to the **Attachments** section, and then attach the generated log file (typically, the file is at %TEMP%\vslogs.zip).
+3. Give your problem report a title, and provide relevant details. Click **Next** to go to the **Attachments** section, and then attach the generated log file (typically, the file is at `%TEMP%\vslogs.zip`).
 ![Tab to the Report New Problem button, then follow through the steps](media/problem-report-details.png)
 4. Click **Next** to review your problem report, and then click **Submit**.
 
 ### Step 5 - Run InstallCleanup.exe to clean up installation files
-As a last resort, you can run InstallCleanup.exe. InstallCleanup.exe is a tool that's packaged with the Visual Studio Installer, and it cleans up installation files. This tool doesn't perform a full reinstall. This tool deletes cache and instance data for Visual Studio 2017.
+As a last resort, you can [clean up Visual Studio](cleanup-visual-studio.md) to remove all installation files and product information.
 
-1. Close the Visual Studio Installer.
-2. Open an administrator command prompt. To do this, follow these steps:
-   * On the **Start** menu, click **Run** (Start + R).
-   * Type **cmd**.
-   * Right-click **Command Prompt**, and then choose **Run as administrator**.
-3. Type the full path of the InstallCleanup.exe utility, and pass the following command-line switch: -f. By default, the path of the utility is as follows:
-   ```
-   C:\Program Files (x86)\Microsoft Visual Studio\Installer\resources\app\layout\InstallCleanup.exe
-   ```
-4. Rerun the bootstrapper that's described in [Step 3 - Delete the Visual Studio Installer directory to fix upgrade problems](#step-3--delete-the-visual-studio-installer-directory-to-fix-upgrade-problems).
-5. Try to install or update Visual Studio again.
+1. Follow the instructions in [Clean up Visual Studio](cleanup-visual-studio.md).
+2. Rerun the bootstrapper that's described in [Step 3 - Delete the Visual Studio Installer directory to fix upgrade problems](#step-3--delete-the-visual-studio-installer-directory-to-fix-upgrade-problems).
+3. Try to install or update Visual Studio again.
 
 ## How to troubleshoot an offline installer
 Here is a table of known issues and some workarounds when installing from a local layout that might help.
@@ -82,8 +74,8 @@ To collect the logs
 
 1. [Download the tool](https://aka.ms/vscollect).
 2. Open an administrative command prompt.
-3. Run Collect.exe from the directory where you saved the tool.
-4. Find the resulting Vslogs.zip file in your %TEMP% directory, for example, C:\Users\YourName\AppData\Local\Temp\vslogs.zip.
+3. Run `Collect.exe` from the directory where you saved the tool.
+4. Find the resulting `vslogs.zip` file in your `%TEMP%` directory, for example, `C:\Users\YourName\AppData\Local\Temp\vslogs.zip`.
 
 > [!NOTE]
-> The tool must be run under the same user account that the failed installation was run under. If you are running the tool from a different user account, set the –user:\<name\> option to specify the user account under which the failed installation was run. Run `Collect.exe -?` from an administrator command prompt for additional options and usage information.
+> The tool must be run under the same user account that the failed installation was run under. If you are running the tool from a different user account, set the `–user:<name>` option to specify the user account under which the failed installation was run. Run `Collect.exe -?` from an administrator command prompt for additional options and usage information.

--- a/docs/install/uninstall-visual-studio.md
+++ b/docs/install/uninstall-visual-studio.md
@@ -46,9 +46,9 @@ To completely remove all installations of Visual Studio 2017 as well as the Visu
 2. Find **Microsoft Visual Studio 2017**.  
 3. Click **Uninstall**.  
 
-
-## See also  
+## See also
 * [Install Visual Studio](install-visual-studio.md)
 * [Modify Visual Studio 2017](modify-visual-studio.md)
 * [Update Visual Studio](update-visual-studio.md)
+* [Clean up Visual Studio](cleanup-visual-studio.md)
 * [How to Report a Problem with Visual Studio 2017](../ide/how-to-report-a-problem-with-visual-studio-2017.md)

--- a/docs/install/update-visual-studio.md
+++ b/docs/install/update-visual-studio.md
@@ -69,8 +69,8 @@ We update Visual Studio often to extend its functionality and to fix customer-re
 Sometimes, things can go wrong. If your Visual Studio installation fails, see the [Troubleshooting Visual Studio 2017 installation and upgrade failures](https://support.microsoft.com/help/4015967/troubleshooting-visual-studio-2017-installation-and-upgrade-failures) KB article for troubleshooting tips.
 
 ## See also
-* [Install Visual Studio 2017](https://go.microsoft.com/fwlink/?linkid=833223)
+* [Install Visual Studio 2017](install-visual-studio.md)
 * [Modify Visual Studio 2017](modify-visual-studio.md)
 * [Uninstall Visual Studio 2017](uninstall-visual-studio.md)
-* [Visual Studio administrator guide for Visual Studio 2017](visual-studio-administrator-guide.md)
+* [Administrator guide for Visual Studio 2017](visual-studio-administrator-guide.md)
 * [Report a problem with Visual Studio 2017](../ide/how-to-report-a-problem-with-visual-studio-2017.md)


### PR DESCRIPTION
Also made a few other changes for consistency, like backticks for paths (including file names) and proper branding.