### PR TITLE
Fix name of referenced group

### DIFF
--- a/docs/extensibility/creating-reusable-groups-of-buttons.md
+++ b/docs/extensibility/creating-reusable-groups-of-buttons.md
@@ -43,7 +43,7 @@ A command group is a collection of commands that always appear together on a men
     </GuidSymbol>  
     ```  
   
-     By default, the command item template creates a group named **MyGroup** and a button that has the name that you provided, together with an IDSymbol entry for each.  
+     By default, the command item template creates a group named **MyMenuGroup** and a button that has the name that you provided, together with an IDSymbol entry for each.  
   
 5.  In the Groups section, create a Group element that has the same GUID and ID attributes as the ones given in the Symbols section. You can also use an existing group, or use the entry that is provided by the command template, as in the following example. This group appears on the **Tools** menu  
   


### PR DESCRIPTION
By default the template creates a group named "MyMenuGroup".  Not one named "MyGroup".