### PR TITLE
Improve the 'Suppress JIT Optimizations' debugger help topics

### DIFF
--- a/docs/debugger/general-debugging-options-dialog-box.md
+++ b/docs/debugger/general-debugging-options-dialog-box.md
@@ -113,7 +113,7 @@ Sends all debugger messages that would ordinarily appear in the **Output** windo
 Turns off all object structure view customizations. For more information about view customizations, see [Create custom views of .managed objects](../debugger/create-custom-views-of-dot-managed-objects.md).  
   
 **Suppress JIT optimization on module load (Managed only)**  
-Disables the JIT optimization of managed code when a module is loaded and JIT is compiled while the debugger is attached. Disabling optimization may make it easier to debug some problems, although at the expense of performance. If you are using Just My Code, suppressing JIT optimization can cause non-user code to appear as user code ("My Code").
+Disables the JIT optimization of managed code when a module is loaded and JIT is compiled while the debugger is attached. Disabling optimization may make it easier to debug some problems, although at the expense of performance. If you are using Just My Code, suppressing JIT optimization can cause non-user code to appear as user code ("My Code"). For more information, see [JIT Optimization and Debugging](../debugger/jit-optimization-and-debugging.md).
 
 **Enable JavaScript debugging for ASP.NET (Chrome and IE)**
 Enables the script debugger for ASP.NET apps. On first use in Chrome, you may need to sign into the browser on first use to enable Chrome extensions that you have installed. Disable this option to revert to legacy behavior.    

--- a/docs/debugger/jit-optimization-and-debugging.md
+++ b/docs/debugger/jit-optimization-and-debugging.md
@@ -31,7 +31,7 @@ Normally the Release build configuration creates optimized code and the Debug bu
 
 In the .NET ecosystem, code is turned from source to CPU instructions in a two-step process: first, the C# compiler converts the text you type to an intermediate binary form called MSIL and writes this out to .dll files. Later, the .NET Runtime converts this MSIL to CPU instructions. Both steps can optimize to some degree, but the second step performed by the .NET Runtime performs the more significant optimizations.
 
-**The 'Suppress JIT optimization on module load' option:** The debugger exposes an option that controls what happens when a DLL that is compiled with optimizations enabled loads inside of the target process. If this option is unchecked (the default state), then when the .NET Runtime compiles the MSIL code into CPU code, it leaves the optimizations enabled. If the option is checked, then the debugger requests that optimizations be disabled.
+**The 'Suppress JIT optimization on module load (Managed only' option:** The debugger exposes an option that controls what happens when a DLL that is compiled with optimizations enabled loads inside of the target process. If this option is unchecked (the default state), then when the .NET Runtime compiles the MSIL code into CPU code, it leaves the optimizations enabled. If the option is checked, then the debugger requests that optimizations be disabled.
 
 The **Suppress JIT optimization on module load (Managed only)** option can be found on the **General** page under the **Debugging** node in the **Options** dialog box.
 

--- a/docs/debugger/jit-optimization-and-debugging.md
+++ b/docs/debugger/jit-optimization-and-debugging.md
@@ -25,16 +25,28 @@ ms.workload:
   - "multiple"
 ---
 # JIT Optimization and Debugging
