### PR TITLE
Add Requirement for only .NET Framework projects

### DIFF
--- a/docs/test/using-shims-to-isolate-your-application-from-other-assemblies-for-unit-testing.md
+++ b/docs/test/using-shims-to-isolate-your-application-from-other-assemblies-for-unit-testing.md
@@ -21,7 +21,10 @@ author: gewarren
  **Requirements**
 
 -   Visual Studio Enterprise
--   Only for .NET Framework projects. Currently, there is not support for .NET Framework projects that target .NET Standard. 
+-   A .NET Framework project
+
+[!NOTE]
+.NET Standard projects are not supported.
 
 ## Example: The Y2K bug
 

--- a/docs/test/using-shims-to-isolate-your-application-from-other-assemblies-for-unit-testing.md
+++ b/docs/test/using-shims-to-isolate-your-application-from-other-assemblies-for-unit-testing.md
@@ -1,3 +1,4 @@
+
 ---
 title: "Using shims to isolate your application for unit testing in Visual Studio | Microsoft Docs"
 ms.date: "11/04/2016"
@@ -20,6 +21,7 @@ author: gewarren
  **Requirements**
 
 -   Visual Studio Enterprise
+-   Only for .NET Framework projects. Currently, there is not support for .NET Framework projects that target .NET Standard. 
 
 ## Example: The Y2K bug
 

--- a/docs/test/using-shims-to-isolate-your-application-from-other-assemblies-for-unit-testing.md
+++ b/docs/test/using-shims-to-isolate-your-application-from-other-assemblies-for-unit-testing.md
@@ -23,8 +23,8 @@ author: gewarren
 -   Visual Studio Enterprise
 -   A .NET Framework project
 
-[!NOTE]
-.NET Standard projects are not supported.
+> [!NOTE]
+> .NET Standard projects are not supported.
 
 ## Example: The Y2K bug
 


### PR DESCRIPTION
Fakes only supports .NET Framework projects. It also cannot support a .NET Framework that targets .NET Standard.