### PR TITLE
Add Requirement qualification for only .NET Framework projects

### DIFF
--- a/docs/test/isolating-code-under-test-with-microsoft-fakes.md
+++ b/docs/test/isolating-code-under-test-with-microsoft-fakes.md
@@ -30,8 +30,8 @@ Fakes come in two flavors:
 -   Visual Studio Enterprise
 -   A .NET Framework project
 
-[!NOTE]
-.NET Standard projects are not supported.
+> [!NOTE]
+> .NET Standard projects are not supported.
 
 ## Choosing between stub and shim types
 Typically, you would consider a Visual Studio project to be a component, because you develop and update those classes at the same time. You would consider using stubs and shims for calls that the project makes to other projects in your solution, or to other assemblies that the project references.

--- a/docs/test/isolating-code-under-test-with-microsoft-fakes.md
+++ b/docs/test/isolating-code-under-test-with-microsoft-fakes.md
@@ -28,7 +28,10 @@ Fakes come in two flavors:
 **Requirements**
 
 -   Visual Studio Enterprise
--   Only for .NET Framework projects. Currently, there is not support for .NET Framework projects that target .NET Standard.
+-   A .NET Framework project
+
+[!NOTE]
+.NET Standard projects are not supported.
 
 ## Choosing between stub and shim types
 Typically, you would consider a Visual Studio project to be a component, because you develop and update those classes at the same time. You would consider using stubs and shims for calls that the project makes to other projects in your solution, or to other assemblies that the project references.

--- a/docs/test/isolating-code-under-test-with-microsoft-fakes.md
+++ b/docs/test/isolating-code-under-test-with-microsoft-fakes.md
@@ -1,3 +1,4 @@
+
 ---
 title: "Isolating Code Under Test with Microsoft Fakes in Visual Studio | Microsoft Docs"
 ms.date: "11/04/2016"
@@ -27,6 +28,7 @@ Fakes come in two flavors:
 **Requirements**
 
 -   Visual Studio Enterprise
+-   Only for .NET Framework projects. Currently, there is not support for .NET Framework projects that target .NET Standard.
 
 ## Choosing between stub and shim types
 Typically, you would consider a Visual Studio project to be a component, because you develop and update those classes at the same time. You would consider using stubs and shims for calls that the project makes to other projects in your solution, or to other assemblies that the project references.


### PR DESCRIPTION
FAKES only supports .NET Framework projects. It also cannot support a .NET Framework that targets .NET Standard.