### PR TITLE
MSBuild: Document updating to v15

### DIFF
--- a/docs/msbuild/TOC.md
+++ b/docs/msbuild/TOC.md
@@ -194,4 +194,6 @@
 ##### [UidManager Task](uidmanager-task.md)
 ##### [UpdateManifestForBrowserApplication Task](updatemanifestforbrowserapplication-task.md)
 ### [Special Characters to Escape](special-characters-to-escape.md)
+## [Using MSBuild Programmatically](msbuild-api.md)
+### [Updating to MSBuild 15](updating-an-existing-application.md)
 ## [MSBuild Glossary](msbuild-glossary.md)

--- a/docs/msbuild/msbuild-api.md
+++ b/docs/msbuild/msbuild-api.md
@@ -1,0 +1,5 @@
+# Using the MSBuild API
+
+MSBuild provides a public API surface so that your program can perform builds and inspect projects.
+
+Documentation for the MSBuild API can be found [on MSDN](https://msdn.microsoft.com/en-us/library/mt476050(v=vs.110).aspx).

--- a/docs/msbuild/updating-an-existing-application.md
+++ b/docs/msbuild/updating-an-existing-application.md
@@ -1,18 +1,20 @@
 # Updating an existing application for MSBuild 15
 
-In versions of MSBuild prior to 15.0, MSBuild was loaded from the Global Assembly Cache and MSBuild extensions were installed in the registry. This ensured that all applications used the same version of MSBuild and had access to the same toolsets, but prevented side-by-side installations of different versions of Visual Studio.
+In versions of MSBuild prior to 15.0, MSBuild was loaded from the Global Assembly Cache (GAC) and MSBuild extensions were installed in the registry. This ensured that all applications used the same version of MSBuild and had access to the same toolsets, but prevented side-by-side installations of different versions of Visual Studio.
 
-In order to support
+In order to support faster, smaller, and side-by-side installation, Visual Studio 2017 no longer places MSBuild in the GAC or modifies the registry. Unfortunately, this means that applications that wish to use the MSBuild API to evaluate or build projects cannot implicitly rely on the Visual Studio installation.
 
 ## Using MSBuild from Visual Studio
 
-To ensure that programmatic builds from your application match those Visual Studio or MSBuild.exe, load MSBuild assemblies from Visual Studio and use the SDKs available within Visual Studio. The Microsoft.Build.Locator NuGet package automates this.
+To ensure that programmatic builds from your application match those done within Visual Studio or MSBuild.exe, load MSBuild assemblies from Visual Studio and use the SDKs available within Visual Studio. The Microsoft.Build.Locator NuGet package streamlines this.
 
 ## Using Microsoft.Build.Locator
 
-Must deploy at runtime, but then don't have to ship MSBuild.
+If you redistribute `Microsoft.Build.Locator.dll` with your application, you will not need to distribute other MSBuild assemblies.
 
-### Change MSBuild refs
+Updating a project to use MSBuild 15 and the locator API requires a few changes in your project, described below. To see an example of the changes required to update a project, see [the commits made to an example project in the MSBuildLocator repository](https://github.com/Microsoft/MSBuildLocator/commits/example-updating-to-msbuild-15).
+
+### Change MSBuild references
 
 In order to ensure that MSBuild is loaded from a central location, you must not distribute its assemblies with your application.
 
@@ -20,13 +22,13 @@ The mechanism for changing your project to avoid that depends on how you referen
 
 #### Using NuGet packages (preferred)
 
-If you
+These instructions assume that you're using [`PackageReference`-style NuGet references](https://docs.microsoft.com/en-us/nuget/consume-packages/package-references-in-project-files).
 
 Change your project file(s) to reference MSBuild assemblies from their NuGet packages. Specify `ExcludeAssets=runtime` to tell NuGet that the assemblies are needed only at build time, and should not be copied to the output directory.
 
 The major and minor version of the MSBuild packages must be less than or equal to the minimum version of Visual Studio you wish to support. If you wish to support any version of Visual Studio 2017, reference package version `15.1.548`.
 
-For example, 
+For example,
 
 ```xml
 <ItemGroup>
@@ -37,15 +39,36 @@ For example,
 
 #### Using extension assemblies
 
-#### Binding redirects?
-#### Ensure output clean
+TODO: describe this
+
+#### Binding redirects
+
+Referencing the Microsoft.Build.Locator package automatically ensures that your application uses the required binding redirects of all versions of MSBuild assemblies to version `15.1.0.0`.
+
+### Ensure output clean
+
+Build your project and inspect the output directory to make sure that it does not contain any `Microsoft.Build.*.dll` assemblies (other than `Microsoft.Build.Locator.dll`, added in the next step).
 
 ### Add package reference
 
 Add a NuGet package reference to [Microsoft.Build.Locator](https://www.nuget.org/packages/Microsoft.Build.Locator/).
 
-If possible, do this from a project that uses [`PackageReference`](https://docs.microsoft.com/en-us/nuget/consume-packages/package-references-in-project-files) rather than `packages.config`. Doing so enables functionality within the package that checks project state at build time.
+```xml
+    <PackageReference Include="Microsoft.Build.Locator">
+      <Version>1.0.7-preview-ge60d679b53</Version>
+    </PackageReference>
+```
 
-### Ensure output clean
 ### Register instance before calling MSBuild
 
+Add a call to the Locator API before calling any method that uses MSBuild.
+
+The simplest way to do this is to add a call to
+
+```c#
+MSBuildLocator.RegisterDefaults();
+```
+
+in your application startup code.
+
+If you would like finer-grained control over the loading of MSBuild, you can select a result of `MSBuildLocator.QueryVisualStudioInstances()` to pass to `MSBuildLocator.RegisterInstance()` manually, but this is generally not needed.

--- a/docs/msbuild/updating-an-existing-application.md
+++ b/docs/msbuild/updating-an-existing-application.md
@@ -39,7 +39,13 @@ For example,
 
 #### Using extension assemblies
 
-TODO: describe this
+If you cannot use NuGet packages, you can reference MSBuild assemblies that are distributed with Visual Studio. If you reference MSBuild directly, ensure that it will not be copied to your ouput directory by setting `Copy Local` to `False`. In the project file this will look like
+
+```xml
+    <Reference Include="Microsoft.Build, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <Private>False</Private>
+    </Reference>
+```
 
 #### Binding redirects
 

--- a/docs/msbuild/updating-an-existing-application.md
+++ b/docs/msbuild/updating-an-existing-application.md
@@ -10,9 +10,30 @@ To ensure that programmatic builds from your application match those Visual Stud
 
 ## Using Microsoft.Build.Locator
 
+Must deploy at runtime, but then don't have to ship MSBuild.
+
 ### Change MSBuild refs
 
+In order to ensure that MSBuild is loaded from a central location, you must not distribute its assemblies with your application.
+
+The mechanism for changing your project to avoid that depends on how you reference MSBuild.
+
 #### Using NuGet packages (preferred)
+
+If you
+
+Change your project file(s) to reference MSBuild assemblies from their NuGet packages. Specify `ExcludeAssets=runtime` to tell NuGet that the assemblies are needed only at build time, and should not be copied to the output directory.
+
+The major and minor version of the MSBuild packages must be less than or equal to the minimum version of Visual Studio you wish to support. If you wish to support any version of Visual Studio 2017, reference package version `15.1.548`.
+
+For example, 
+
+```xml
+<ItemGroup>
+  <PackageReference Include="Microsoft.Build" Version="15.1.548" ExcludeAssets="runtime" />
+  <PackageReference Include="Microsoft.Build.Utilities" Version="15.1.548" ExcludeAssets="runtime" />
+</ItemGroup>
+```
 
 #### Using extension assemblies
 
@@ -23,7 +44,7 @@ To ensure that programmatic builds from your application match those Visual Stud
 
 Add a NuGet package reference to [Microsoft.Build.Locator](https://www.nuget.org/packages/Microsoft.Build.Locator/).
 
-If possible, do this from a project that uses [`PackageReference`](https://docs.microsoft.com/en-us/nuget/consume-packages/package-references-in-project-files) rather than `packages.config`. Doing so enables functionality within the package that check project state at build time.
+If possible, do this from a project that uses [`PackageReference`](https://docs.microsoft.com/en-us/nuget/consume-packages/package-references-in-project-files) rather than `packages.config`. Doing so enables functionality within the package that checks project state at build time.
 
 ### Ensure output clean
 ### Register instance before calling MSBuild

--- a/docs/msbuild/updating-an-existing-application.md
+++ b/docs/msbuild/updating-an-existing-application.md
@@ -1,0 +1,30 @@
+# Updating an existing application for MSBuild 15
+
+In versions of MSBuild prior to 15.0, MSBuild was loaded from the Global Assembly Cache and MSBuild extensions were installed in the registry. This ensured that all applications used the same version of MSBuild and had access to the same toolsets, but prevented side-by-side installations of different versions of Visual Studio.
+
+In order to support
+
+## Using MSBuild from Visual Studio
+
+To ensure that programmatic builds from your application match those Visual Studio or MSBuild.exe, load MSBuild assemblies from Visual Studio and use the SDKs available within Visual Studio. The Microsoft.Build.Locator NuGet package automates this.
+
+## Using Microsoft.Build.Locator
+
+### Change MSBuild refs
+
+#### Using NuGet packages (preferred)
+
+#### Using extension assemblies
+
+#### Binding redirects?
+#### Ensure output clean
+
+### Add package reference
+
+Add a NuGet package reference to [Microsoft.Build.Locator](https://www.nuget.org/packages/Microsoft.Build.Locator/).
+
+If possible, do this from a project that uses [`PackageReference`](https://docs.microsoft.com/en-us/nuget/consume-packages/package-references-in-project-files) rather than `packages.config`. Doing so enables functionality within the package that check project state at build time.
+
+### Ensure output clean
+### Register instance before calling MSBuild
+

--- a/docs/msbuild/updating-an-existing-application.md
+++ b/docs/msbuild/updating-an-existing-application.md
@@ -18,7 +18,7 @@ Updating a project to use MSBuild 15 and the locator API requires a few changes 
 
 In order to ensure that MSBuild is loaded from a central location, you must not distribute its assemblies with your application.
 
-The mechanism for changing your project to avoid that depends on how you reference MSBuild.
+The mechanism for changing your project to avoid loading MSBuild from a central locations depends on how you reference MSBuild.
 
 #### Using NuGet packages (preferred)
 
@@ -28,7 +28,7 @@ Change your project file(s) to reference MSBuild assemblies from their NuGet pac
 
 The major and minor version of the MSBuild packages must be less than or equal to the minimum version of Visual Studio you wish to support. If you wish to support any version of Visual Studio 2017, reference package version `15.1.548`.
 
-For example,
+For example, you can use this XML:
 
 ```xml
 <ItemGroup>
@@ -39,7 +39,7 @@ For example,
 
 #### Using extension assemblies
 
-If you cannot use NuGet packages, you can reference MSBuild assemblies that are distributed with Visual Studio. If you reference MSBuild directly, ensure that it will not be copied to your ouput directory by setting `Copy Local` to `False`. In the project file this will look like
+If you cannot use NuGet packages, you can reference MSBuild assemblies that are distributed with Visual Studio. If you reference MSBuild directly, ensure that it will not be copied to your ouput directory by setting `Copy Local` to `False`. In the project file, this will look like the following:
 
 ```xml
     <Reference Include="Microsoft.Build, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">


### PR DESCRIPTION
Visual Studio 2017/MSBuild 15 introduced some changes in how to consume and load the MSBuild API. This new documentation describes the best practice for using MSBuild from a program that isn't Visual Studio.

I've sent this to a couple of customers who thought it was helpful but it's still a bit draft-y.

cc @andygerlicher @Mikejo5000 