### PR TITLE
Escape fixes

### DIFF
--- a/docs/code-quality/best-practices-and-examples-sal.md
+++ b/docs/code-quality/best-practices-and-examples-sal.md
@@ -145,7 +145,7 @@ BOOL StrEquals2(_In_ PSTR p1, _In_ PSTR p2)
 
 ```
 
-## \_Out_range\_
+## \_Out\_range\_
 
 If the parameter is a pointer and you want to express the range of the value of the element that is pointed to by the pointer, use `_Deref_out_range_` instead of `_Out_range_`. In the following example, the range of *pcbFilled is expressed, not pcbFilled.
 

--- a/docs/code-quality/c26130.md
+++ b/docs/code-quality/c26130.md
@@ -16,7 +16,7 @@ ms.workload:
   - "multiple"
 ---
 # C26130
-warning C26130: Missing annotation _Requires_lock_held\_(\<lock>) or _No_competing_thread\_ at function \<func>. Otherwise it could be a race condition. Variable \<var> should be protected by lock \<lock>.
+warning C26130: Missing annotation \_Requires\_lock\_held\_(\<lock>) or \_No\_competing\_thread\_ at function \<func>. Otherwise it could be a race condition. Variable \<var> should be protected by lock \<lock>.
 
  Warning C26130 is issued when the analyzer detects a potential race condition but infers that the function is likely to be run in a single threaded mode, for example, when the function is in the initialization stage based on certain heuristics.
 

--- a/docs/code-quality/c28020.md
+++ b/docs/code-quality/c28020.md
@@ -18,6 +18,6 @@ ms.workload:
 # C28020
 warning C28020: The expression \<expr> is not true at this call
 
- This warning is reported when the _Satisfies\_ expression listed is not true. Frequently this indicates an incorrect parameter.
+ This warning is reported when the \_Satisfies\_ expression listed is not true. Frequently this indicates an incorrect parameter.
 
  If this occurs on a function declaration, the annotations indicate an impossible condition.

--- a/docs/code-quality/c28216.md
+++ b/docs/code-quality/c28216.md
@@ -16,6 +16,6 @@ ms.workload:
   - "multiple"
 ---
 # C28216
-warning C28216: The _Check_return\_ annotation only applies to post-conditions for the specific function parameter.
+warning C28216: The \_Check\_return\_ annotation only applies to post-conditions for the specific function parameter.
 
  The `_Check_return_` annotation has been applied in a context other than `__post`; it may need a `__post` (or `__drv_out`) modifier, or it may be placed incorrectly.

--- a/docs/code-quality/c28222.md
+++ b/docs/code-quality/c28222.md
@@ -16,6 +16,6 @@ ms.workload:
   - "multiple"
 ---
 # C28222
-warning 28222: _Yes\_, _No\_, or _Maybe\_ expected for annotation
+warning 28222: \_Yes\_, \_No\_, or \_Maybe\_ expected for annotation
 
  This warning indicates that a parameter to an annotation is expected to be one of the symbols `_Yes_`, `_No_`, or `_Maybe_`, and some other symbol was encountered. This usually indicates an incorrectly coded annotation macro.

--- a/docs/code-quality/c28232.md
+++ b/docs/code-quality/c28232.md
@@ -16,6 +16,6 @@ ms.workload:
   - "multiple"
 ---
 # C28232
-warning C28232: _Pre\_, _Post\_, or _Deref\_ not applied to any annotation
+warning C28232: \_Pre\_, \_Post\_, or \_Deref\_ not applied to any annotation
 
  This warning indicates that a `_Pre_`, `_Post_`, or `_Deref_` operator appears in an annotation expression without a subsequent functional annotation; the modifier was ignored, but this indicates an incorrectly coded annotation.

--- a/docs/code-quality/c28234.md
+++ b/docs/code-quality/c28234.md
@@ -16,6 +16,6 @@ ms.workload:
   - "multiple"
 ---
 # C28234
-warning C28234: _At\_ expression does not apply to current function
+warning C28234: \_At\_ expression does not apply to current function
 
  This warning indicates that the value of an `_At_` expression does not identify an accessible object.

--- a/docs/code-quality/c28275.md
+++ b/docs/code-quality/c28275.md
@@ -16,6 +16,6 @@ ms.workload:
   - "multiple"
 ---
 # C28275
-warning C28275: The parameter to _Macro_value\_ is null
+warning C28275: The parameter to \_Macro\_value\_ is null
 
  This warning indicates that there is an internal error in the model file, not in the code being analyzed. The *macroValue* function was called without a parameter.

--- a/docs/code-quality/c28287.md
+++ b/docs/code-quality/c28287.md
@@ -16,6 +16,6 @@ ms.workload:
   - "multiple"
 ---
 # C28287
-warning C28287: For function, syntax Error in _At\_() annotation (unrecognized parameter name)
+warning C28287: For function, syntax Error in \_At\_() annotation (unrecognized parameter name)
 
  The Code Analysis tool reports this warning when the `SAL_at` (`__drv_at`) annotation is used and the parameter expression cannot be interpreted in the current context. This might include using a misspelled parameter or member name, or a misspelling of "return" or "this" keywords.

--- a/docs/code-quality/c28288.md
+++ b/docs/code-quality/c28288.md
@@ -16,6 +16,6 @@ ms.workload:
   - "multiple"
 ---
 # C28288
-warning C28288: For function, syntax Error in _At\_() annotation (invalid parameter name)
+warning C28288: For function, syntax Error in \_At\_() annotation (invalid parameter name)
 
  The Code Analysis tool reports this warning when the `SAL_at` (`__drv_at`) annotation is used and the parameter expression cannot be interpreted in the current context. This might include using a misspelled parameter or member name, or a misspelling of "return" or "this" keywords.

--- a/docs/code-quality/c6517.md
+++ b/docs/code-quality/c6517.md
@@ -16,7 +16,7 @@ ms.workload:
   - "multiple"
 ---
 # C6517
-warning C6517: Invalid annotation: 'SAL_readableTo' property may not be specified on buffers that are not readable: '_Param\_(1)'.
+warning C6517: Invalid annotation: 'SAL_readableTo' property may not be specified on buffers that are not readable: '\_Param\_(1)'.
 
 > [!NOTE]
 >  This warning occurs only in code that is using a deprecated version of the source-code annotation language (SAL). We recommend that you port your code to use the latest version of SAL. For more information, see [Using SAL Annotations to Reduce C/C++ Code Defects](../code-quality/using-sal-annotations-to-reduce-c-cpp-code-defects.md).

--- a/docs/code-quality/c6518.md
+++ b/docs/code-quality/c6518.md
@@ -16,7 +16,7 @@ ms.workload:
   - "multiple"
 ---
 # C6518
-warning C6518: Invalid annotation: 'SAL_writableTo' property may not be specified as a precondition on buffers that are not writable: '_Param\_(1)'
+warning C6518: Invalid annotation: 'SAL_writableTo' property may not be specified as a precondition on buffers that are not writable: '\_Param\_(1)'
 
  This warning indicates that a conflict exists between a `SAL_writableTo` property value and a writable property. This ordinarily indicates that a writable property does not have write access to the parameter being annotated.
 

--- a/docs/code-quality/mixed-minimum-rules-rule-set.md
+++ b/docs/code-quality/mixed-minimum-rules-rule-set.md
@@ -85,7 +85,7 @@ The Microsoft Mixed Minimum Rules focus on the most critical problems in your C+
 |[C28210](../code-quality/c28210.md)|Annotations for the __on_failure context must not be in explicit pre context|
 |[C28211](../code-quality/c28211.md)|Static context name expected for SAL_context|
 |[C28212](../code-quality/c28212.md)|Pointer expression expected for annotation|
-|[C28213](../code-quality/c28213.md)|The \_Use\_decl_annotations\_ annotation must be used to reference, without modification, a prior declaration.|
+|[C28213](../code-quality/c28213.md)|The \_Use\_decl\_annotations\_ annotation must be used to reference, without modification, a prior declaration.|
 |[C28214](../code-quality/c28214.md)|Attribute parameter names must be p1...p9|
 |[C28215](../code-quality/c28215.md)|The typefix cannot be applied to a parameter that already has a typefix|
 |[C28216](../code-quality/c28216.md)|The checkReturn annotation only applies to postconditions for the specific function parameter.|

--- a/docs/code-quality/mixed-minimum-rules-rule-set.md
+++ b/docs/code-quality/mixed-minimum-rules-rule-set.md
@@ -79,13 +79,13 @@ The Microsoft Mixed Minimum Rules focus on the most critical problems in your C+
 |[C28182](../code-quality/c28182.md)|Dereferencing NULL pointer. The pointer contains the same NULL value as another pointer did.|
 |[C28202](../code-quality/c28202.md)|Illegal reference to non-static member|
 |[C28203](../code-quality/c28203.md)|Ambiguous reference to class member.|
-|[C28205](../code-quality/c28205.md)|_Success\_ or _On_failure\_ used in an illegal context|
+|[C28205](../code-quality/c28205.md)|\_Success\_ or \_On\_failure\_ used in an illegal context|
 |[C28206](../code-quality/c28206.md)|Left operand points to a struct, use '->'|
 |[C28207](../code-quality/c28207.md)|Left operand is a struct, use '.'|
 |[C28210](../code-quality/c28210.md)|Annotations for the __on_failure context must not be in explicit pre context|
 |[C28211](../code-quality/c28211.md)|Static context name expected for SAL_context|
 |[C28212](../code-quality/c28212.md)|Pointer expression expected for annotation|
-|[C28213](../code-quality/c28213.md)|The _Use_decl_annotations\_ annotation must be used to reference, without modification, a prior declaration.|
+|[C28213](../code-quality/c28213.md)|The \_Use\_decl_annotations\_ annotation must be used to reference, without modification, a prior declaration.|
 |[C28214](../code-quality/c28214.md)|Attribute parameter names must be p1...p9|
 |[C28215](../code-quality/c28215.md)|The typefix cannot be applied to a parameter that already has a typefix|
 |[C28216](../code-quality/c28216.md)|The checkReturn annotation only applies to postconditions for the specific function parameter.|
@@ -127,22 +127,22 @@ The Microsoft Mixed Minimum Rules focus on the most critical problems in your C+
 |[C28267](../code-quality/c28267.md)|A syntax error in the annotations was found annotation in the function.|
 |[C28272](../code-quality/c28272.md)|The annotation for function, parameter when examining is inconsistent with the function declaration|
 |[C28273](../code-quality/c28273.md)|For function, the clues are inconsistent with the function declaration|
-|[C28275](../code-quality/c28275.md)|The parameter to _Macro_value\_ is null|
+|[C28275](../code-quality/c28275.md)|The parameter to \_Macro\_value\_ is null|
 |[C28279](../code-quality/c28279.md)|For symbol, a 'begin' was found without a matching 'end'|
 |[C28280](../code-quality/c28280.md)|For symbol, an 'end' was found without a matching 'begin'|
 |[C28282](../code-quality/c28282.md)|Format Strings must be in preconditions|
 |[C28285](../code-quality/c28285.md)|For function, syntax error in parameter|
 |[C28286](../code-quality/c28286.md)|For function, syntax error near the end|
-|[C28287](../code-quality/c28287.md)|For function, syntax Error in _At\_() annotation (unrecognized parameter name)|
-|[C28288](../code-quality/c28288.md)|For function, syntax Error in _At\_() annotation (invalid parameter name)|
+|[C28287](../code-quality/c28287.md)|For function, syntax Error in \_At\_() annotation (unrecognized parameter name)|
+|[C28288](../code-quality/c28288.md)|For function, syntax Error in \_At\_() annotation (invalid parameter name)|
 |[C28289](../code-quality/c28289.md)|For function: ReadableTo or WritableTo did not have a limit-spec as a parameter|
 |[C28290](../code-quality/c28290.md)|the annotation for function contains more Externals than the actual number of parameters|
 |[C28291](../code-quality/c28291.md)|post null/notnull at deref level 0 is meaningless for function.|
 |[C28300](../code-quality/c28300.md)|Expression operands of incompatible types for operator|
 |[C28301](../code-quality/c28301.md)|No annotations for first declaration of function.|
-|[C28302](../code-quality/c28302.md)|An extra _Deref\_ operator was found on annotation.|
-|[C28303](../code-quality/c28303.md)|An ambiguous _Deref\_ operator was found on annotation.|
-|[C28304](../code-quality/c28304.md)|An improperly placed _Notref\_ operator was found applied to token.|
+|[C28302](../code-quality/c28302.md)|An extra \_Deref\_ operator was found on annotation.|
+|[C28303](../code-quality/c28303.md)|An ambiguous \_Deref\_ operator was found on annotation.|
+|[C28304](../code-quality/c28304.md)|An improperly placed \_Notref\_ operator was found applied to token.|
 |[C28305](../code-quality/c28305.md)|An error while parsing a token was discovered.|
 |[C28350](../code-quality/c28350.md)|The annotation describes a situation that is not conditionally applicable.|
 |[C28351](../code-quality/c28351.md)|The annotation describes where a dynamic value (a variable) cannot be used in the condition.|

--- a/docs/code-quality/mixed-recommended-rules-rule-set.md
+++ b/docs/code-quality/mixed-recommended-rules-rule-set.md
@@ -145,7 +145,7 @@ The Microsoft Mixed Recommended Rules focus on the most common and critical prob
 |[C28020](../code-quality/c28020.md)|The expression is not true at this call|
 |[C28021](../code-quality/c28021.md)|The parameter being annotated must be a pointer|
 |[C28022](../code-quality/c28022.md)|The function class(es) on this function do not match the function class(es) on the typedef used to define it.|
-|[C28023](../code-quality/c28023.md)|The function being assigned or passed should have a _Function_class\_ annotation for at least one of the class(es)|
+|[C28023](../code-quality/c28023.md)|The function being assigned or passed should have a \_Function\_class\_ annotation for at least one of the class(es)|
 |[C28024](../code-quality/c28024.md)|The function pointer being assigned to is annotated with the function class, which is not contained in the function class(es) list.|
 |[C28039](../code-quality/c28039.md)|The type of actual parameter should exactly match the type|
 |[C28112](../code-quality/c28112.md)|A variable which is accessed via an Interlocked function must always be accessed via an Interlocked function.|
@@ -163,14 +163,14 @@ The Microsoft Mixed Recommended Rules focus on the most common and critical prob
 |[C28196](../code-quality/c28196.md)|The requirement is not satisfied. (The expression does not evaluate to true.)|
 |[C28202](../code-quality/c28202.md)|Illegal reference to non-static member|
 |[C28203](../code-quality/c28203.md)|Ambiguous reference to class member.|
-|[C28205](../code-quality/c28205.md)|_Success\_ or _On_failure\_ used in an illegal context|
+|[C28205](../code-quality/c28205.md)|\_Success\_ or \_On\_failure\_ used in an illegal context|
 |[C28206](../code-quality/c28206.md)|Left operand points to a struct, use '->'|
 |[C28207](../code-quality/c28207.md)|Left operand is a struct, use '.'|
 |[C28209](../code-quality/c28209.md)|The declaration for symbol has a conflicting declaration|
 |[C28210](../code-quality/c28210.md)|Annotations for the __on_failure context must not be in explicit pre context|
 |[C28211](../code-quality/c28211.md)|Static context name expected for SAL_context|
 |[C28212](../code-quality/c28212.md)|Pointer expression expected for annotation|
-|[C28213](../code-quality/c28213.md)|The _Use_decl_annotations\_ annotation must be used to reference, without modification, a prior declaration.|
+|[C28213](../code-quality/c28213.md)|The \_Use\_decl_annotations\_ annotation must be used to reference, without modification, a prior declaration.|
 |[C28214](../code-quality/c28214.md)|Attribute parameter names must be p1...p9|
 |[C28215](../code-quality/c28215.md)|The typefix cannot be applied to a parameter that already has a typefix|
 |[C28216](../code-quality/c28216.md)|The checkReturn annotation only applies to postconditions for the specific function parameter.|
@@ -213,22 +213,22 @@ The Microsoft Mixed Recommended Rules focus on the most common and critical prob
 |[C28267](../code-quality/c28267.md)|A syntax error in the annotations was found annotation in the function.|
 |[C28272](../code-quality/c28272.md)|The annotation for function, parameter when examining is inconsistent with the function declaration|
 |[C28273](../code-quality/c28273.md)|For function, the clues are inconsistent with the function declaration|
-|[C28275](../code-quality/c28275.md)|The parameter to _Macro_value\_ is null|
+|[C28275](../code-quality/c28275.md)|The parameter to \_Macro\_value\_ is null|
 |[C28279](../code-quality/c28279.md)|For symbol, a 'begin' was found without a matching 'end'|
 |[C28280](../code-quality/c28280.md)|For symbol, an 'end' was found without a matching 'begin'|
 |[C28282](../code-quality/c28282.md)|Format Strings must be in preconditions|
 |[C28285](../code-quality/c28285.md)|For function, syntax error in parameter|
 |[C28286](../code-quality/c28286.md)|For function, syntax error near the end|
-|[C28287](../code-quality/c28287.md)|For function, syntax Error in _At\_() annotation (unrecognized parameter name)|
-|[C28288](../code-quality/c28288.md)|For function, syntax Error in _At\_() annotation (invalid parameter name)|
+|[C28287](../code-quality/c28287.md)|For function, syntax Error in \_At\_() annotation (unrecognized parameter name)|
+|[C28288](../code-quality/c28288.md)|For function, syntax Error in \_At\_() annotation (invalid parameter name)|
 |[C28289](../code-quality/c28289.md)|For function: ReadableTo or WritableTo did not have a limit-spec as a parameter|
 |[C28290](../code-quality/c28290.md)|the annotation for function contains more Externals than the actual number of parameters|
 |[C28291](../code-quality/c28291.md)|post null/notnull at deref level 0 is meaningless for function.|
 |[C28300](../code-quality/c28300.md)|Expression operands of incompatible types for operator|
 |[C28301](../code-quality/c28301.md)|No annotations for first declaration of function.|
-|[C28302](../code-quality/c28302.md)|An extra _Deref\_ operator was found on annotation.|
-|[C28303](../code-quality/c28303.md)|An ambiguous _Deref\_ operator was found on annotation.|
-|[C28304](../code-quality/c28304.md)|An improperly placed _Notref\_ operator was found applied to token.|
+|[C28302](../code-quality/c28302.md)|An extra \_Deref\_ operator was found on annotation.|
+|[C28303](../code-quality/c28303.md)|An ambiguous \_Deref\_ operator was found on annotation.|
+|[C28304](../code-quality/c28304.md)|An improperly placed \_Notref\_ operator was found applied to token.|
 |[C28305](../code-quality/c28305.md)|An error while parsing a token was discovered.|
 |[C28306](../code-quality/c28306.md)|The annotation on parameter is obsolescent|
 |[C28307](../code-quality/c28307.md)|The annotation on parameter is obsolescent|

--- a/docs/code-quality/mixed-recommended-rules-rule-set.md
+++ b/docs/code-quality/mixed-recommended-rules-rule-set.md
@@ -170,7 +170,7 @@ The Microsoft Mixed Recommended Rules focus on the most common and critical prob
 |[C28210](../code-quality/c28210.md)|Annotations for the __on_failure context must not be in explicit pre context|
 |[C28211](../code-quality/c28211.md)|Static context name expected for SAL_context|
 |[C28212](../code-quality/c28212.md)|Pointer expression expected for annotation|
-|[C28213](../code-quality/c28213.md)|The \_Use\_decl_annotations\_ annotation must be used to reference, without modification, a prior declaration.|
+|[C28213](../code-quality/c28213.md)|The \_Use\_decl\_annotations\_ annotation must be used to reference, without modification, a prior declaration.|
 |[C28214](../code-quality/c28214.md)|Attribute parameter names must be p1...p9|
 |[C28215](../code-quality/c28215.md)|The typefix cannot be applied to a parameter that already has a typefix|
 |[C28216](../code-quality/c28216.md)|The checkReturn annotation only applies to postconditions for the specific function parameter.|

--- a/docs/code-quality/native-minimum-rules-rule-set.md
+++ b/docs/code-quality/native-minimum-rules-rule-set.md
@@ -85,7 +85,7 @@ The Microsoft Native Minimum Rules focus on the most critical problems in your n
 |[C28210](../code-quality/c28210.md)|Annotations for the __on_failure context must not be in explicit pre context|
 |[C28211](../code-quality/c28211.md)|Static context name expected for SAL_context|
 |[C28212](../code-quality/c28212.md)|Pointer expression expected for annotation|
-|[C28213](../code-quality/c28213.md)|The \_Use\_decl_annotations\_ annotation must be used to reference, without modification, a prior declaration.|
+|[C28213](../code-quality/c28213.md)|The \_Use\_decl\_annotations\_ annotation must be used to reference, without modification, a prior declaration.|
 |[C28214](../code-quality/c28214.md)|Attribute parameter names must be p1...p9|
 |[C28215](../code-quality/c28215.md)|The typefix cannot be applied to a parameter that already has a typefix|
 |[C28216](../code-quality/c28216.md)|The checkReturn annotation only applies to postconditions for the specific function parameter.|

--- a/docs/code-quality/native-minimum-rules-rule-set.md
+++ b/docs/code-quality/native-minimum-rules-rule-set.md
@@ -79,13 +79,13 @@ The Microsoft Native Minimum Rules focus on the most critical problems in your n
 |[C28182](../code-quality/c28182.md)|Dereferencing NULL pointer. The pointer contains the same NULL value as another pointer did.|
 |[C28202](../code-quality/c28202.md)|Illegal reference to non-static member|
 |[C28203](../code-quality/c28203.md)|Ambiguous reference to class member.|
-|[C28205](../code-quality/c28205.md)|_Success\_ or _On_failure\_ used in an illegal context|
+|[C28205](../code-quality/c28205.md)|\_Success\_ or \_On\_failure\_ used in an illegal context|
 |[C28206](../code-quality/c28206.md)|Left operand points to a struct, use '->'|
 |[C28207](../code-quality/c28207.md)|Left operand is a struct, use '.'|
 |[C28210](../code-quality/c28210.md)|Annotations for the __on_failure context must not be in explicit pre context|
 |[C28211](../code-quality/c28211.md)|Static context name expected for SAL_context|
 |[C28212](../code-quality/c28212.md)|Pointer expression expected for annotation|
-|[C28213](../code-quality/c28213.md)|The _Use_decl_annotations\_ annotation must be used to reference, without modification, a prior declaration.|
+|[C28213](../code-quality/c28213.md)|The \_Use\_decl_annotations\_ annotation must be used to reference, without modification, a prior declaration.|
 |[C28214](../code-quality/c28214.md)|Attribute parameter names must be p1...p9|
 |[C28215](../code-quality/c28215.md)|The typefix cannot be applied to a parameter that already has a typefix|
 |[C28216](../code-quality/c28216.md)|The checkReturn annotation only applies to postconditions for the specific function parameter.|
@@ -127,22 +127,22 @@ The Microsoft Native Minimum Rules focus on the most critical problems in your n
 |[C28267](../code-quality/c28267.md)|A syntax error in the annotations was found annotation in the function.|
 |[C28272](../code-quality/c28272.md)|The annotation for function, parameter when examining is inconsistent with the function declaration|
 |[C28273](../code-quality/c28273.md)|For function, the clues are inconsistent with the function declaration|
-|[C28275](../code-quality/c28275.md)|The parameter to _Macro_value\_ is null|
+|[C28275](../code-quality/c28275.md)|The parameter to \_Macro\_value\_ is null|
 |[C28279](../code-quality/c28279.md)|For symbol, a 'begin' was found without a matching 'end'|
 |[C28280](../code-quality/c28280.md)|For symbol, an 'end' was found without a matching 'begin'|
 |[C28282](../code-quality/c28282.md)|Format Strings must be in preconditions|
 |[C28285](../code-quality/c28285.md)|For function, syntax error in parameter|
 |[C28286](../code-quality/c28286.md)|For function, syntax error near the end|
-|[C28287](../code-quality/c28287.md)|For function, syntax Error in _At\_() annotation (unrecognized parameter name)|
-|[C28288](../code-quality/c28288.md)|For function, syntax Error in _At\_() annotation (invalid parameter name)|
+|[C28287](../code-quality/c28287.md)|For function, syntax Error in \_At\_() annotation (unrecognized parameter name)|
+|[C28288](../code-quality/c28288.md)|For function, syntax Error in \_At\_() annotation (invalid parameter name)|
 |[C28289](../code-quality/c28289.md)|For function: ReadableTo or WritableTo did not have a limit-spec as a parameter|
 |[C28290](../code-quality/c28290.md)|the annotation for function contains more Externals than the actual number of parameters|
 |[C28291](../code-quality/c28291.md)|post null/notnull at deref level 0 is meaningless for function.|
 |[C28300](../code-quality/c28300.md)|Expression operands of incompatible types for operator|
 |[C28301](../code-quality/c28301.md)|No annotations for first declaration of function.|
-|[C28302](../code-quality/c28302.md)|An extra _Deref\_ operator was found on annotation.|
-|[C28303](../code-quality/c28303.md)|An ambiguous _Deref\_ operator was found on annotation.|
-|[C28304](../code-quality/c28304.md)|An improperly placed _Notref\_ operator was found applied to token.|
+|[C28302](../code-quality/c28302.md)|An extra \_Deref\_ operator was found on annotation.|
+|[C28303](../code-quality/c28303.md)|An ambiguous \_Deref\_ operator was found on annotation.|
+|[C28304](../code-quality/c28304.md)|An improperly placed \_Notref\_ operator was found applied to token.|
 |[C28305](../code-quality/c28305.md)|An error while parsing a token was discovered.|
 |[C28350](../code-quality/c28350.md)|The annotation describes a situation that is not conditionally applicable.|
 |[C28351](../code-quality/c28351.md)|The annotation describes where a dynamic value (a variable) cannot be used in the condition.|

--- a/docs/code-quality/native-recommended-rules-rule-set.md
+++ b/docs/code-quality/native-recommended-rules-rule-set.md
@@ -145,7 +145,7 @@ The Native Recommended Rules focus on the most critical and common problems in y
 |[C28020](../code-quality/c28020.md)|The expression is not true at this call|
 |[C28021](../code-quality/c28021.md)|The parameter being annotated must be a pointer|
 |[C28022](../code-quality/c28022.md)|The function class(es) on this function do not match the function class(es) on the typedef used to define it.|
-|[C28023](../code-quality/c28023.md)|The function being assigned or passed should have a _Function_class\_ annotation for at least one of the class(es)|
+|[C28023](../code-quality/c28023.md)|The function being assigned or passed should have a \_Function\_class\_ annotation for at least one of the class(es)|
 |[C28024](../code-quality/c28024.md)|The function pointer being assigned to is annotated with the function class, which is not contained in the function class(es) list.|
 |[C28039](../code-quality/c28039.md)|The type of actual parameter should exactly match the type|
 |[C28112](../code-quality/c28112.md)|A variable which is accessed via an Interlocked function must always be accessed via an Interlocked function.|
@@ -163,14 +163,14 @@ The Native Recommended Rules focus on the most critical and common problems in y
 |[C28196](../code-quality/c28196.md)|The requirement is not satisfied. (The expression does not evaluate to true.)|
 |[C28202](../code-quality/c28202.md)|Illegal reference to non-static member|
 |[C28203](../code-quality/c28203.md)|Ambiguous reference to class member.|
-|[C28205](../code-quality/c28205.md)|_Success\_ or _On_failure\_ used in an illegal context|
+|[C28205](../code-quality/c28205.md)|\_Success\_ or \_On\_failure\_ used in an illegal context|
 |[C28206](../code-quality/c28206.md)|Left operand points to a struct, use '->'|
 |[C28207](../code-quality/c28207.md)|Left operand is a struct, use '.'|
 |[C28209](../code-quality/c28209.md)|The declaration for symbol has a conflicting declaration|
 |[C28210](../code-quality/c28210.md)|Annotations for the __on_failure context must not be in explicit pre context|
 |[C28211](../code-quality/c28211.md)|Static context name expected for SAL_context|
 |[C28212](../code-quality/c28212.md)|Pointer expression expected for annotation|
-|[C28213](../code-quality/c28213.md)|The _Use_decl_annotations\_ annotation must be used to reference, without modification, a prior declaration.|
+|[C28213](../code-quality/c28213.md)|The \_Use\_decl_annotations\_ annotation must be used to reference, without modification, a prior declaration.|
 |[C28214](../code-quality/c28214.md)|Attribute parameter names must be p1...p9|
 |[C28215](../code-quality/c28215.md)|The typefix cannot be applied to a parameter that already has a typefix|
 |[C28216](../code-quality/c28216.md)|The checkReturn annotation only applies to postconditions for the specific function parameter.|
@@ -213,22 +213,22 @@ The Native Recommended Rules focus on the most critical and common problems in y
 |[C28267](../code-quality/c28267.md)|A syntax error in the annotations was found annotation in the function.|
 |[C28272](../code-quality/c28272.md)|The annotation for function, parameter when examining is inconsistent with the function declaration|
 |[C28273](../code-quality/c28273.md)|For function, the clues are inconsistent with the function declaration|
-|[C28275](../code-quality/c28275.md)|The parameter to _Macro_value\_ is null|
+|[C28275](../code-quality/c28275.md)|The parameter to \_Macro\_value\_ is null|
 |[C28279](../code-quality/c28279.md)|For symbol, a 'begin' was found without a matching 'end'|
 |[C28280](../code-quality/c28280.md)|For symbol, an 'end' was found without a matching 'begin'|
 |[C28282](../code-quality/c28282.md)|Format Strings must be in preconditions|
 |[C28285](../code-quality/c28285.md)|For function, syntax error in parameter|
 |[C28286](../code-quality/c28286.md)|For function, syntax error near the end|
-|[C28287](../code-quality/c28287.md)|For function, syntax Error in _At\_() annotation (unrecognized parameter name)|
-|[C28288](../code-quality/c28288.md)|For function, syntax Error in _At\_() annotation (invalid parameter name)|
+|[C28287](../code-quality/c28287.md)|For function, syntax Error in \_At\_() annotation (unrecognized parameter name)|
+|[C28288](../code-quality/c28288.md)|For function, syntax Error in \_At\_() annotation (invalid parameter name)|
 |[C28289](../code-quality/c28289.md)|For function: ReadableTo or WritableTo did not have a limit-spec as a parameter|
 |[C28290](../code-quality/c28290.md)|the annotation for function contains more Externals than the actual number of parameters|
 |[C28291](../code-quality/c28291.md)|post null/notnull at deref level 0 is meaningless for function.|
 |[C28300](../code-quality/c28300.md)|Expression operands of incompatible types for operator|
 |[C28301](../code-quality/c28301.md)|No annotations for first declaration of function.|
-|[C28302](../code-quality/c28302.md)|An extra _Deref\_ operator was found on annotation.|
-|[C28303](../code-quality/c28303.md)|An ambiguous _Deref\_ operator was found on annotation.|
-|[C28304](../code-quality/c28304.md)|An improperly placed _Notref\_ operator was found applied to token.|
+|[C28302](../code-quality/c28302.md)|An extra \_Deref\_ operator was found on annotation.|
+|[C28303](../code-quality/c28303.md)|An ambiguous \_Deref\_ operator was found on annotation.|
+|[C28304](../code-quality/c28304.md)|An improperly placed \_Notref\_ operator was found applied to token.|
 |[C28305](../code-quality/c28305.md)|An error while parsing a token was discovered.|
 |[C28306](../code-quality/c28306.md)|The annotation on parameter is obsolescent|
 |[C28307](../code-quality/c28307.md)|The annotation on parameter is obsolescent|

--- a/docs/code-quality/native-recommended-rules-rule-set.md
+++ b/docs/code-quality/native-recommended-rules-rule-set.md
@@ -170,7 +170,7 @@ The Native Recommended Rules focus on the most critical and common problems in y
 |[C28210](../code-quality/c28210.md)|Annotations for the __on_failure context must not be in explicit pre context|
 |[C28211](../code-quality/c28211.md)|Static context name expected for SAL_context|
 |[C28212](../code-quality/c28212.md)|Pointer expression expected for annotation|
-|[C28213](../code-quality/c28213.md)|The \_Use\_decl_annotations\_ annotation must be used to reference, without modification, a prior declaration.|
+|[C28213](../code-quality/c28213.md)|The \_Use\_decl\_annotations\_ annotation must be used to reference, without modification, a prior declaration.|
 |[C28214](../code-quality/c28214.md)|Attribute parameter names must be p1...p9|
 |[C28215](../code-quality/c28215.md)|The typefix cannot be applied to a parameter that already has a typefix|
 |[C28216](../code-quality/c28216.md)|The checkReturn annotation only applies to postconditions for the specific function parameter.|

--- a/docs/code-quality/understanding-sal.md
+++ b/docs/code-quality/understanding-sal.md
@@ -109,12 +109,12 @@ wchar_t * wmemcpy(
 
 2.  On the menu bar, choose **Build**, **Run Code Analysis on Solution**.
 
-     Consider the _In\_ example in this section. If you run code analysis on it, this warning is displayed:
+     Consider the \_In\_ example in this section. If you run code analysis on it, this warning is displayed:
 
     > **C6387 Invalid Parameter Value**
     > 'pInt' could be '0': this does not adhere to the specification for the function 'InCallee'.
 
-### Example: The _In\_ Annotation
+### Example: The \_In\_ Annotation
  The `_In_` annotation indicates that:
 
 -   The parameter must be valid and will not be modified.
@@ -152,7 +152,7 @@ void BadInCaller()
 
  If you use Visual Studio Code Analysis on this example, it validates that the callers pass a non-Null pointer to an initialized buffer for `pInt`. In this case, `pInt` pointer cannot be NULL.
 
-### Example: The _In_opt\_ Annotation
+### Example: The \_In\_opt\_ Annotation
  `_In_opt_` is the same as `_In_`, except that the input parameter is allowed to be NULL and, therefore, the function should check for this.
 
 ```cpp
