### PR TITLE
Add lost known issue from transfer.

### DIFF
--- a/docs/debugger/debug-live-azure-apps-troubleshooting.md
+++ b/docs/debugger/debug-live-azure-apps-troubleshooting.md
@@ -27,8 +27,7 @@ If you see a warning icon ![Snappoint warning icon](../debugger/media/snapshot-t
 
 Take these steps:
 
-1. Make sure you have the same version of source code that was used to build and deploy your app.
-1. Make sure you are loading the correct symbols for your deployment. To do this, view the **Modules** window while Snapshot Debugging and verify the Symbol File column shows a .pdb file loaded for the module you are debugging. Note that the Snapshot Debugger will try to automatically download and use symbols for your deployment.
+1. Make sure you have the same version of source code that was used to build and deploy your app.isua1. Make sure you are loading the correct symbols for your deployment. To do this, view the **Modules** window while Snapshot Debugging and verify the Symbol File column shows a .pdb file loaded for the module you are debugging. Note that the Snapshot Debugger will try to automatically download and use symbols for your deployment.
 
 ## Issue: Symbols do not load when I open a Snapshot
 
@@ -67,7 +66,7 @@ Take these steps:
 - Roslyn IL optimizations are not fully supported in ASP.NET Core projects. For some ASP.NET Core projects, you may not be able to see some variables or use some variables in conditional statements. 
 - Special variables, such as *$FUNCTION* or *$CALLER*, cannot be evaluated in conditional statements or logpoints for ASP.NET Core projects.
 - Snapshot debugging does not work on App Services that have [Local Caching](https://docs.microsoft.com/en-us/azure/app-service/app-service-local-cache) turned on.
-- Snapshot debugging API Apps is not yet supported - they will be supported in a future version of VS.
+- Snapshot debugging API Apps is not yet supported - they will be supported in a future version of Visual Studio.
 
 ## See also
 

--- a/docs/debugger/debug-live-azure-apps-troubleshooting.md
+++ b/docs/debugger/debug-live-azure-apps-troubleshooting.md
@@ -67,6 +67,7 @@ Take these steps:
 - Roslyn IL optimizations are not fully supported in ASP.NET Core projects. For some ASP.NET Core projects, you may not be able to see some variables or use some variables in conditional statements. 
 - Special variables, such as *$FUNCTION* or *$CALLER*, cannot be evaluated in conditional statements or logpoints for ASP.NET Core projects.
 - Snapshot debugging does not work on App Services that have [Local Caching](https://docs.microsoft.com/en-us/azure/app-service/app-service-local-cache) turned on.
+- Snapshot debugging API Apps is not yet supported - they will be supported in a future version of VS.
 
 ## See also
 

--- a/docs/debugger/debug-live-azure-apps-troubleshooting.md
+++ b/docs/debugger/debug-live-azure-apps-troubleshooting.md
@@ -66,7 +66,7 @@ Take these steps:
 - Roslyn IL optimizations are not fully supported in ASP.NET Core projects. For some ASP.NET Core projects, you may not be able to see some variables or use some variables in conditional statements. 
 - Special variables, such as *$FUNCTION* or *$CALLER*, cannot be evaluated in conditional statements or logpoints for ASP.NET Core projects.
 - Snapshot debugging does not work on App Services that have [Local Caching](https://docs.microsoft.com/en-us/azure/app-service/app-service-local-cache) turned on.
-- Snapshot debugging API Apps is not yet supported - they will be supported in a future version of Visual Studio.
+- Snapshot debugging API Apps is not currently supported.
 
 ## See also
 


### PR DESCRIPTION
The known issue bullet point `- Snapshot debugging API Apps is not yet supported - they will be supported in a future version of VS.` that was added in from #339 was lost during the transfer of the known issues section from `debug-live-azure-applications.md` to `debug-live-azure-apps-troubleshooting.md` during the 441cb8db6e6e425cddbc5344edf7855e027ab7f5 commit.