### PR TITLE
MSBuild: Additional forbidden properties

### DIFF
--- a/docs/msbuild/msbuild-reserved-and-well-known-properties.md
+++ b/docs/msbuild/msbuild-reserved-and-well-known-properties.md
@@ -25,7 +25,7 @@ ms.workload:
 # MSBuild Reserved and Well-Known Properties
 [!INCLUDE[vstecmsbuild](../extensibility/internals/includes/vstecmsbuild_md.md)] provides a set of predefined properties that store information about the project file and the [!INCLUDE[vstecmsbuild](../extensibility/internals/includes/vstecmsbuild_md.md)] binaries. These properties are evaluated in the same manner as other [!INCLUDE[vstecmsbuild](../extensibility/internals/includes/vstecmsbuild_md.md)] properties. For example, to use the `MSBuildProjectFile` property, you type `$(MSBuildProjectFile)`.  
   
- MSBuild uses the values in the following table to predefine reserved and well-known properties. Reserved properties cannot be overridden, but well-known properties can be overridden by using identically named environment properties, global properties, or properties that are declared in the project file.  
+ MSBuild uses the values in the following table to predefine reserved and well-known properties. Reserved properties cannot be overridden, but well-known properties can be overridden by using identically named environment properties, global properties, or properties that are declared in the project file.
   
 ## Reserved and Well-Known Properties  
  The following table describes the [!INCLUDE[vstecmsbuild](../extensibility/internals/includes/vstecmsbuild_md.md)] predefined properties.  
@@ -56,7 +56,24 @@ ms.workload:
 |`MSBuildThisFileName`|The file name portion of `MSBuildThisFileFullPath`, without the file name extension.|Reserved|  
 |`MSBuildToolsPath`|The installation path of the [!INCLUDE[vstecmsbuild](../extensibility/internals/includes/vstecmsbuild_md.md)] version that's associated with the value of `MSBuildToolsVersion`.<br /><br /> Do not include the final backslash in the path.<br /><br /> This property cannot be overridden.|Reserved|  
 |`MSBuildToolsVersion`|The version of the [!INCLUDE[vstecmsbuild](../extensibility/internals/includes/vstecmsbuild_md.md)] Toolset that is used to build the project.<br /><br /> Note: An [!INCLUDE[vstecmsbuild](../extensibility/internals/includes/vstecmsbuild_md.md)] Toolset consists of tasks, targets, and tools that are used to build an application. The tools include compilers such as csc.exe and vbc.exe. For more information, see [Toolset (ToolsVersion)](../msbuild/msbuild-toolset-toolsversion.md), and [Standard and Custom Toolset Configurations](../msbuild/standard-and-custom-toolset-configurations.md).|Reserved|  
-  
+
+## Names that conflict with MSBuild elements
+
+In addition to the above, names corresponding to MSBuild language elements cannot be used for user-defined properties, items, or item metadata:
+
+* VisualStudioProject
+* Target
+* PropertyGroup
+* Output
+* ItemGroup
+* UsingTask
+* ProjectExtensions
+* OnError
+* ImportGroup
+* Choose
+* When
+* Otherwise
+
 ## See Also  
  [MSBuild Reference](../msbuild/msbuild-reference.md)
  [MSBuild Properties](../msbuild/msbuild-properties.md)


### PR DESCRIPTION
These names are disallowed because they conflict with MSBuild language
elements, but they weren't listed here.

See the official list:
https://github.com/Microsoft/msbuild/blob/d83a9eda20970d2bfa3ad96d47cbecf93343256b/src/Shared/XMakeElements.cs#L41-L58

Closes Microsoft/msbuild#3133.