### PR TITLE
Mention name mangling in MSBuild solution builds

### DIFF
--- a/docs/msbuild/how-to-build-specific-targets-in-solutions-by-using-msbuild-exe.md
+++ b/docs/msbuild/how-to-build-specific-targets-in-solutions-by-using-msbuild-exe.md
@@ -38,9 +38,9 @@ msbuild SlnFolders.sln /target:NotInSlnfolder:Rebuild;NewFolder\InSolutionFolder
 
 ## Troubleshooting
 
-If you would like to examine the options available to you, you can use a debugging option built into MSBuild to do so. Set the environment variable `MSBUILDEMITSOLUTION=1` and build your solution. This will produce an MSBuild file named `<SolutionName>.sln.metaproj` that shows MSBuild's internal view of the solution at build time. It can be inspected to determine what targets are available to build.
+If you would like to examine the options available to you, you can use a debugging option provided by MSBuild to do so. Set the environment variable `MSBUILDEMITSOLUTION=1` and build your solution. This will produce an MSBuild file named `<SolutionName>.sln.metaproj` that shows MSBuild's internal view of the solution at build time. You can inspect this view to determine what targets are available to build.
 
-Do not build with this environment variable set as a matter of course; it can cause problems building projects in your solution.
+Do not build with this environment variable set unless you need this internal view. This setting can cause problems building projects in your solution.
 
 ## See Also  
  [Command-Line Reference](../msbuild/msbuild-command-line-reference.md)   

--- a/docs/msbuild/how-to-build-specific-targets-in-solutions-by-using-msbuild-exe.md
+++ b/docs/msbuild/how-to-build-specific-targets-in-solutions-by-using-msbuild-exe.md
@@ -27,15 +27,21 @@ You can use MSBuild.exe to build specific targets of specific projects in a solu
   
 1.  At the command line, type `MSBuild.exe <SolutionName>.sln`, where `<SolutionName>` corresponds to the file name of the solution that contains the target that you want to execute.  
   
-2.  Specify the target after the **/t** switch in the format *ProjectName*:*TargetName*.  
+2. Specify the target after the `/target:` switch in the format **`ProjectName`**`:`**`TargetName`**. If the project name contains any of the characters `%`, `$`, `@`, `;`, `.`, `(`, `)`, or `'`, replace them with an `_` in the specified target name.
   
 ## Example  
  The following example executes the `Rebuild` target of the `NotInSlnFolder` project, and then executes the `Clean` target of the `InSolutionFolder` project, which is located in the `NewFolder` solution folder.  
   
-```  
-msbuild SlnFolders.sln /t:NotInSlnfolder:Rebuild;NewFolder\InSolutionFolder:Clean  
-```  
-  
+```
+msbuild SlnFolders.sln /target:NotInSlnfolder:Rebuild;NewFolder\InSolutionFolder:Clean`
+```
+
+## Troubleshooting
+
+If you would like to examine the options available to you, you can use a debugging option built into MSBuild to do so. Set the environment variable `MSBUILDEMITSOLUTION=1` and build your solution. This will produce an MSBuild file named `<SolutionName>.sln.metaproj` that shows MSBuild's internal view of the solution at build time. It can be inspected to determine what targets are available to build.
+
+Do not build with this environment variable set as a matter of course; it can cause problems building projects in your solution.
+
 ## See Also  
  [Command-Line Reference](../msbuild/msbuild-command-line-reference.md)   
  [MSBuild Reference](../msbuild/msbuild-reference.md)   


### PR DESCRIPTION
MSBuild replaces some characters in project names when creating targets

But this wasn't mentioned in the documentation.

Also mention troubleshooting options.
for individual projects in a solution metaproject:

https://github.com/Microsoft/msbuild/blob/adf225bf6abf2c6ab41a3214f6806b7618878939/src/Build/Construction/Solution/ProjectInSolution.cs#L397

Based on customer feedback sent via email.