### PR TITLE
Add Requirement for only .NET Framework projects

### DIFF
--- a/docs/test/code-generation-compilation-and-naming-conventions-in-microsoft-fakes.md
+++ b/docs/test/code-generation-compilation-and-naming-conventions-in-microsoft-fakes.md
@@ -18,8 +18,8 @@ This article discusses options and issues in Fakes code generation and compilati
 -   Visual Studio Enterprise
 -   A .NET Framework project
 
-[!NOTE]
-.NET Standard projects are not supported.
+> [!NOTE]
+> .NET Standard projects are not supported.
 
 ## Code generation and compilation
 

--- a/docs/test/code-generation-compilation-and-naming-conventions-in-microsoft-fakes.md
+++ b/docs/test/code-generation-compilation-and-naming-conventions-in-microsoft-fakes.md
@@ -16,7 +16,10 @@ This article discusses options and issues in Fakes code generation and compilati
 **Requirements**
 
 -   Visual Studio Enterprise
--   Only for .NET Framework projects. Currently, there is not support for .NET Framework projects that target .NET Standard. 
+-   A .NET Framework project
+
+[!NOTE]
+.NET Standard projects are not supported.
 
 ## Code generation and compilation
 

--- a/docs/test/code-generation-compilation-and-naming-conventions-in-microsoft-fakes.md
+++ b/docs/test/code-generation-compilation-and-naming-conventions-in-microsoft-fakes.md
@@ -16,6 +16,7 @@ This article discusses options and issues in Fakes code generation and compilati
 **Requirements**
 
 -   Visual Studio Enterprise
+-   Only for .NET Framework projects. Currently, there is not support for .NET Framework projects that target .NET Standard. 
 
 ## Code generation and compilation
 


### PR DESCRIPTION
Fakes only supports .NET Framework projects. It also cannot support a .NET Framework that targets .NET Standard.