### PR TITLE
Used boost-test instead of boost

### DIFF
--- a/docs/test/how-to-use-boost-test-for-cpp.md
+++ b/docs/test/how-to-use-boost-test-for-cpp.md
@@ -27,11 +27,15 @@ Boost.Test requires [Boost](http://www.boost.org/)! If you do not have Boost ins
 
 1. Follow the instructions at [Vcpkg: a C++ Package Manager for Windows](/cpp/vcpkg) to install vcpkg (if you don't already have it).
 
-1. Install the Boost.Test dynamic or static library
-	1. Run `vcpkg install boost-test` to install the Boost.Test dynamic library. 
-	1. Or run `vcpkg install boost-test:x86-windows-static` to install the Boost.Test static library. 
+1. Install the Boost.Test dynamic or static library:
 
-1. Run the `vcpkg integrate install` command to configure Visual Studio with the library and include paths to the Boost headers and binaries.
+	- Run `vcpkg install boost-test` to install the Boost.Test dynamic library.
+	
+	   -OR-
+	   
+	- Run `vcpkg install boost-test:x86-windows-static` to install the Boost.Test static library.
+
+1. Run `vcpkg integrate install` to configure Visual Studio with the library and include paths to the Boost headers and binaries.
 
 ## Create a project for your tests
 

--- a/docs/test/how-to-use-boost-test-for-cpp.md
+++ b/docs/test/how-to-use-boost-test-for-cpp.md
@@ -27,7 +27,9 @@ Boost.Test requires [Boost](http://www.boost.org/)! If you do not have Boost ins
 
 1. Follow the instructions at [Vcpkg: a C++ Package Manager for Windows](/cpp/vcpkg) to install vcpkg (if you don't already have it).
 
-1. Run `vcpkg install boost:x86-windows-static` to install the Boost static library.
+1. Install the Boost.Test dynamic or static library
+	1. Run `vcpkg install boost-test` to install the Boost.Test dynamic library. 
+	1. Or run `vcpkg install boost-test:x86-windows-static` to install the Boost.Test static library. 
 
 1. Run the `vcpkg integrate install` command to configure Visual Studio with the library and include paths to the Boost headers and binaries.
 


### PR DESCRIPTION
For the installation instructions, I included how to get the Boost.Test dynamic or static library. The install command uses boost-test rather than just boost because the vcpkg team recently broke Boost up into its smaller components. This will greatly reduce the install time for people that don't need all of Boost.