### PR TITLE
chore: Update mac links so they work on GH

### DIFF
--- a/mac/activation.md
+++ b/mac/activation.md
@@ -15,7 +15,7 @@ Visual Studio for Mac provides you with three different subscription levels to c
 * Visual Studio Professional for Mac
 * Visual Studio Community for Mac
 
-To start using a subscription, log in to Visual Studio for Mac by following the steps in the [Signing in to Visual Studio for Mac](~/signing-in.md) guide. Signing in activates your subscription, which is displayed in the accounts dialog:
+To start using a subscription, log in to Visual Studio for Mac by following the steps in the [Signing in to Visual Studio for Mac](signing-in.md) guide. Signing in activates your subscription, which is displayed in the accounts dialog:
 
 ![Show user license dialog](media/user-accounts-login.png)
 
@@ -25,11 +25,11 @@ If your subscription has expired, you have two options:
 
 1. Renew your subscription. You can renew your subscription by browsing to [https://www.visualstudio.com/vs/pricing/](https://www.visualstudio.com/vs/pricing/).
 
-2. If you have another account with an active subscription, you can add it to Visual Studio for Mac as detailed in the [Adding multiple user accounts](~/signing-in.md) article. Visual Studio for Mac will detect the best available license from all accounts that you have added. 
+2. If you have another account with an active subscription, you can add it to Visual Studio for Mac as detailed in the [Adding multiple user accounts](signing-in.md) article. Visual Studio for Mac will detect the best available license from all accounts that you have added. 
 
 ## Product key usage
 
-Currently, there is no way to utilize a product key to enable Professional or Enterprise entitlements for Visual Studio for Mac. To use Visual Studio Enterprise for Mac or Visual Studio Professional for Mac, you must have a relevant [subscription](https://www.visualstudio.com/subscriptions/) and be [signed in](~/signing-in.md) to the IDE.
+Currently, there is no way to utilize a product key to enable Professional or Enterprise entitlements for Visual Studio for Mac. To use Visual Studio Enterprise for Mac or Visual Studio Professional for Mac, you must have a relevant [subscription](https://www.visualstudio.com/subscriptions/) and be [signed in](signing-in.md) to the IDE.
 
 ## Offline activation
 

--- a/mac/azure-workload.md
+++ b/mac/azure-workload.md
@@ -11,6 +11,6 @@ ms.date: 05/06/2018
 
 Visual Studio for Mac allows you to connect to Azure in a variety of ways:
 
-- [Azure Functions](~/azure-functions.md)
+- [Azure Functions](azure-functions.md)
 - [Publishing to Azure](https://blog.xamarin.com/publish-azure-visual-studio-mac/)
-- [Mobile App Services](~/connected-services.md)
+- [Mobile App Services](connected-services.md)

--- a/mac/compiling-and-building.md
+++ b/mac/compiling-and-building.md
@@ -17,7 +17,7 @@ Using Visual Studio for Mac lets you create and run builds instantly, while stil
 
 All Projects and Solutions created in the IDE will have a default build configuration, which define the context for builds. These configurations can be edited or you can create your own. Creating or modifying these configurations will automatically update the project file, which is then used by MSBuild to build your project.  
 
-For more information regarding how to build projects and solutions in the IDE, see the [Building and cleaning Projects and Solutions](~/building-and-cleaning-projects-and-solutions.md) guide.
+For more information regarding how to build projects and solutions in the IDE, see the [Building and cleaning Projects and Solutions](building-and-cleaning-projects-and-solutions.md) guide.
 
 Visual Studio for Mac can also be used to do the following:
 

--- a/mac/ide-tour.md
+++ b/mac/ide-tour.md
@@ -48,7 +48,7 @@ The Solution Pad organizes the project(s) in a solution:
 
 This is where files for the source code, resources, user interface, and dependencies are organized into platform-specific Projects.
 
-For more information on using Projects and Solutions in Visual Studio for Mac, see the [Projects and Solutions](~/projects-and-solutions.md) article.
+For more information on using Projects and Solutions in Visual Studio for Mac, see the [Projects and Solutions](projects-and-solutions.md) article.
 
 ## Assembly References
  
@@ -60,7 +60,7 @@ Additional references are added using the **Edit References** dialog, which is d
  
 ![Edit References Dialog](media/ide-tour-image20.png)
 
-For more information on using References in Visual Studio for Mac, see the [Managing References in a Project](~/managing-references-in-a-project.md) article.
+For more information on using References in Visual Studio for Mac, see the [Managing References in a Project](managing-references-in-a-project.md) article.
 
 ## Dependencies / Packages
 
@@ -72,19 +72,19 @@ To add a dependency to your application, right-click on the Dependencies / Packa
 
 ![Add a NuGet package](media/ide-tour-image21.png)
 
-Information on using a NuGet package in an application can be found in the [Including a NuGet project in your project](~/nuget-walkthrough.md) article.
+Information on using a NuGet package in an application can be found in the [Including a NuGet project in your project](nuget-walkthrough.md) article.
 
 ## Refactoring
 
-Visual Studio for Mac provides two useful ways to refactor your code: Context Actions, and Source Analysis. You can read more about them in the [Refactoring](~/refactoring.md) article.
+Visual Studio for Mac provides two useful ways to refactor your code: Context Actions, and Source Analysis. You can read more about them in the [Refactoring](refactoring.md) article.
 
 ## Debugging
 
-Visual Studio for Mac has a native debugger allowing debugging support for Xamarin.iOS, Xamarin.Mac, and Xamarin.Android applications. Visual Studio for Mac uses the Mono Soft Debugger, which is implemented into the Mono runtime, allowing the IDE to debug managed code across all platforms. For additional information on debugging, visit the [Debugging](~/debugging.md) article.
+Visual Studio for Mac has a native debugger allowing debugging support for Xamarin.iOS, Xamarin.Mac, and Xamarin.Android applications. Visual Studio for Mac uses the Mono Soft Debugger, which is implemented into the Mono runtime, allowing the IDE to debug managed code across all platforms. For additional information on debugging, visit the [Debugging](debugging.md) article.
 
 The debugger contains rich visualizers for special types such as strings, colors, URLs, as well as sizes, co-ordinates, and bézier curves.
 
-For more information on the debugger's data visualizations, visit the [Data Visualizations](~/data-visualizations.md) article.
+For more information on the debugger's data visualizations, visit the [Data Visualizations](data-visualizations.md) article.
 
 ## Version Control
 
@@ -96,4 +96,4 @@ Files with uncommitted changed have an annotation on their icons in the Solution
 
 ![Uncommitted files in solution pad](media/ide-tour-image23.png)
 
-For more information on using version control in Visual Studio, see the [Version Control](~/version-control.md) article.
+For more information on using version control in Visual Studio, see the [Version Control](version-control.md) article.

--- a/mac/index.md
+++ b/mac/index.md
@@ -23,7 +23,7 @@ This article surveys various sections of Visual Studio for Mac, providing a look
 
 ## Installation
 
-Follow the steps in the [Installation](~/installation.md) guide to download and Install Visual Studio for Mac.
+Follow the steps in the [Installation](installation.md) guide to download and Install Visual Studio for Mac.
 
 ## Language support
 
@@ -114,8 +114,8 @@ For more information, see the [Xamarin Inspector](https://developer.xamarin.com/
 
 ## Next steps
 
-* **Get the tour** - To get an overview of many of the major features in Visual Studio for Mac, see the Visual Studio for Mac [IDE Tour](~/ide-tour.md).
-* **Set up** - To learn about how to download and install Visual Studio, see the [Installation](~/installation.md) guide.
+* **Get the tour** - To get an overview of many of the major features in Visual Studio for Mac, see the Visual Studio for Mac [IDE Tour](ide-tour.md).
+* **Set up** - To learn about how to download and install Visual Studio, see the [Installation](installation.md) guide.
 * **Xamarin Tutorials** - To learn more about how to develop code with Xamarin, go to the Xamarin [Developer Center](https://developer.xamarin.com).
 * **Videos** - To learn more about other features and aspects of Visual Studio for Mac, check out videos on the [Xamarin University](https://university.xamarin.com) website.
 * **Hands-on Labs** - To get started working with the various workloads included in Visual Studio for Mac, check out the [hands-on labs](https://github.com/Microsoft/vs4mac-labs).

--- a/mac/install-preview.md
+++ b/mac/install-preview.md
@@ -13,7 +13,7 @@ ms.assetid: 0E1EF257-9DE4-4653-9DF4-805CE007A1A1
 
 Before a new version of Visual Studio for Mac is officially released, it's released as a preview. The preview release gives you a chance to try out new features and get the latest bug fixes before they are fully incorporated into the product.
 
-Preview releases to Visual Studio for Mac are distributed as an update, rather than through a separate download. Visual Studio for Mac has three updater channels, as described in the [update](~/update.md) article: Stable, Beta, and Alpha.
+Preview releases to Visual Studio for Mac are distributed as an update, rather than through a separate download. Visual Studio for Mac has three updater channels, as described in the [update](update.md) article: Stable, Beta, and Alpha.
 
 Most preview releases will be available through both the **Beta** and **Alpha** channels, but always check the [Preview Release Notes](/visualstudio/releasenotes/vs2017-mac-preview-relnotes) for the most accurate information.
 
@@ -24,4 +24,4 @@ To install the preview of Visual Studio for Mac, use the following steps:
 3. Select the **Switch channel** button to switch to the selected channel and start downloading any new updates.
 4. Select the **Restart and Install Updates** button to start installing the updates.
 
-For more information on updating in Visual Studio for Mac, see the [update](~/update.md) article.
+For more information on updating in Visual Studio for Mac, see the [update](update.md) article.

--- a/mac/installation.md
+++ b/mac/installation.md
@@ -88,7 +88,7 @@ To install Visual Studio for Mac behind a firewall, certain endpoints must be ma
 
 Configure your network to allow access to the following locations:
 
-* [Visual Studio endpoints](../docs/install/install-and-use-visual-studio-behind-a-firewall-or-proxy-server)
+* [Visual Studio endpoints](../docs/install/install-and-use-visual-studio-behind-a-firewall-or-proxy-server.md)
 
 ## Next Steps
 

--- a/mac/installation.md
+++ b/mac/installation.md
@@ -54,7 +54,7 @@ For working with iOS in Visual Studio you need the following pieces:
       - Fully cross-platform Xamarin apps – Select **Android**, **iOS**, and **macOS** platforms.
   * **.NET Core applications** – Select **.NET Core** platform.
   * **ASP.NET Core Web Applications** – Select **.NET Core** platform.
-  * **Cross-platform Unity Game Development** – No additional platforms need to be installed beyond Visual Studio for Mac. Refer to the [Unity setup guide](~/setup-vsmac-tools-unity.md) for more information on installing the Unity extension.
+  * **Cross-platform Unity Game Development** – No additional platforms need to be installed beyond Visual Studio for Mac. Refer to the [Unity setup guide](setup-vsmac-tools-unity.md) for more information on installing the Unity extension.
 
   This installation screen displays the version and size of each individual component. You can click each component to display a list of dependencies for that component (for Android), see additional packages that it downloads (for .NET Core), or view any additional applications required (for iOS and macOS):
 
@@ -88,7 +88,7 @@ To install Visual Studio for Mac behind a firewall, certain endpoints must be ma
 
 Configure your network to allow access to the following locations:
 
-* [Visual Studio endpoints](/visualstudio/install/install-visual-studio-behind-a-firewall-or-proxy-server)
+* [Visual Studio endpoints](../docs/install/install-and-use-visual-studio-behind-a-firewall-or-proxy-server)
 
 ## Next Steps
 
@@ -108,4 +108,4 @@ Installing Visual Studio for Mac allows you to start writing code for your apps.
 
 ### .NET Core apps, ASP.NET Core web apps, Unity game development
 
-For other Workloads, refer to the [Workloads](~/workloads.md) page.
+For other Workloads, refer to the [Workloads](workloads.md) page.

--- a/mac/keyboard-shortcuts.md
+++ b/mac/keyboard-shortcuts.md
@@ -27,7 +27,7 @@ This command contextually generates code:
 
 ## Quick fixes and actions
 
-Displays [refactoring](~/refactoring.md) context actions:
+Displays [refactoring](refactoring.md) context actions:
 
 `option + enter`
 

--- a/mac/managing-references-in-a-project.md
+++ b/mac/managing-references-in-a-project.md
@@ -36,4 +36,4 @@ NuGet is the most popular package manager for .NET development. Visual Studio fo
 
 To do this, right-click on the **Package** folder in the Solution Pad, and select Add Packages.
 
-More information on using a NuGet Package is provided in the [Including a NuGet package in your Project](~/nuget-walkthrough.md) walkthrough.
+More information on using a NuGet Package is provided in the [Including a NuGet package in your Project](nuget-walkthrough.md) walkthrough.

--- a/mac/projects-and-solutions.md
+++ b/mac/projects-and-solutions.md
@@ -12,8 +12,8 @@ Visual Studio for Mac provides a _Solution Pad_ to display a tree view of the 
 
 ## Using Projects and Solutions
 
-To create a new Project or Solution, refer to the [Creating new Projects and Solutions](~/create-new-projects.md) article.
+To create a new Project or Solution, refer to the [Creating new Projects and Solutions](create-new-projects.md) article.
 
 ## Project and Solution Options
 
-You can manage the properties of both projects and solutions by either double-clicking on the Project/Solution name, or by right-clicking and browsing to **Options**. More information on these options is provided in the [Managing Solutions and Project Properties](~/managing-solutions-and-project-properties.md) article.
+You can manage the properties of both projects and solutions by either double-clicking on the Project/Solution name, or by right-clicking and browsing to **Options**. More information on these options is provided in the [Managing Solutions and Project Properties](managing-solutions-and-project-properties.md) article.

--- a/mac/setup-vsmac-tools-unity.md
+++ b/mac/setup-vsmac-tools-unity.md
@@ -16,7 +16,7 @@ Download and install Visual Studio for Mac. All editions of Visual Studio for Ma
 
 * Download Visual Studio for Mac from [visualstudio.com](https://www.visualstudio.com/).
 * Visual Studio for Mac Tools for Unity are installed automatically during the installation process.
-* Follow the steps in the [installation guide](/visualstudio/mac/installation) for additional installation help.
+* Follow the steps in the [installation guide](installation.md) for additional installation help.
 
 ## Confirm that the Visual Studio for Mac Tools for Unity extension is enabled
 

--- a/mac/unity-tools.md
+++ b/mac/unity-tools.md
@@ -39,7 +39,7 @@ Visual Studio for Mac Tools for Unity supports all the [debugging](using-vsmac-t
 
 ### Powerful refactoring and context actions
 
-Write more usable code with quick menus and keyboard shortcuts for [renaming, refactoring, and context actions](/visualstudio/mac/refactoring).
+Write more usable code with quick menus and keyboard shortcuts for [renaming, refactoring, and context actions](refactoring.md).
 
 ### Browse and add new files
 
@@ -47,15 +47,15 @@ Browse Unity projects and [add folders, scripts, or shaders](using-vsmac-tools-u
 
 ### Use familiar key bindings
 
-Boost productivity by using the key bindings that you know. Visual Studio for Mac provides familiar [key bindings](/visualstudio/mac/customizing-the-ide) for many popular IDEs, such as Visual Studio on Windows, ReSharper, Visual Studio Code, and Xcode.
+Boost productivity by using the key bindings that you know. Visual Studio for Mac provides familiar [key bindings](customizing-the-ide.md) for many popular IDEs, such as Visual Studio on Windows, ReSharper, Visual Studio Code, and Xcode.
 
 ### Customize the Visual theme
 
-Give your eyes a rest with the included [dark theme](/visualstudio/mac/customizing-the-ide).
+Give your eyes a rest with the included [dark theme](customizing-the-ide.md).
 
 ## Tips for Unity developers getting started with Visual Studio for Mac
 
 These links explain useful features for Unity developers just starting with Visual Studio for Mac:
 
-* [Customizing the IDE](/visualstudio/mac/customizing-the-ide) – Learn how to [change the visual theme](/visualstudio/mac/customizing-the-ide#dark-theme) or switch to a more familiar [key binding](/visualstudio/mac/customizing-the-ide#key-bindings) scheme.
-* [Source Editor](/visualstudio/mac/source-editor) – Learn how Visual Studio for Mac can make writing better code faster and easier, including common [keyboard shortcuts](/visualstudio/mac/keyboard-shortcuts).
+* [Customizing the IDE](customizing-the-ide.md) – Learn how to [change the visual theme](customizing-the-ide.md#dark-theme) or switch to a more familiar [key binding](customizing-the-ide.md#key-bindings) scheme.
+* [Source Editor](source-editor.md) – Learn how Visual Studio for Mac can make writing better code faster and easier, including common [keyboard shortcuts](keyboard-shortcuts.md).

--- a/mac/using-vsmac-tools-unity.md
+++ b/mac/using-vsmac-tools-unity.md
@@ -12,7 +12,7 @@ In this section, you'll learn how to use Visual Studio for Mac Tools for Unity's
 
 ## Opening Unity scripts in Visual Studio for Mac
 
-Once Visual Studio for Mac is [set as the external script editor for Unity](/visualstudio/mac/setup-vsmac-tools-unity#configure-unity-for-use-with-visual-studio-for-mac), opening any script from the Unity editor will automatically launch or switch to Visual Studio for Mac, with the chosen script open.
+Once Visual Studio for Mac is [set as the external script editor for Unity](setup-vsmac-tools-unity.md#configure-unity-for-use-with-visual-studio-for-mac), opening any script from the Unity editor will automatically launch or switch to Visual Studio for Mac, with the chosen script open.
 
 Alternatively, Visual Studio for Mac can be opened with no script open in the source editor by selecting **Open C# Project** from the **Assets** menu in Unity.
 

--- a/mac/version-control.md
+++ b/mac/version-control.md
@@ -23,7 +23,7 @@ Git is a distributed version control system that allows teams to work on the sam
 
 Visual Studio for Mac provides support for both Git and Subversion version control systems. The following articles explore setting up Git and Subversion repositories through Visual Studio for Mac, as well as simple functionality such as reviewing, committing, and pushing changes.
 
-* [Setting Up a Git Repository](~/set-up-git-repository.md) 
-* [Working with Git](~/working-with-git.md)
-* [Setting Up a Subversion Repository](~/set-up-subversion-repository.md)
-* [Working with Subversion](~/working-with-subversion.md)
+* [Setting Up a Git Repository](set-up-git-repository.md) 
+* [Working with Git](working-with-git.md)
+* [Setting Up a Subversion Repository](set-up-subversion-repository.md)
+* [Working with Subversion](working-with-subversion.md)

--- a/mac/working-with-subversion.md
+++ b/mac/working-with-subversion.md
@@ -25,7 +25,7 @@ The following image illustrates the options provided by Visual Studio for Mac by
 
 Before starting to use a remote Subversion repository, check out the repo to create a working copy of that directory on your local machine.
 
-To find out about using the **Checkout** feature in Visual Studio for Mac, follow the steps in the [Setting up a Subversion repository](~/set-up-subversion-repository.md) section.
+To find out about using the **Checkout** feature in Visual Studio for Mac, follow the steps in the [Setting up a Subversion repository](set-up-subversion-repository.md) section.
 
 ## Update solution
 

--- a/mac/workloads.md
+++ b/mac/workloads.md
@@ -29,8 +29,8 @@ For more information on using .NET Core, refer to the [documentation](https://do
 
 ## ASP.NET Core Web Applications
 
-For information on getting started using ASP.NET Core in Visual Studio for Mac, refer to the [Getting Started with ASP.NET Core](~/asp-net-core.md) guide or check out the ASP.NET Core web apps [hands-on lab](https://github.com/Microsoft/vs4mac-labs/tree/master/Web/Getting-Started).
+For information on getting started using ASP.NET Core in Visual Studio for Mac, refer to the [Getting Started with ASP.NET Core](asp-net-core.md) guide or check out the ASP.NET Core web apps [hands-on lab](https://github.com/Microsoft/vs4mac-labs/tree/master/Web/Getting-Started).
 
 ## Cross-platform Unity Game Development
 
-To start building games with Unity, see the [Setup page](~/setup-vsmac-tools-unity.md) and the [guide to using Unity Tools](~/using-vsmac-tools-unity.md), or check out the Unity [hands-on lab](https://github.com/Microsoft/vs4mac-labs/tree/master/Unity/Getting-Started).
+To start building games with Unity, see the [Setup page](setup-vsmac-tools-unity.md) and the [guide to using Unity Tools](using-vsmac-tools-unity.md), or check out the Unity [hands-on lab](https://github.com/Microsoft/vs4mac-labs/tree/master/Unity/Getting-Started).


### PR DESCRIPTION
Some of these may have special handlings in the openpublishing platform, but they don't work on GitHub or VSCode.
- `~/` used for same folder links
- Extensionless absolute links starting with `/visualstudio/mac/` change to relative links with `.md` extension