### PR TITLE
added one more OOP process name

### DIFF
--- a/docs/ide/not-in-toc/visual-studio-unrecoverable-process-error.md
+++ b/docs/ide/not-in-toc/visual-studio-unrecoverable-process-error.md
@@ -38,6 +38,7 @@ Following is a list of out-of-proc processes used by Visual Studio that must be 
 - ServiceHub.SettingsHost.exe
 - ServiceHub.Host.CLR.x86.exe
 - ServiceHub.RoslynCodeAnalysisService32.exe
+- ServiceHub.RoslynCodeAnalysisService.exe
 - WindowsAzureGuestAgent.exe
 - WindowsAzureTelemetryService.exe
 - WaAppAgent.exe


### PR DESCRIPTION
depends on arch (x86 or AnyCpu) of out of proc, name can be either ServiceHub.RoslynCodeAnalysisService32.exe or 
 ServiceHub.RoslynCodeAnalysisService.exe