@@ -180,7 +180,7 @@ void InOptCaller()
 
  Visual Studio Code Analysis validates that the function checks for NULL before it accesses the buffer.
 
-### Example: The _Out\_ Annotation
+### Example: The \_Out\_ Annotation
  `_Out_` supports a common scenario in which a non-NULL pointer that points to an element buffer is passed in and the function initializes the element. The caller doesn't have to initialize the buffer before the call; the called function promises to initialize it before it returns.
 
 ```cpp
@@ -207,7 +207,7 @@ void OutCaller()
 
  Visual Studio Code Analysis Tool validates that the caller passes a non-NULL pointer to a buffer for `pInt` and that the buffer is initialized by the function before it returns.
 
-### Example: The _Out_opt\_ Annotation
+### Example: The \_Out\_opt\_ Annotation
  `_Out_opt_` is the same as `_Out_`, except that the parameter is allowed to be NULL and, therefore, the function should check for this.
 
 ```cpp
@@ -235,7 +235,7 @@ void OutOptCaller()
 
  Visual Studio Code Analysis validates that this function checks for NULL before `pInt` is dereferenced, and if `pInt` is not NULL, that the buffer is initialized by the function before it returns.
 
-### Example: The _Inout\_ Annotation
+### Example: The \_Inout\_ Annotation
  `_Inout_` is used to annotate a pointer parameter that may be changed by the function. The pointer must point to valid initialized data before the call, and even if it changes, it must still have a valid value on return. The annotation specifies that the function may freely read from and write to the one-element buffer. The caller must provide the buffer and initialize it.
 
 > [!NOTE]
