### PR TITLE
Fix subscription links

### DIFF
--- a/subscriptions/using-admin-portal.md
+++ b/subscriptions/using-admin-portal.md
@@ -46,7 +46,7 @@ When your organization is ready to be onboarded to the Visual Studio Subscriptio
 > [!NOTE]
 > If the Primary or Notices Contacts receive more than one email, this means that they have more than one PCN. They will need to complete the process using the unique link for the PCN referenced in each email.*
 
-If you need to be added to the new Visual Studio Subscriptions Administration Portal and you aren’t sure who your Primary/Notices Contact is, you can find this information after signing in to the [VLSC](https://www.microsoft.com/Licensing/servicecenter/default.aspx). Take a look at the [Find Your Primary Contact](/find-primary-contact/) topic for steps to locate your Primary/Notices Contact in the VLSC.
+If you need to be added to the new Visual Studio Subscriptions Administration Portal and you aren’t sure who your Primary/Notices Contact is, you can find this information after signing in to the [VLSC](https://www.microsoft.com/Licensing/servicecenter/default.aspx). Take a look at the [Find Your Primary Contact](find-primary-contact.md) topic for steps to locate your Primary/Notices Contact in the VLSC.
 If you have already been set up as an administrator, then you can go directly to the [Visual Studio Subscriptions Administration Portal](https://manage.visualstudio.com).
 
 ### Understanding the Subscribers page

--- a/subscriptions/vlsc-admin-faq.md
+++ b/subscriptions/vlsc-admin-faq.md
@@ -73,7 +73,7 @@ Your organization’s Primary Contacts and Notices Contacts will receive an emai
 You will continue managing subscriptions through the VLSC until you receive the email from Visual Studio Subscriptions that your organization has been migrated and is ready to be managed in the new portal. 
 
 ### Where can I locate my organization’s Public Customer Number (PCN) or Authorization Number?
-Sign in to the [VLSC](https://www.microsoft.com/Licensing/servicecenter/default.aspx) and navigate the following path: **Subscriptions** > **Visual Studio Subscriptions**. The PCN is located below the **Agreement/Public Customer Number Results**. Get step by step guidance on locating your PCN in this [help article](/find-pcn/). 
+Sign in to the [VLSC](https://www.microsoft.com/Licensing/servicecenter/default.aspx) and navigate the following path: **Subscriptions** > **Visual Studio Subscriptions**. The PCN is located below the **Agreement/Public Customer Number Results**. Get step by step guidance on locating your PCN in this [help article](find-pcn.md). 
 
 ### How do I find out who my Primary or Notices Contact is?
 Sign in to the [VLSC](https://www.microsoft.com/Licensing/servicecenter/default.aspx) and navigate the following path: **Licenses > Relationship Summary**  Select your **Licensing ID > Contacts**. Get step by step guidance on finding your Primary or Notices Contact in this [help article](find-primary-contact.md). 


### PR DESCRIPTION
Since the Subscription docs are under `/visualstudio/subscriptions/` these should be relative and use the `.md` extension for GH navigation