### PR TITLE
Small typo in parameters

### DIFF
--- a/docs/msbuild/how-to-build-incrementally.md
+++ b/docs/msbuild/how-to-build-incrementally.md
@@ -75,7 +75,7 @@ When you build a large project, it is important that previously built components
   
     <ItemGroup>  
         <TXTFile Include="*.txt"/>  
-        <XMLFile Include="\metadata\*.xml"/>  
+        <XMLFiles Include="\metadata\*.xml"/>  
     </ItemGroup>  
   
     <Target Name = "Convert"  
@@ -95,7 +95,7 @@ When you build a large project, it is important that previously built components
   
         <BuildHelp  
             ContentFiles = "@(ContentFiles)"  
-            MetadataFiles = "@(XMLFile)"  
+            MetadataFiles = "@(XMLFiles)"  
             OutputFileName = "$(MSBuildProjectName).help"/>  
     </Target>  
 </Project>  


### PR DESCRIPTION
As I understand the second property in ItemGroup should be named XmlFiles to declare that it pointing to multiple XML files. So the second parameter to 'Build' target stay as it today @(XmlFiles) and 'MetadataFiles' parameter to 'BuildHelp' task should also receive @(XmlFiles) parameter.