@@ -267,7 +267,7 @@ void BadInOutCaller()
 
  Visual Studio Code Analysis validates that callers pass a non-NULL pointer to an initialized buffer for `pInt`, and that, before return, `pInt` is still non-NULL and the buffer is initialized.
 
-### Example: The _Inout_opt\_ Annotation
+### Example: The \_Inout\_opt\_ Annotation
  `_Inout_opt_` is the same as `_Inout_`, except that the input parameter is allowed to be NULL and, therefore, the function should check for this.
 
 ```cpp
@@ -297,7 +297,7 @@ void InOutOptCaller()
 
  Visual Studio Code Analysis validates that this function checks for NULL before it accesses the buffer, and if `pInt` is not NULL, that the buffer is initialized by the function before it returns.
 
-### Example: The _Outptr\_ Annotation
+### Example: The \_Outptr\_ Annotation
  `_Outptr_` is used to annotate a parameter that's intended to return a pointer.  The parameter itself should not be NULL, and the called function returns a non-NULL pointer in it and that pointer points to initialized data.
 
 ```cpp
@@ -328,7 +328,7 @@ void OutPtrCaller()
 
  Visual Studio Code Analysis validates that the caller passes a non-NULL pointer for `*pInt`, and that the buffer is initialized by the function before it returns.
 
