### PR TITLE
fix: tfsconfig-cmd links

### DIFF
--- a/docs/ide/codeindex-command.md
+++ b/docs/ide/codeindex-command.md
@@ -121,4 +121,4 @@ TFSConfig CodeIndex /destroyCodeIndex /collectionName:"Fabrikam Web Site"
 ## See also
 
 - [Find code changes and other history with CodeLens](../ide/find-code-changes-and-other-history-with-codelens.md)
-- [Managing server configuration with TFSConfig](/vsts/tfs-server/command-line/tfsconfig-cmd)
+- [Managing server configuration with TFSConfig](/tfs/server/ref/command-line/tfsconfig-cmd)

--- a/docs/ide/find-code-changes-and-other-history-with-codelens.md
+++ b/docs/ide/find-code-changes-and-other-history-with-codelens.md
@@ -78,7 +78,7 @@ This is what you see when you use Team Foundation Version Control (TFVC) in Team
 
 ![CodeLens: Get change history for your code in TFVC](../ide/media/codelens-code-changes.png)
 
-The default time period is the last 12 months. If your code is stored in Team Foundation Server, you can change the time period by running the [TFSConfig command](/vsts/tfs-server/command-line/tfsconfig-cmd) with the [CodeIndex command](../ide/codeindex-command.md) and the **/indexHistoryPeriod** flag.
+The default time period is the last 12 months. If your code is stored in Team Foundation Server, you can change the time period by running the [TFSConfig command](/tfs/server/ref/command-line/tfsconfig-cmd) with the [CodeIndex command](../ide/codeindex-command.md) and the **/indexHistoryPeriod** flag.
 
 To see a detailed history of all the changes, including those from more than a year ago, choose **Show all file changes**:
 
@@ -247,7 +247,7 @@ Turn CodeLens file-level indicators on and off using the chevron icons at the bo
 
 - Make sure CodeLens is turned on. Go to **Tools** > **Options** > **Text Editor** > **All Languages** > **CodeLens**.
 
-- If your code is stored in TFS, make sure that code indexing is turned on by using the [CodeIndex command](../ide/codeindex-command.md) with the [TFS Config command](/vsts/tfs-server/command-line/tfsconfig-cmd).
+- If your code is stored in TFS, make sure that code indexing is turned on by using the [CodeIndex command](../ide/codeindex-command.md) with the [TFS Config command](/tfs/server/ref/command-line/tfsconfig-cmd).
 
 - TFS-related indicators appear only when work items are linked to the code and when you have permissions to open linked work items. Confirm that you have [team member permissions](/vsts/work/scale/multiple-teams).
 
@@ -315,7 +315,7 @@ To use the keyboard:
 
 ### Q: Can I manage how CodeLens processes code to show history and linked items?
 
-**A:** Yes. If your code is in TFS, use the [CodeIndex command](../ide/codeindex-command.md) with the [TFS Config command](/vsts/tfs-server/command-line/tfsconfig-cmd).
+**A:** Yes. If your code is in TFS, use the [CodeIndex command](../ide/codeindex-command.md) with the [TFS Config command](/tfs/server/ref/command-line/tfsconfig-cmd).
 
 ## See also
 


### PR DESCRIPTION
Not sure if these links changed without a redirect since they don't appear be part of the vsts-docs repo currently