### PR TITLE
Fix display of named entities

### DIFF
--- a/docs/msbuild/how-to-use-reserved-xml-characters-in-project-files.md
+++ b/docs/msbuild/how-to-use-reserved-xml-characters-in-project-files.md
@@ -25,18 +25,18 @@ When you author project files, you might need to use reserved XML characters, fo
   
 |Reserved character|Named entity|  
 |------------------------|------------------|  
-|\<|&lt;|  
-|>|&gt;|  
-|&|&amp;|  
-|"|&quot;|  
-|'|&apos;|  
+|\<|&amp;lt;|  
+|>|&amp;gt;|  
+|&|&amp;amp;|  
+|"|&amp;quot;|  
+|'|&amp;apos;|  
   
 #### To use double quotes in a project file  
   
--   Replace the double quotes with the corresponding named entity, &quot;. For example, to place double quotes around the `EXEFile` item list, type:  
+-   Replace the double quotes with the corresponding named entity, &amp;quot;. For example, to place double quotes around the `EXEFile` item list, type:  
   
     ```xml  
-    <Message Text="The output file is "@(EXEFile)"."/>  
+    <Message Text="The output file is &quot;@(EXEFile)&quot;."/>  
     ```  
   
 ## Example  
@@ -64,7 +64,7 @@ When you author project files, you might need to use reserved XML characters, fo
                 ItemName = "EXEFile"/>  
         </Csc>  
         <!-- Log the file name of the output file -->  
-        <Message Text="The output file is "@(EXEFile)"."/>  
+        <Message Text="The output file is &quot;@(EXEFile)&quot;."/>  
     </Target>  
 </Project>  
 ```  

--- a/docs/msbuild/how-to-use-reserved-xml-characters-in-project-files.md
+++ b/docs/msbuild/how-to-use-reserved-xml-characters-in-project-files.md
@@ -70,5 +70,5 @@ When you author project files, you might need to use reserved XML characters, fo
 ```  
   
 ## See Also  
- [MSBuild Reference](../msbuild/msbuild-reference.md)
- [MSBuild](../msbuild/msbuild.md)
+ [MSBuild Reference](../msbuild/msbuild-reference.md)    
+ [MSBuild](../msbuild/msbuild.md)    


### PR DESCRIPTION
Replace reserved characters in named entities with named entities so they show up as named entities. They currently display as literals.

**Current view**
![chrome_2017-12-09_10-17-59](https://user-images.githubusercontent.com/5265970/33796831-8b928b3e-dcca-11e7-9159-30fa26a46cfb.png)