-### Example: The _Outptr_opt\_ Annotation
+### Example: The \_Outptr\_opt\_ Annotation
  `_Outptr_opt_` is the same as `_Outptr_`, except that the parameter is optional—the caller can pass in a NULL pointer for the parameter.
 
 ```cpp
@@ -361,7 +361,7 @@ void OutPtrOptCaller()
 
  Visual Studio Code Analysis validates that this function checks for NULL before `*pInt` is dereferenced, and that the buffer is initialized by the function before it returns.
 
-### Example: The _Success\_ Annotation in Combination with _Out\_
+### Example: The \_Success\_ Annotation in Combination with \_Out\_
  Annotations  can be applied to most objects.  In particular, you can annotate a whole function.  One of the most obvious characteristics of a function is that it can succeed or fail. But like the association between a buffer and its size, C/C++ cannot express function success or failure. By using the `_Success_` annotation, you can say what success for a function looks like.  The parameter to the `_Success_` annotation is just an expression that when it is true indicates that the function has succeeded. The expression can be anything that the annotation parser can handle. The effects of the annotations after the function returns are only applicable when the function succeeds. This example shows how `_Success_` interacts with `_Out_` to do the right thing. You can use the keyword `return` to represent the return value.
 
 ```cpp

--- a/docs/ide/using-regular-expressions-in-visual-studio.md
+++ b/docs/ide/using-regular-expressions-in-visual-studio.md
@@ -37,9 +37,9 @@ Here are some examples:
 |-------------|----------------|-------------|
 |Match any single character (except a line break)|.|`a.o` matches "aro" in "around" and "abo" in "about" but not "acro" in "across".|
 |Match zero or more occurrences of the preceding expression (match as many characters as possible)|*|`a*r` matches "r" in "rack", "ar" in "ark", and "aar" in "aardvark"|
