### PR TITLE
Minor typo in creation of "__init__.py"

### DIFF
--- a/docs/python/learn-flask-visual-studio-step-02-create-app.md
+++ b/docs/python/learn-flask-visual-studio-step-02-create-app.md
@@ -31,7 +31,7 @@ In the code created by the "Blank Flask Web Project" template, you have a single
 
 1. In your project folder, create an app folder called `HelloFlask` (right-click the project in **Solution Explorer** and select **Add** > **New Folder**.)
 
-1. In the `HelloFlask` folder, create a file named `__init.py__` with the following contents that creates the `Flask` instance and loads the app's views (created in the next step):
+1. In the `HelloFlask` folder, create a file named `__init__.py` with the following contents that creates the `Flask` instance and loads the app's views (created in the next step):
 
     ```python
     from flask import Flask


### PR DESCRIPTION
Line 34: Initially, the documentation instructed the user to create a new file named "__init.py__".  This is referenced as "__init__.py" in the remainder of the document. This edit is to reflect that.