### PR TITLE
Explain global property scope for child projects

### DIFF
--- a/docs/msbuild/msbuild-properties.md
+++ b/docs/msbuild/msbuild-properties.md
@@ -89,7 +89,7 @@ $(registry:Hive\MyKey\MySubKey)
 msbuild.exe MyProj.proj /p:Configuration=DEBUG  
 ```  
   
- Global properties can also be set or modified for child projects in a multi-project build by using the `Properties` attribute of the MSBuild task. For more information, see [MSBuild Task](../msbuild/msbuild-task.md).  
+ Global properties can also be set or modified for child projects in a multi-project build by using the `Properties` attribute of the MSBuild task. Global properties are also forwarded to child projects unless the `RemoveProperties` attribute of the MSBuild task is used to specify the list of proerties not to forward. For more information, see [MSBuild Task](../msbuild/msbuild-task.md).
   
  If you specify a property by using the `TreatAsLocalProperty` attribute in a project tag, that global property value doesn't override the property value that's set in the project file. For more information, see [Project Element (MSBuild)](../msbuild/project-element-msbuild.md) and [How to: Build the Same Source Files with Different Options](../msbuild/how-to-build-the-same-source-files-with-different-options.md).  
   


### PR DESCRIPTION
Add sentence to explain that child projects inherit the current global properties.

This originated from https://stackoverflow.com/questions/47165625/msbuild-what-are-rules-for-scope-inheritance-of-properties-items and it turns out this isn't documented very explicitly.