### PR TITLE
Correct item function name 'HasMetadata'

### DIFF
--- a/docs/msbuild/item-functions.md
+++ b/docs/msbuild/item-functions.md
@@ -59,7 +59,7 @@ Starting with MSBuild 4.0, code in tasks and targets can call item functions to 
 |`Reverse`|`@(MyItem->Reverse())`|Returns the items in reverse order.|  
 |`AnyHaveMetadataValue`|`@(MyItem->AnyHaveMetadataValue("MetadataName", "MetadataValue"))`|Returns a `boolean` to indicate whether any item has the given metadata name and value. The comparison is case insensitive.|  
 |`ClearMetadata`|`@(MyItem->ClearMetadata())`|Returns items with their metadata cleared. Only the `itemspec` is retained.|  
-|`HasMetadata`|`@(MyItem->HasMetadataValue("MetadataName"))`|Returns items that have the given metadata name. The comparison is case insensitive.|  
+|`HasMetadata`|`@(MyItem->HasMetadata("MetadataName"))`|Returns items that have the given metadata name. The comparison is case insensitive.|  
 |`Metadata`|`@(MyItem->Metadata("MetadataName"))`|Returns the values of the metadata that have the metadata name.|  
 |`WithMetadataValue`|`@(MyItem->WithMetadataValue("MetadataName", "MetadataValue"))`|Returns items that have the given metadata name and value. The comparison is case insensitive.|  
   


### PR DESCRIPTION
The function name is `HasMetadata` (the left column is correct), not `HasMetadataValue`.

See https://github.com/Microsoft/msbuild/blob/v15.4.8.50001/src/Build/Evaluation/Expander.cs#L2366