### PR TITLE
Method naming casing wrong (minor typo)

### DIFF
--- a/docs/cross-platform/build-apps-with-native-ui-using-xamarin-in-visual-studio.md
+++ b/docs/cross-platform/build-apps-with-native-ui-using-xamarin-in-visual-studio.md
@@ -140,7 +140,7 @@ Visual Studio does not have a solution template for creating native UI applicati
     {  
         public class DataService  
         {  
-            public static async Task<dynamic> getDataFromService(string queryString)  
+            public static async Task<dynamic> GetDataFromService(string queryString)  
             {  
                 HttpClient client = new HttpClient();  
                 var response = await client.GetAsync(queryString);  


### PR DESCRIPTION
We declare DataService.getDataFromService but call it as DataService.GetDataFromService in the sample code in the 'Build apps with native UI using Xamarin in Visual Studio' documentation. The declaration should start with a capital 'G' too.