### PR TITLE
fix: GoogleTest link casing

### DIFF
--- a/docs/test/how-to-use-google-test-for-cpp.md
+++ b/docs/test/how-to-use-google-test-for-cpp.md
@@ -40,7 +40,7 @@ an IntelliSense window will appear and enable you to select the full path to the
 ![Add #include directives](media/cpp-gtest-includes.png)
 
 ## Write and run Tests
-You are now ready to write and run Google Tests. See the [Google Test Primer](https://github.com/google/googletest/blob/master/googletest/docs/Primer.md) for information about the test macros. See [Run unit tests with Test Explorer](run-unit-tests-with-test-explorer.md) for information about discovering, running, and grouping your tests by using **Test Explorer**.
+You are now ready to write and run Google Tests. See the [Google Test Primer](https://github.com/google/googletest/blob/master/googletest/docs/primer.md) for information about the test macros. See [Run unit tests with Test Explorer](run-unit-tests-with-test-explorer.md) for information about discovering, running, and grouping your tests by using **Test Explorer**.
 
 ## See also
 [Writing Unit Tests for C/C++](writing-unit-tests-for-c-cpp.md)

--- a/docs/test/writing-unit-tests-for-c-cpp.md
+++ b/docs/test/writing-unit-tests-for-c-cpp.md
@@ -63,7 +63,7 @@ Next, in your unit test .cpp file, add an `#include` directive for any header fi
 ### Write test methods
 
 > [!NOTE]
-> This section shows syntax for the Microsoft Unit Testing Framework for C/C++. It is documented here: [Microsoft.VisualStudio.TestTools.CppUnitTestFramework API Reference](microsoft-visualstudio-testtools-cppunittestframework-api-reference.md). For Google Test documentation, see [Google Test Primer](https://github.com/google/googletest/blob/master/googletest/docs/Primer.md). For Boost.Test, see [Boost Test Library: The Unit Test Framework](http://www.boost.org/doc/libs/1_46_0/libs/test/doc/html/utf.html).
+> This section shows syntax for the Microsoft Unit Testing Framework for C/C++. It is documented here: [Microsoft.VisualStudio.TestTools.CppUnitTestFramework API Reference](microsoft-visualstudio-testtools-cppunittestframework-api-reference.md). For Google Test documentation, see [Google Test Primer](https://github.com/google/googletest/blob/master/googletest/docs/primer.md). For Boost.Test, see [Boost Test Library: The Unit Test Framework](http://www.boost.org/doc/libs/1_46_0/libs/test/doc/html/utf.html).
 
 The .cpp file in your test project has a stub class and method defined for you as an example of how to write test code. Note that the signatures use the TEST_CLASS and TEST_METHOD macros, which make the methods discoverable from the Test Explorer window.
 


### PR DESCRIPTION
They renamed the files to lowercase and GH no longer was picking it up