### PR TITLE
M26805: Possible incorrect term: "Django Web Project" vs. "Blank Djan…

### DIFF
--- a/docs/python/learn-django-in-visual-studio-step-04-full-django-project-template.md
+++ b/docs/python/learn-django-in-visual-studio-step-04-full-django-project-template.md
@@ -17,7 +17,7 @@ ms.workload:
 
 **Previous step: [Serve static files, add pages, and use template inheritance](learn-django-in-visual-studio-step-03-serve-static-files-and-add-pages.md)**
 
-Now that you've explored the basics of Django by building an app upon the "Blank Django App Project" template in Visual Studio, you can easily understand the fuller app that's produced by the "Django Web Project" template.
+Now that you've explored the basics of Django by building an app upon the "Blank Django Web Project" template in Visual Studio, you can easily understand the fuller app that's produced by the "Django Web Project" template.
 
 In this step you now:
 


### PR DESCRIPTION
…go Web Project"

Hello, @kraigb,

Translator has reported possible source content issue. 
 
Please review and merge the suggested proposed file change to avoid this error. If you make related fix in another PR, then share your PR number, so we can confirm and close this PR.

Many thanks in advance.