### PR TITLE
Update NUnit Test Generator Extension link for VS 2017

### DIFF
--- a/docs/test/generate-unit-tests-for-your-code-with-intellitest.md
+++ b/docs/test/generate-unit-tests-for-your-code-with-intellitest.md
@@ -139,7 +139,7 @@ Specify the general relationship between inputs and outputs that you want the ge
 **A:** Yes, follow these steps to [find and install other frameworks](../test/install-third-party-unit-test-frameworks.md).
 Test framework extensions are also available in Visual Studio Marketplace:
 
-* [NUnit Extension for the Test Generators](https://marketplace.visualstudio.com/items?itemName=NUnitDevelopers.TestGeneratorNUnitextension)
+* [NUnit Extension for the Test Generators](https://marketplace.visualstudio.com/items?itemName=NUnitDevelopers.TestGeneratorNUnitextension-18371)
 * [xUnit.net Extension for the Test Generators](https://marketplace.visualstudio.com/items?itemName=BradWilson.xUnitnetTestExtensions)
 
 


### PR DESCRIPTION
The NUnit extension was released separately for VS 2017 to the VS 2015 extension. This link points to the VS 2015 version, which is still supported, but I thought it made more sense to point to the VS 2017 version.