### PR TITLE
Using nameof when throwing ArgumentOutOfRangeException.

### DIFF
--- a/docs/code-quality/codesnippet/CSharp/ca2233-operations-should-not-overflow_2.cs
+++ b/docs/code-quality/codesnippet/CSharp/ca2233-operations-should-not-overflow_2.cs
@@ -7,7 +7,7 @@ namespace Samples
         public static int Decrement(int input)        
         {            
             if (input == int.MinValue)                
-                throw new ArgumentOutOfRangeException("input", "input must be greater than Int32.MinValue");
+                throw new ArgumentOutOfRangeException(nameof(input), "input must be greater than Int32.MinValue");
                              
             input--;             
             return input;        


### PR DESCRIPTION
Used nameof to avoid hard-coding the name of the parameter responsible for the ArgumentOutOfRangeException.