### PR TITLE
spelling/grammar fix

### DIFF
--- a/docs/extensibility/language-server-protocol.md
+++ b/docs/extensibility/language-server-protocol.md
@@ -48,7 +48,7 @@ Below is an example for how a tool and a language server communicate during a ro
 
 * **The user opens a file (referred to as a document) in the tool**: The tool notifies the language server that a document is open ('textDocument/didOpen'). From now on, the truth about the contents of the document is no longer on the file system but kept by the tool in memory.
 
-* **The user makes edits**: The tool notifies the server about the document change ('textDocument/didChange') and the semantic information of the program is updated by the language server. As this happens, the language server analyses this information and notifies the tool with the detected errors and warnings ('textDocument/publishDiagnostics').
+* **The user makes edits**: The tool notifies the server about the document change ('textDocument/didChange') and the semantic information of the program is updated by the language server. As this happens, the language server analyzes this information and notifies the tool with the detected errors and warnings ('textDocument/publishDiagnostics').
 
 * **The user executes "Go to Definition" on a symbol in the editor**: The tool sends a 'textDocument/definition' request with two parameters: (1) the document URI and (2) the text position from where the Go to Definition request was initiated to the server. The server responds with the document URI and the position of the symbol's definition inside the document.
 


### PR DESCRIPTION
analysis is a noun, but the verb analyzes is what was intended. "analyses" is just misspelled.