### PR TITLE
Older projects need a different base docker image : microsoft/dotnet-framework

### DIFF
--- a/docs/install/build-tools-container.md
+++ b/docs/install/build-tools-container.md
@@ -158,7 +158,7 @@ You must save the following example Dockerfile to a new file on your disk. If th
    ```
 
 > [!NOTE]
-> If you are using Visual Studio 2017 version 15.6 or later, you should use the following as Docker image as the base image instead: microsoft/dotnet-framework
+> If you are using Visual Studio 2017 version 15.6 or later, you should use the following Docker image as the base image instead: microsoft/dotnet-framework
 
 ```dockerfile
   # Use the following image to build older projects

--- a/docs/install/build-tools-container.md
+++ b/docs/install/build-tools-container.md
@@ -158,7 +158,7 @@ You must save the following example Dockerfile to a new file on your disk. If th
    ```
 
 > [!NOTE]
-> If you want to build solutions / projects referencing older versions of the .NET Framework (e.g. v4.0) you should use the following Docker image instead: microsoft/dotnet-framework
+> If you are using Visual Studio 2017 version 15.6 or later, you should use the following as Docker image as the base image instead: microsoft/dotnet-framework
 
 ```dockerfile
   # Use the following image to build older projects

--- a/docs/install/build-tools-container.md
+++ b/docs/install/build-tools-container.md
@@ -157,6 +157,14 @@ You must save the following example Dockerfile to a new file on your disk. If th
    CMD ["powershell.exe", "-NoLogo", "-ExecutionPolicy", "Bypass"]
    ```
 
+> [!NOTE]
+> If you want to build solutions / projects referencing older versions of the .NET Framework (e.g. v4.0) you should use the following Docker image instead: microsoft/dotnet-framework
+
+```dockerfile
+  # Use the following image to build older projects
+  FROM microsoft/dotnet-framework
+```
+
 4. Run the following command within that directory.
 
    ```shell


### PR DESCRIPTION
Hi,

I added a note regarding an error which arises when building projects based on an older version of the Framework if you don't use a dotnet-framework base image (instead of windowservercore image) :

“C:\sources\Mysolution.sln” (default target) (1) ->
“C:\sources\Project.Web\Project.Web.csproj” (default target) (2) ->
“C:\sources\Project.DataAccess\Project.DataAccess.csproj” (default target) (3:2) ->
(CoreCompile target) ->
C:\BuildTools\MSBuild\15.0\bin\Roslyn\Microsoft.CSharp.Core.targets(84,5): error MSB6003: The specified task executab
le “csc.exe” could not be run. Could not load file or assembly ‘System.IO.FileSystem, Version=4.0.1.0, Culture=neutral,
PublicKeyToken=b03f5f7f11d50a3a’ or one of its dependencies. The system cannot find the file specified. [C:\sources\Project.DataAccess\Project.DataAccess.csproj]