### PR TITLE
remote debugger path to match default VS 2017 install location

### DIFF
--- a/docs/debugger/remote-debugging.md
+++ b/docs/debugger/remote-debugging.md
@@ -63,11 +63,11 @@ If you just want to download and install the remote debugger and don't need any 
 
 You can find the remote debugger (**msvsmon.exe**) on a computer with Visual Studio Community, Professional, or Enterprise already installed. For some scenarios, the easiest way to set up remote debugging is to run the remote debugger (msvsmon.exe) from a file share. For usage limitations, see the remote debugger's Help page (**Help > Usage** in the remote debugger).
 
-1. Find **msvsmon.exe** in the directory matching your version of Visual Studio. For Visual Studio 2017:
+1. Find **msvsmon.exe** in the directory matching your version of Visual Studio. For Visual Studio Enterprise 2017:
 
-      **Program Files\Microsoft Visual Studio 15.0\Common7\IDE\Remote Debugger\x86\msvsmon.exe**
+      **Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\Remote Debugger\x86\msvsmon.exe**
       
-      **Program Files\Microsoft Visual Studio 15.0\Common7\IDE\Remote Debugger\x64\msvsmon.exe**
+      **Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\Remote Debugger\x64\msvsmon.exe**
 
 2. Share the **Remote Debugger** folder on the Visual Studio computer.
 


### PR DESCRIPTION
I think folks coming to this page are best served by having a path which will match the default install location of Visual Studio.  Unfortunately due to the side-by-side installs of VS, we do have to choose an edition for the example paths.