-|Match any character zero or more times (Wildcard *)|.*|c.*e matches "cke" in "racket", "comme" in "comment", and "code" in "code"|
-|Match one or more occurrences of the preceding expression (match as many characters as possible)|+|`e.+e` matches "eede" in "feeder" but not "ee".|
-|Match any character one or more times (Wildcard ?)|.+|e.+e matches "eede" in "feeder" but not "ee".|
+|Match any character zero or more times (Wildcard *)|.*|`c.*e` matches "cke" in "racket", "comme" in "comment", and "code" in "code"|
+|Match one or more occurrences of the preceding expression (match as many characters as possible)|+|`e.+d` matches "eed" in "feeder" but not "ed".|
+|Match any character one or more times (Wildcard ?)|.+|`e.+e` matches "eede" in "feeder" but not "ee".|
 |Match zero or more occurrences of the preceding expression (match as few characters as possible)|*?|`e.*?e` matches "ee" in "feeder" but not "eede".|
 |Match one or more occurrences of the preceding expression (match as few characters as possible)|+?|`e.+?e` matches "ente" and "erprise" in "enterprise", but not the whole word "enterprise".|
 |Anchor the match string to the beginning of a line or string|^|`^car` matches the word "car" only when it appears at the beginning of a line.|
@@ -47,9 +47,9 @@ Here are some examples:
 |Match any single character in a set|[abc]|`b[abc]` matches "ba", "bb", and "bc".|
 |Match any character in a range of characters|[a-f]|`be[n-t]` matches "bet" in "between", "ben" in "beneath", and "bes" in "beside", but not "below".|
 |Capture and implicitly number the expression contained within parenthesis|()|`([a-z])X\1` matches "aXa"and "bXb", but not "aXb". "\1" refers to the first expression group "[a-z]".|
