### PR TITLE
Fix language list on "Writing a Visualizer in C#"

### DIFF
--- a/docs/debugger/walkthrough-writing-a-visualizer-in-csharp.md
+++ b/docs/debugger/walkthrough-writing-a-visualizer-in-csharp.md
@@ -10,9 +10,6 @@ ms.tgt_pltfrm: ""
 ms.topic: "article"
 dev_langs: 
   - "CSharp"
-  - "VB"
-  - "FSharp"
-  - "C++"
 helpviewer_keywords: 
   - "visualizers, writing"
   - "walkthroughs [Visual Studio], visualizers"
@@ -67,7 +64,7 @@ Follow the tasks below to create a visualizer.
   
 6.  In DebuggerSide.cs, add the following statement to the `using` statements:  
   
-    ```  
+    ```csharp  
     using Microsoft.VisualStudio.DebuggerVisualizers;  
     ```  
   
@@ -77,13 +74,13 @@ Follow the tasks below to create a visualizer.
   
 1.  In DebuggerSide.cs, go to the following line of code:  
   
-    ```  
+    ```csharp  
     public class DebuggerSide  
     ```  
   
 2.  Change the code to:  
   
-    ```  
+    ```csharp  
     public class DebuggerSide : DialogDebuggerVisualizer  
     ```  
   
@@ -93,8 +90,8 @@ Follow the tasks below to create a visualizer.
   
 -   In `public class DebuggerSide`, add the following **method:**  
   
-    ```  
-    override protected void Show(IDialogVisualizerService windowService, IVisualizerObjectProvider objectProvider)  
+    ```csharp  
+    protected override void Show(IDialogVisualizerService windowService, IVisualizerObjectProvider objectProvider)  
     {  
     }  
     ```  
@@ -111,7 +108,7 @@ Follow the tasks below to create a visualizer.
   
 4.  In DebuggerSide.cs, add the following statement to the `using` statements:  
   
-    ```  
+    ```csharp  
     using System.Windows.Forms;  
     ```  
   
@@ -121,7 +118,7 @@ Follow the tasks below to create a visualizer.
   
 1.  In the `Show` method, add the following line of code:  
   
-    ```  
+    ```csharp  
     MessageBox.Show(objectProvider.GetObject().ToString());  
     ```  
   
@@ -135,12 +132,12 @@ Follow the tasks below to create a visualizer.
   
 1.  Add the following attribute code to DebuggerSide.cs, after the `using` statements but before `namespace MyFirstVisualizer`:  
   
-    ```  
+    ```csharp  
     [assembly:System.Diagnostics.DebuggerVisualizer(  
     typeof(MyFirstVisualizer.DebuggerSide),  
     typeof(VisualizerObjectSource),  
-    Target  = typeof(System.String),  
-    Description  = "My First Visualizer")]  
+    Target = typeof(System.String),  
+    Description = "My First Visualizer")]  
     ```  
   
 2.  On the **Build** menu, choose **Build MyFirstVisualizer**. The project should build successfully. Correct any build errors before continuing.  
@@ -151,7 +148,7 @@ Follow the tasks below to create a visualizer.
   
 1.  Add the following method to class `public DebuggerSide`:  
   
-    ```  
+    ```csharp  
     public static void TestShowVisualizer(object objectToVisualize)  
     {  
        VisualizerDevelopmentHost visualizerHost = new VisualizerDevelopmentHost(objectToVisualize, typeof(DebuggerSide));  
@@ -201,13 +198,13 @@ Follow the tasks below to create a visualizer.
   
 3.  In TestConsole.cs, add the following code to the `using` statements:  
   
-    ```  
+    ```csharp  
     using MyFirstVisualizer;  
     ```  
   
 4.  In method `Main`, add the following code:  
   
-    ```  
+    ```csharp  
     String myString = "Hello, World";  
     DebuggerSide.TestShowVisualizer(myString);  
     ```  


### PR DESCRIPTION
This page listed VB, F# and C++ options, but is C# specific. I fixed that list, and also added `csharp` to the code samples for syntax highlighting, and fixed a couple of formatting inconsistencies.