### PR TITLE
Fix alignment and new lines in attributes

### DIFF
--- a/docs/extensibility/registering-a-tool-window.md
+++ b/docs/extensibility/registering-a-tool-window.md
@@ -26,7 +26,9 @@ You can register your tool windows using <xref:Microsoft.VisualStudio.Shell.Prov
   
 ```csharp  
   
-      [ProvideToolWindow(typeof(PersistedWindowPane), Style = MsVsShell.VsDockStyle.Tabbed, Window = "3ae79031-e1bc-11d0-8f78-00a0c9110057")] [ProvideToolWindow(typeof(DynamicWindowPane), PositionX=250, PositionY=250, Width=160, Height=180, Transient=true)] [ProvideToolWindowVisibility(typeof(DynamicWindowPane), /*UICONTEXT_SolutionExists*/"f1536ef8-92ec-443c-9ed7-fdadf150da82")]  
+[ProvideToolWindow(typeof(PersistedWindowPane), Style = MsVsShell.VsDockStyle.Tabbed, Window = "3ae79031-e1bc-11d0-8f78-00a0c9110057")]
+[ProvideToolWindow(typeof(DynamicWindowPane), PositionX=250, PositionY=250, Width=160, Height=180, Transient=true)]
+[ProvideToolWindowVisibility(typeof(DynamicWindowPane), /*UICONTEXT_SolutionExists*/"f1536ef8-92ec-443c-9ed7-fdadf150da82")]  
 [ProvideMenuResource(1000, 1)]  
 [PackageRegistration(UseManagedResourcesOnly = true)]  
 [Guid("01069CDD-95CE-4620-AC21-DDFF6C57F012")]  


### PR DESCRIPTION
First attribute was indented.  Some attributes weren't on a new line, causing them to scroll way off screen.