-|Invalidate a match|(?!abc)|`real (?!ity)` matches "real" in "realty" and "really" but not in "reality." It also finds the second "real" (but not the first "real") in "realityreal".|
+|Invalidate a match|(?!abc)|`real(?!ity)` matches "real" in "realty" and "really" but not in "reality." It also finds the second "real" (but not the first "real") in "realityreal".|
 |Match any character that is not in a given set of characters|[^abc]|`be[^n-t]` matches "bef" in "before", "beh" in "behind", and "bel" in "below", but not "beneath".|
-|Match either the expression before or the one after the symbol.|&#124;|`(sponge&#124;mud) bath` matches "sponge bath" and "mud bath."|
+|Match either the expression before or the one after the symbol.|&#124;|`(sponge\|mud) bath` matches "sponge bath" and "mud bath."|
 |Escape the character following the backslash| \\ |`\^` matches the character ^.|
 |Specify the number of occurrences of the preceding character or group|{x}, where x is the number of occurrences|`x(ab){2}x` matches "xababx", and `x(ab){2,3}x` matches "xababx" and "xabababx" but not "xababababx".|
 |Match text in a Unicode character class, where "X" is the Unicode number. For more information about Unicode character classes, see<br /><br /> [Unicode Standard 5.2 Character Properties](http://www.unicode.org/versions/Unicode5.2.0/ch04.pdf).|\p{X}|`\p{Lu}` matches "T" and "D" in "Thomas Doe".|
@@ -59,7 +59,7 @@ Here are some examples:
 |Match any whitespace character.|(?([^\r\n])\s)|`Public\sInterface` matches the phrase "Public Interface".|
 |Match any numeric character|\d|`\d` matches and "3" in "3456", "2" in 23", and "1" in "1".|
 |Match a Unicode character|\uXXXX where XXXX specifies the Unicode character value.|`\u0065` matches the character "e".|
-|Match an identifier|\b(_\w+&#124;[\w-[0-9\_]]\w*)\b|Matches "type1" but not &type1" or "#define".|
+|Match an identifier|\b[\_\w-[0-9]][\_\w]*\b|Matches "type1" but not "&type1" or "#define".|
 |Match a string inside quotes|((\\".+?\\")&#124;('.+?'))|Matches any string inside single or double quotes.|
 |Match a hexadecimal number|\b0[xX]([0-9a-fA-F]\)\b|Matches "0xc67f" but not "0xc67fc67f".|
 |Match integers and decimals|\b[0-9]*\\.\*[0-9]+\b|Matches "1.333".|

--- a/docs/sharepoint/walkthrough-import-a-custom-master-page-and-site-page-with-an-image.md
+++ b/docs/sharepoint/walkthrough-import-a-custom-master-page-and-site-page-with-an-image.md
@@ -149,13 +149,13 @@ ms.workload:
   
     |File Name|Description|  
     |---------------|-----------------|  
-    |_catalogsmasterpage\_|The custom master page.|  
+    |\_catalogsmasterpage\_|The custom master page.|  
     |images_|The image file in the SharePoint file system.|  
     |SitePages_|The site page.|  
   
 3.  Choose the **Finish** button to import the selected items.  
   
-4.  In **Solution Explorer**, choose the _catalogsmasterpage\_ node, and set the value of its **Deployment Conflict Resolution** property to **Automatic**.  
+4.  In **Solution Explorer**, choose the \_catalogsmasterpage\_ node, and set the value of its **Deployment Conflict Resolution** property to **Automatic**.  
   
      This helps ensure that any deployment conflicts are resolved automatically.  
   

--- a/docs/test/how-to-use-boost-test-for-cpp.md
+++ b/docs/test/how-to-use-boost-test-for-cpp.md
@@ -106,7 +106,7 @@ The following example is sufficient for the test to be discoverable in **Test Ex
 #include "../MyProgram/MyClass.h" // project being tested
 #include <string>
 
-BOOST_AUTO_TEST_CASE(my\_boost_test)
+BOOST_AUTO_TEST_CASE(my_boost_test)
 {
 	std::string expected_value = "Bill";
 


### PR DESCRIPTION
Commit [9a52da0](https://github.com/MicrosoftDocs/visualstudio-docs/commit/9a52da095a849003010879f1846dd5941f49b788) fixes a number of problems that I first saw on the [Understanding SAL examples](https://docs.microsoft.com/en-us/visualstudio/code-quality/understanding-sal#example-the-in-annotation), where \_In\_ was rendered as _In_\\.

I did a search to correct all instances of this error and also found the error fixed in commit [c3cbfd3](https://github.com/MicrosoftDocs/visualstudio-docs/commit/c3cbfd3812986118e2476728ad68ed9eb3c95b15) where an escape was added when none should have been (resulting in a code sample saying `BOOST_AUTO_TEST_CASE(my\_boost_test)`!).

Finally, the search for missing escapes led me to the VS [regex examples](https://docs.microsoft.com/en-us/visualstudio/ide/using-regular-expressions-in-visual-studio#regular-expression-examples
), which had a missing escape in the C identifier regex. Since not only was there a missing escape, but also a number of errors / inconsistencies in these regex examples, I fixed both in commit [f6172dd](https://github.com/MicrosoftDocs/visualstudio-docs/commit/f6172ddcc2e16df3a03c42faf4ccd8b8af46d111).

I hope all this is acceptable and look forward to seeing the changes live soon!
