### PR TITLE
Correct the criteria for `BeforeTargets`

### DIFF
--- a/docs/msbuild/target-build-order.md
+++ b/docs/msbuild/target-build-order.md
@@ -110,7 +110,7 @@ Targets must be ordered if the input to one target depends on the output of anot
   
 4.  Before a target is executed, its `DependsOnTargets` targets are run.  
   
-5.  Before a target is executed, any target that lists it in a `BeforeTargets` attribute is run.  
+5.  Before a target is executed or skipped, any target that lists it in a `BeforeTargets` attribute is run.  
   
 6.  Before a target is executed, its `Inputs` attribute and `Outputs` attribute are compared. If MSBuild determines that any output files are out of date with respect to the corresponding input file or files, then MSBuild executes the target. Otherwise, MSBuild skips the target.  
   


### PR DESCRIPTION
# Change

Under "Determining the Target Build Order", added "or skipped" to the criteria regarding when targets listed in `BeforeTargets` are run.

# Tests verifying the revised criteria is accurate

## CONDITION FALSE, OUTPUTS NOT UP TO DATE
### DependsOnTargets: BeforeDefault does not run.
  Code:
```
    <Target Name="Default" Condition="false" DependsOnTargets="BeforeDefault" />
    <Target Name="BeforeDefault" />
```
  Log:
_Target "Default" skipped, due to false condition; (false) was evaluated as (false)._

### BeforeTargets: BeforeDefault runs.
  Code:
```
    <Target Name="Default" Condition="false" />
    <Target Name="BeforeDefault" BeforeTargets="Default" />
```
  Log:
    _Target "Default" skipped, due to false condition; (false) was evaluated as (false).
    Target "BeforeDefault" (target "Default" depends on it):
    Done building target "BeforeDefault"_

### AfterTargets: AfterDefault runs.
  Code:
```
    <Target Name="Default" Condition="false" />
    <Target Name="AfterDefault" AfterTargets="Default" />
```
  Log:
    _Target "Default" skipped, due to false condition; (false) was evaluated as (false).
    Target "AfterDefault" (entry point):
    Done building target "AfterDefault"_


## CONDITION FALSE, OUTPUTS UP TO DATE

### DependsOnTargets: BeforeDefault does not run.
  Code:
```
    <Target Name="Default" Condition="false" DependsOnTargets="BeforeDefault" Inputs="c:\install.ini" Outputs="c:\install.ini" />
    <Target Name="BeforeDefault" />
```
  Log:
    _Target "Default" skipped, due to false condition; (false) was evaluated as (false)._

### BeforeTargets: BeforeDefault runs.
  Code:
```
    <Target Name="Default" Condition="false" Inputs="c:\install.ini" Outputs="c:\install.ini" />
    <Target Name="BeforeDefault" BeforeTargets="Default" />
```
  Log:
    _Target "Default" skipped, due to false condition; (false) was evaluated as (false).
    Target "BeforeDefault" (target "Default" depends on it):
    Done building target "BeforeDefault"_

### AfterTargets: AfterDefault runs.
  Code:
```
    <Target Name="Default" Condition="false" Inputs="c:\install.ini" Outputs="c:\install.ini" />
    <Target Name="AfterDefault" AfterTargets="Default" />
```
  Log:
    _Target "Default" skipped, due to false condition; (false) was evaluated as (false).
    Target "AfterDefault" (entry point):
    Done building target "AfterDefault"_


## CONDITION TRUE, OUTPUTS UP TO DATE

### DependsOnTargets: BeforeDefault runs.
  Code:
```
    <Target Name="Default" DependsOnTargets="BeforeDefault" Inputs="c:\install.ini" Outputs="c:\install.ini" />
    <Target Name="BeforeDefault" />
```
  Log:
    _Target "BeforeDefault" (target "Default" depends on it):
    Done building target "BeforeDefault" in project "temp.proj".
    Target "Default" (entry point):
    Skipping target "Default" because all output files are up-to-date with respect to the input files._

### BeforeTargets: BeforeDefault runs.
  Code:
```
    <Target Name="Default" Inputs="c:\install.ini" Outputs="c:\install.ini" />
    <Target Name="BeforeDefault" BeforeTargets="Default" />
```
  Log:
    _Target "BeforeDefault" (target "Default" depends on it):
    Done building target "BeforeDefault"
    Target "Default" (entry point):
    Skipping target "Default" because all output files are up-to-date with respect to the input files._

### AfterTargets: AfterDefault runs.
  Code:
```
    <Target Name="Default" Inputs="c:\install.ini" Outputs="c:\install.ini" />
    <Target Name="AfterDefault" AfterTargets="Default" />
```
  Log:
    _Target "Default" (entry point):
    Skipping target "Default" because all output files are up-to-date with respect to the input files.
    Done building target "Default"
    Target "AfterDefault" (entry point):
    Done building target "AfterDefault"_