-When you debug a managed application, [!INCLUDE[vsprvs](../code-quality/includes/vsprvs_md.md)] suppresses optimization of just-in-time (JIT) code by default. Suppressing JIT optimization means you are debugging non-optimized code. The code runs a bit slower because it is not optimized, but your debugging experience is much more thorough. Debugging optimized code is harder and recommended only if you encounter a bug that occurs in optimized code but cannot be reproduced in the non-optimized version.  
-  
- JIT optimization is controlled in [!INCLUDE[vsprvs](../code-quality/includes/vsprvs_md.md)] by the **Suppress JIT optimization on module load** option. You can find this option on the **General** page under the **Debugging** node in the **Options** dialog box.  
-  
- If you clear the **Suppress JIT optimization on module load** option, you can debug optimized JIT code, but your ability to debug may be limited because the optimized code does not match the source code. As a result, debugger windows such as the **Locals** and **Autos** window may not display as much information as they would if you were debugging non-optimized code.  
-  
- Another important difference concerns debugging with Just My Code. If you are debugging with Just My Code, the debugger considers optimized code to be non-user code, which should not be displayed while you are debugging. Consequently, if you are debugging JIT optimized code, you probably want to turn Just My Code off. For more information, see  [Restrict stepping to Just My Code](../debugger/navigating-through-code-with-the-debugger.md#BKMK_Restrict_stepping_to_Just_My_Code).  
-  
- Remember that the **Suppress JIT optimization on module load** option suppresses optimization of code when modules are loaded. If you attach to a process that is already running, it may contain code that is already loaded, JIT-compiled, and optimized. The **Suppress JIT optimization on module load** option has no effect on such code, although it will affect modules that are loaded after you attach. In addition, the **Suppress JIT optimization on module load** option does not affect modules, such as WinForms.dll, that are created with NGEN.  
-  
+**How optimizations work in .NET:** If you are trying to debug code, it is easier when that code is NOT optimized. This is because when code is optimized, the compiler and runtime will make changes to the emitted CPU code so that it runs faster, but has a less straight forwards mapping to original source code. This means that debuggers will frequently be unable to tell you the value of local variables, and stepping/breakpoints might not work as you expect.
+
+Normally the 'Release' build configuration will create optimized code and the 'Debug' build configuration will NOT. The 'Optimize' MSBuild property controls if the compiler is told to optimize code.
+
+In the .NET ecosystem, code is turned from source to CPU instructions in a two step process - first the C# compiler converts the text you type in into an intermediate binary form called MSIL and writes this out to .dll files. Then later the .NET Runtime converts this MSIL to CPU instructions. Both steps can optimize to some degree, but the second step performed by the .NET Runtime performs the more significant optimizations.
+
+**The 'Suppress JIT optimization on module load' option:** The debugger exposes an option which controls what happens when a dll that was compiled with optimizations enabled loads inside of the target process. If this option is unchecked (the default state), then when the .NET Runtime needs to compile the MSIL code into CPU code, it will leave optimizations enabled. If the option is checked then the debugger will ask that optimizations be disabled.
+
+This option is called **Suppress JIT optimization on module load (Managed only)** and it can be found on the **General** page under the **Debugging** node in the **Options** dialog box.
+
+**When should you check this option:** This option should be checked when you have downloaded dlls from another source, such as a nuget package, and you want to debug the code in this dll. In order for this to work you must also find the symbol (.pdb) file for this dll.
+
+If you are only interested in debugging the code you are building locally, it is best to leave this option unchecked, as, in some cases, enabling this option will significantly slow down debugging. There are two reason for this slow down --
+
+* Optimized code runs faster. If you are turning off optimizations for lots of code the time can add up.
+* If you have Just My Code enabled, the debugger will not even try and load symbols for dlls which are optimized. Finding symbols can take a long time.
+
+**Limitations of this option:** There are two situations where this option will **NOT** work:
+
+1. In situations where you are attaching the debugger to an already running process, this option will have no effect on modules that were already loaded at the time the debugger was attached.
+2. This option has no effect on dlls that have been pre-compiled (a.k.a ngen'ed) to native code. However, you can disable usage of pre-compiled code by starting the process with the environment variable 'COMPlus_ZapDisable' set to '1'.
+
 ## See Also  
  [Debugging Managed Code](../debugger/debugging-managed-code.md)   
  [Navigating through Code with the Debugger](../debugger/navigating-through-code-with-the-debugger.md)   

--- a/docs/debugger/jit-optimization-and-debugging.md
+++ b/docs/debugger/jit-optimization-and-debugging.md
@@ -31,7 +31,7 @@ Normally the Release build configuration creates optimized code and the Debug bu
 
 In the .NET ecosystem, code is turned from source to CPU instructions in a two-step process: first, the C# compiler converts the text you type to an intermediate binary form called MSIL and writes this out to .dll files. Later, the .NET Runtime converts this MSIL to CPU instructions. Both steps can optimize to some degree, but the second step performed by the .NET Runtime performs the more significant optimizations.
 
-**The 'Suppress JIT optimization on module load (Managed only' option:** The debugger exposes an option that controls what happens when a DLL that is compiled with optimizations enabled loads inside of the target process. If this option is unchecked (the default state), then when the .NET Runtime compiles the MSIL code into CPU code, it leaves the optimizations enabled. If the option is checked, then the debugger requests that optimizations be disabled.
+**The 'Suppress JIT optimization on module load (Managed only)' option:** The debugger exposes an option that controls what happens when a DLL that is compiled with optimizations enabled loads inside of the target process. If this option is unchecked (the default state), then when the .NET Runtime compiles the MSIL code into CPU code, it leaves the optimizations enabled. If the option is checked, then the debugger requests that optimizations be disabled.
 
 The **Suppress JIT optimization on module load (Managed only)** option can be found on the **General** page under the **Debugging** node in the **Options** dialog box.
 

--- a/docs/debugger/jit-optimization-and-debugging.md
+++ b/docs/debugger/jit-optimization-and-debugging.md
@@ -25,27 +25,27 @@ ms.workload:
   - "multiple"
 ---
 # JIT Optimization and Debugging
-**How optimizations work in .NET:** If you are trying to debug code, it is easier when that code is NOT optimized. This is because when code is optimized, the compiler and runtime will make changes to the emitted CPU code so that it runs faster, but has a less straight forwards mapping to original source code. This means that debuggers will frequently be unable to tell you the value of local variables, and stepping/breakpoints might not work as you expect.
+**How optimizations work in .NET:** If you are trying to debug code, it is easier when that code is **NOT** optimized. This is because when code is optimized, the compiler and runtime make changes to the emitted CPU code so that it runs faster, but has a less direct mapping to original source code. This means that debuggers are frequently unable to tell you the value of local variables, and code stepping and breakpoints might not work as you expect.
 
-Normally the 'Release' build configuration will create optimized code and the 'Debug' build configuration will NOT. The 'Optimize' MSBuild property controls if the compiler is told to optimize code.
+Normally the Release build configuration creates optimized code and the Debug build configuration does not. The `Optimize` MSBuild property controls whether the compiler is told to optimize code.
 
-In the .NET ecosystem, code is turned from source to CPU instructions in a two step process - first the C# compiler converts the text you type in into an intermediate binary form called MSIL and writes this out to .dll files. Then later the .NET Runtime converts this MSIL to CPU instructions. Both steps can optimize to some degree, but the second step performed by the .NET Runtime performs the more significant optimizations.
+In the .NET ecosystem, code is turned from source to CPU instructions in a two-step process: first, the C# compiler converts the text you type to an intermediate binary form called MSIL and writes this out to .dll files. Later, the .NET Runtime converts this MSIL to CPU instructions. Both steps can optimize to some degree, but the second step performed by the .NET Runtime performs the more significant optimizations.
 
-**The 'Suppress JIT optimization on module load' option:** The debugger exposes an option which controls what happens when a dll that was compiled with optimizations enabled loads inside of the target process. If this option is unchecked (the default state), then when the .NET Runtime needs to compile the MSIL code into CPU code, it will leave optimizations enabled. If the option is checked then the debugger will ask that optimizations be disabled.
+**The 'Suppress JIT optimization on module load' option:** The debugger exposes an option that controls what happens when a DLL that is compiled with optimizations enabled loads inside of the target process. If this option is unchecked (the default state), then when the .NET Runtime compiles the MSIL code into CPU code, it leaves the optimizations enabled. If the option is checked, then the debugger requests that optimizations be disabled.
 
-This option is called **Suppress JIT optimization on module load (Managed only)** and it can be found on the **General** page under the **Debugging** node in the **Options** dialog box.
+The **Suppress JIT optimization on module load (Managed only)** option can be found on the **General** page under the **Debugging** node in the **Options** dialog box.
 
-**When should you check this option:** This option should be checked when you have downloaded dlls from another source, such as a nuget package, and you want to debug the code in this dll. In order for this to work you must also find the symbol (.pdb) file for this dll.
+**When should you check this option:** Check this option when you downloaded the DLLs from another source, such as a nuget package, and you want to debug the code in this DLL. In order for this to work, you must also find the symbol (.pdb) file for this DLL.
 
-If you are only interested in debugging the code you are building locally, it is best to leave this option unchecked, as, in some cases, enabling this option will significantly slow down debugging. There are two reason for this slow down --
+If you are only interested in debugging the code you are building locally, it is best to leave this option unchecked, as, in some cases, enabling this option will significantly slow down debugging. There are two reason for this slow down:
 
-* Optimized code runs faster. If you are turning off optimizations for lots of code the time can add up.
-* If you have Just My Code enabled, the debugger will not even try and load symbols for dlls which are optimized. Finding symbols can take a long time.
+* Optimized code runs faster. If you are turning off optimizations for lots of code, the performance impact can add up.
+* If you have Just My Code enabled, the debugger will not even try and load symbols for DLLs that are optimized. Finding symbols can take a long time.
 
 **Limitations of this option:** There are two situations where this option will **NOT** work:
 
 1. In situations where you are attaching the debugger to an already running process, this option will have no effect on modules that were already loaded at the time the debugger was attached.
-2. This option has no effect on dlls that have been pre-compiled (a.k.a ngen'ed) to native code. However, you can disable usage of pre-compiled code by starting the process with the environment variable 'COMPlus_ZapDisable' set to '1'.
+2. This option has no effect on DLLs that have been pre-compiled (a.k.a ngen'ed) to native code. However, you can disable usage of pre-compiled code by starting the process with the environment variable 'COMPlus_ZapDisable' set to '1'.
 
 ## See Also  
  [Debugging Managed Code](../debugger/debugging-managed-code.md)   


### PR DESCRIPTION
This makes several improvements to the 'Suppress JIT Optimizations' help topics:
1. The help topic was written back when the default state of the option was checked, but that hasn't been true for several releases now, and the help topic was never updated.
2. The help topic lacked a bunch of details that are important to understand what the option really does. So I tried to explain everything.
3. There wasn't a link from the Tools->Options->Debugging->General options page.