### PR TITLE
fix indentation and casing of Source Link bullet

### DIFF
--- a/docs/debugger/general-debugging-options-dialog-box.md
+++ b/docs/debugger/general-debugging-options-dialog-box.md
@@ -89,7 +89,7 @@ Tells the Visual Studio debugger to get source files from source servers that im
 - **Allow source server for partial trust assemblies (Managed only)**  
     When source server support is enabled, this setting overrides the default behavior of not retrieving sources for partial trust assemblies.  
 
-- **Enable source link support**  
+**Enable Source Link support**  
     Tells the Visual Studio debugger to download source files for .pdb files that contain Source Link information. For more information about Source Link, see the [Source Link Specification](https://github.com/dotnet/core/blob/master/Documentation/diagnostics/source_link.md).
 
     > [!IMPORTANT]


### PR DESCRIPTION
To match the dialog:

![image](https://user-images.githubusercontent.com/677704/40433763-13108b42-5ead-11e8-86ca-984e64d9bd02.png)
