### PR TITLE
deleted unnecessary require('http')

### DIFF
--- a/docs/nodejs/tutorial-nodejs-with-react-and-jsx.md
+++ b/docs/nodejs/tutorial-nodejs-with-react-and-jsx.md
@@ -144,7 +144,6 @@ For this simple app, you add the new project files in the project root. (In most
 
     ```javascript
     'use strict';
-    var http = require('http');
     var path = require('path');
     var express = require('express');
 


### PR DESCRIPTION
This is a great starter template, but the line "var http = require('http');" is unnecessary because express created its own server and the other server never gets used for possible scenarios where it would be necessary(https://stackoverflow.com/questions/17696801/express-js-app-listen-vs-server-listen). I propose removing it.