### PR TITLE
Fixed: A typo in one of registry keys

### DIFF
--- a/docs/debugger/debug-using-the-just-in-time-debugger.md
+++ b/docs/debugger/debug-using-the-just-in-time-debugger.md
@@ -53,7 +53,7 @@ Just-In-Time debugging may still be enabled even if Visual Studio is no longer i
   
     -   HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\AeDebug\Debugger  
   
-    -   HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\.NETFramework\DbgManagedDebugger  
+    -   HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\\.NETFramework\DbgManagedDebugger  
 
     ![JIT Registry Key](../debugger/media/dbg-jit-registry.png "JIT Registry Key") 
   


### PR DESCRIPTION
There was a typo in the path to DbgManagedDebugger key.

The path HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\.NETFramework\DbgManagedDebugger is now replaced with  HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\\.NETFramework\DbgManagedDebugger
r