### PR TITLE
MSBuild: ProjectReference ReferenceOutputAssembly metadatum

### DIFF
--- a/docs/msbuild/common-msbuild-project-items.md
+++ b/docs/msbuild/common-msbuild-project-items.md
@@ -72,6 +72,7 @@ In [!INCLUDE[vstecmsbuild](../extensibility/internals/includes/vstecmsbuild_md.m
 |Name|Optional string. The display name of the reference.|  
 |Project|Optional string. A GUID for the reference, in the form {12345678-1234-1234-1234-1234567891234}.|  
 |Package|Optional string. The path of the project file that is being referenced.|  
+|ReferenceOutputAssembly|Optional boolean. If set to `false`, does not include the output of the referenced project as a [Reference](#Reference) of this project, but still ensures that the other project builds before this one. Defaults to `true`.|
   
 ### Compile  
  Represents the source files for the compiler.  


### PR DESCRIPTION
This has been respected for a very long time but wasn't documented.