### PR TITLE
Code language in example is not valid

### DIFF
--- a/docs/ide/code-snippet-functions.md
+++ b/docs/ide/code-snippet-functions.md
@@ -109,7 +109,7 @@ The following example shows how to use the `ClassName` function. When this snipp
                     <Default>ClassNamePlaceholder</Default>   
                 </Literal>  
             </Declarations>  
-            <Code Language="vjsharp" Format="CData">  
+            <Code Language="csharp" Format="CData">  
                 <![CDATA[   
                     public $classname$ ($type$ $name$)  
                     {  


### PR DESCRIPTION
The previous value, vjsharp, is not on the valid list: https://docs.microsoft.com/en-us/visualstudio/ide/code-snippets-schema-reference
Probably a typo