### PR TITLE
Critical differentiation between Self CPU and Total CPU

### DIFF
--- a/docs/profiling/cpu-usage.md
+++ b/docs/profiling/cpu-usage.md
@@ -88,7 +88,7 @@ Here, we show you how to collect and analyze CPU usage with release builds. To a
 |**Total CPU (%)**|![Total % data equation](../profiling/media/cpu_use_wt_totalpercentequation.png "CPU_USE_WT_TotalPercentEquation")<br /><br /> The percentage of the app's CPU activity in the selected time range that was used by calls to the function and the functions called by the function. Note that this is different from the **CPU Utilization** timeline graph, which compares the total activity of the app in a time range to the total available CPU capacity.|  
 |**Self CPU (%)**|![Self % equation](../profiling/media/cpu_use_wt_selflpercentequation.png "CPU_USE_WT_SelflPercentEquation")<br /><br /> The percentage of the app's CPU activity in the selected time range that was used by the calls to the function, excluding the activity of functions called by the function.|  
 |**Total CPU (ms)**|The number of milliseconds spent in calls to the function in the selected time range and the functions that were called by the function.|  
-|**Self CPU (ms)**|The number of milliseconds spent in calls to the function in the selected time range and the functions that were called by the function.|  
+|**Self CPU (ms)**|The number of milliseconds spent in calls to the function in the selected time range and the functions that were called by the function, excluding the activity of functions called by the function.|  
 |**Module**|The name of the module containing the function, or the number of modules containing the functions in an [External Code] node.|  
   
 ###  <a name="BKMK_Asynchronous_functions_in_the_CPU_Usage_call_tree"></a> Asynchronous functions in the CPU usage call tree  


### PR DESCRIPTION
The definitions for *Total CPU (ms)* and *Self CPU (ms)* are exactly the same, making the definition for Self CPU (ms) incorrect. I've added a bit of text from the *Self CPU (%)* definition that makes it correct.