### PR TITLE
Bump VSTU changelog to 3.5.0.3

### DIFF
--- a/docs/cross-platform/change-log-visual-studio-tools-for-unity.md
+++ b/docs/cross-platform/change-log-visual-studio-tools-for-unity.md
@@ -19,6 +19,15 @@ ms.workload:
 # Change Log (Visual Studio Tools for Unity)
 Visual Studio Tools for Unity change log.  
 
+## 3.5.0.3
+ Released 2018-01-09
+
+### Bug fixes  
+
+-   **Integration:**  
+
+    -   Fixed automatic pdb to mdb debug symbol conversion.
+
 ## 3.5.0.2
  Released 2017-12-04
 


### PR DESCRIPTION
3.5.0.3 was a servicing update, initially released for VS 2017, 15.5.3
https://docs.microsoft.com/en-us/visualstudio/releasenotes/vs2017-relnotes#15.5.3