### PR TITLE
Correct typo in C# ("aync" => "async")

### DIFF
--- a/docs/extensibility/how-to-use-asyncpackage-to-load-vspackages-in-the-background.md
+++ b/docs/extensibility/how-to-use-asyncpackage-to-load-vspackages-in-the-background.md
@@ -101,6 +101,6 @@ using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;   
   
 IAsyncServiceProvider asyncServiceProvider = Package.GetService(typeof(SAsyncServiceProvider)) as IAsyncServiceProvider;   
-IMyTestService testService = await ayncServiceProvider.GetServiceAsync(typeof(SMyTestService)) as IMyTestService;  
+IMyTestService testService = await asyncServiceProvider.GetServiceAsync(typeof(SMyTestService)) as IMyTestService;  
 ```
   


### PR DESCRIPTION
'asyncServiceProvider' is created, and used in the subsequent line of code, but the subsequent line of code is missing the first letter 's' i.e. it is 'ayncServiceProvider' not 'asyncServiceProvider'