### PR TITLE
Updated documentation to correct reference

### DIFF
--- a/docs/msbuild/msbuild-inline-tasks.md
+++ b/docs/msbuild/msbuild-inline-tasks.md
@@ -98,7 +98,7 @@ MSBuild tasks are typically created by compiling a class that implements the <xr
     AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll" >  
     <ParameterGroup />  
     <Task>  
-      <Reference Include="System.Xml.dll"/>  
+      <Reference Include="System.Xml"/>
       <Using Namespace="System"/>  
       <Using Namespace="System.IO"/>  
       <Code Type="Fragment" Language="cs">  


### PR DESCRIPTION
Removed the ".dll" extension in the Reference tag. The code works only without the .dll as mentioned in this stackoverlfow.com post - https://stackoverflow.com/questions/16182179/msbuild-referencing-dlls-in-task
