### PR TITLE
chore: Re-write debugger/debugger-basics.md links

### DIFF
--- a/docs/debugger/debug-using-the-just-in-time-debugger.md
+++ b/docs/debugger/debug-using-the-just-in-time-debugger.md
@@ -171,6 +171,6 @@ static void Main(string[] args)
 
 ## See Also
  [Debugger Security](../debugger/debugger-security.md)
- [Debugger Basics](../debugger/debugger-basics.md)
+ [Debugger Basics](../debugger/getting-started-with-the-debugger.md)
  [Just-In-Time, Debugging, Options Dialog Box](../debugger/just-in-time-debugging-options-dialog-box.md)
  [Security Warning: Attaching to a process owned by an untrusted user can be dangerous. If the following information looks suspicious or you are unsure, do not attach to this process](../debugger/security-warning-attaching-to-a-process-owned-by-an-untrusted-user.md)

--- a/docs/debugger/debugger-security.md
+++ b/docs/debugger/debugger-security.md
@@ -75,6 +75,6 @@ The ability to debug another process gives you extremely broad powers that you w
   
 ## See Also  
  [Debugger Settings and Preparation](../debugger/debugger-settings-and-preparation.md)   
- [Debugger Basics](../debugger/debugger-basics.md)   
+ [Debugger Basics](../debugger/getting-started-with-the-debugger.md)   
  [Security Warning: Attaching to a process owned by an untrusted user can be dangerous. If the following information looks suspicious or you are unsure, do not attach to this process](../debugger/security-warning-attaching-to-a-process-owned-by-an-untrusted-user.md)   
  [Security Warning: Debugger Must Execute Untrusted Command](../debugger/security-warning-debugger-must-execute-untrusted-command.md)

--- a/docs/debugger/debugger-windows.md
+++ b/docs/debugger/debugger-windows.md
@@ -45,4 +45,4 @@ You can open most debugger windows while you are debugging your program. To see 
 
 ## See Also
 
-[Debugger Basics](../debugger/debugger-basics.md)
+[Debugger Basics](../debugger/getting-started-with-the-debugger.md)

--- a/docs/debugger/debugging-basics-registers-window.md
+++ b/docs/debugger/debugging-basics-registers-window.md
@@ -46,4 +46,4 @@ The **Registers** window is available only if address-level debugging is enabled
   
 ## See Also  
  [How to: Use the Registers Window](../debugger/how-to-use-the-registers-window.md)   
- [Debugger Basics](../debugger/debugger-basics.md)
+ [Debugger Basics](../debugger/getting-started-with-the-debugger.md)

--- a/docs/debugger/debugging-managed-code.md
+++ b/docs/debugger/debugging-managed-code.md
@@ -21,7 +21,7 @@ ms.workload:
 ---
 # Debugging Managed Code
 
-This section covers common debugging problems and techniques for managed applications, or applications written in languages that target the common language runtime, such as Visual Basic, C#, and C++. The techniques described here are high-level techniques. For more information, see [Using the Debugger](../debugger/debugger-basics.md).
+This section covers common debugging problems and techniques for managed applications, or applications written in languages that target the common language runtime, such as Visual Basic, C#, and C++. The techniques described here are high-level techniques. For more information, see [Using the Debugger](../debugger/getting-started-with-the-debugger.md).
 
 ## In This Section
 

--- a/docs/debugger/debugging-native-code.md
+++ b/docs/debugger/debugging-native-code.md
@@ -24,7 +24,7 @@ ms.workload:
   - "cplusplus"
 ---
 # Debugging Native Code
-The section covers some common debugging problems and techniques for native applications. The techniques covered in this section are high-level techniques. For the mechanics of using the Visual Studio debugger, see [Debugger Roadmap](../debugger/debugger-basics.md).  
+The section covers some common debugging problems and techniques for native applications. The techniques covered in this section are high-level techniques. For the mechanics of using the Visual Studio debugger, see [Debugger Roadmap](../debugger/getting-started-with-the-debugger.md).  
   
 ## In This Section  
  [How to: Debug Optimized Code](../debugger/how-to-debug-optimized-code.md)  

--- a/docs/debugger/debugging-preparation-visual-cpp-project-types.md
+++ b/docs/debugger/debugging-preparation-visual-cpp-project-types.md
@@ -67,7 +67,7 @@ This section describes how to debug the basic project types created by the [!INC
   
 2.  On the **Debug** menu, choose **Start**.  
   
-3.  Debug using the techniques discussed in [Debugger Basics](../debugger/debugger-basics.md).  
+3.  Debug using the techniques discussed in [Debugger Basics](../debugger/getting-started-with-the-debugger.md).  
   
 ###  <a name="BKMK_To_manually_set_a_Debug_configuration"></a> To manually set a Debug configuration  
   
@@ -105,7 +105,7 @@ This section describes how to debug the basic project types created by the [!INC
  [In this topic](../debugger/debugging-preparation-visual-cpp-project-types.md#BKMK_In_this_topic)  
   
 ## See Also  
- [Debugger Basics](../debugger/debugger-basics.md)   
+ [Debugger Basics](../debugger/getting-started-with-the-debugger.md)   
  [Project Settings for a C++ Debug Configuration](../debugger/project-settings-for-a-cpp-debug-configuration.md)   
  [Attaching to a Running Program or Multiple Programs](../debugger/attach-to-running-processes-with-the-visual-studio-debugger.md)   
  [Debug and Release Configurations](../debugger/how-to-set-debug-and-release-configurations.md)   

--- a/docs/debugger/debugging-preparation-windows-forms-applications.md
+++ b/docs/debugger/debugging-preparation-windows-forms-applications.md
@@ -57,7 +57,7 @@ The Windows Forms project template creates a Windows Forms application. Debuggin
   
 3.  On the **Debug** menu, click **Start**.  
   
-4.  Debug using the techniques discussed in [Debugger Basics](../debugger/debugger-basics.md).  
+4.  Debug using the techniques discussed in [Debugger Basics](../debugger/getting-started-with-the-debugger.md).  
   
 ## See Also  
  [Debugging Managed Code](../debugger/debugging-managed-code.md)   

--- a/docs/debugger/debugging-web-applications.md
+++ b/docs/debugger/debugging-web-applications.md
@@ -35,6 +35,6 @@ This section explains how to debug several types of Web applications.
 ## See Also  
  [Debugging Web Applications and Script](../debugger/debugging-web-applications-and-script.md)   
  [Debugger Settings and Preparation](../debugger/debugger-settings-and-preparation.md)   
- [Debugger Basics](../debugger/debugger-basics.md)   
+ [Debugger Basics](../debugger/getting-started-with-the-debugger.md)   
  [Debugging in Visual Studio](../debugger/index.md)  
  [Debugger Feature Tour](../debugger/debugger-feature-tour.md)

--- a/docs/debugger/edit-and-continue.md
+++ b/docs/debugger/edit-and-continue.md
@@ -43,4 +43,4 @@ Edit and Continue is a time-saving feature that enables you to make changes to y
 ## See Also  
  [Debugger Security](../debugger/debugger-security.md)   
  [Edit and Continue, Debugging, Options Dialog Box](http://msdn.microsoft.com/Library/009d225f-ef65-463f-a146-e4c518f86103)   
- [Debugger Basics](../debugger/debugger-basics.md)
+ [Debugger Basics](../debugger/getting-started-with-the-debugger.md)

--- a/docs/debugger/how-to-restore-hidden-debugger-commands.md
+++ b/docs/debugger/how-to-restore-hidden-debugger-commands.md
@@ -70,4 +70,4 @@ When you set up Visual Studio, you are asked to choose a set of default IDE sett
   
 ## See Also  
  [Debugger Security](../debugger/debugger-security.md)   
- [Debugger Basics](../debugger/debugger-basics.md)
+ [Debugger Basics](../debugger/getting-started-with-the-debugger.md)

--- a/docs/debugger/just-in-time-debugging-in-visual-studio.md
+++ b/docs/debugger/just-in-time-debugging-in-visual-studio.md
@@ -44,4 +44,4 @@ You can take steps to prevent the Just-in-Time Debugger dialog box from appearin
     In IIS Manager, right-click the server node and choose **Switch to Features View**. Under the ASP.NET section, choose **.NET Compilation** and then make sure you choose **False** as the Debug behavior (the steps are different in older versions of IIS).
 
 ## See Also
- [Debugger Basics](../debugger/debugger-basics.md)
+ [Debugger Basics](../debugger/getting-started-with-the-debugger.md)

--- a/docs/debugger/managing-exceptions-with-the-debugger.md
+++ b/docs/debugger/managing-exceptions-with-the-debugger.md
@@ -191,4 +191,4 @@ To add conditional exceptions, choose the **Edit condition** icon in the Excepti
  [How to: Examine System Code After an Exception](../debugger/how-to-examine-system-code-after-an-exception.md)   
  [How to: Use Native Run-Time Checks](../debugger/how-to-use-native-run-time-checks.md)   
  [Using Run-Time Checks Without the C Run-Time Library](../debugger/using-run-time-checks-without-the-c-run-time-library.md)   
- [Debugger Basics](../debugger/debugger-basics.md)
+ [Debugger Basics](../debugger/getting-started-with-the-debugger.md)

--- a/docs/debugger/using-the-parallel-stacks-window.md
+++ b/docs/debugger/using-the-parallel-stacks-window.md
@@ -112,7 +112,7 @@ The **Parallel Stacks** window is useful when you are debugging multithreaded ap
 ## See Also  
  [Get Started Debugging a Multithreaded Aplication](../debugger/get-started-debugging-multithreaded-apps.md)   
  [Walkthrough: Debugging a Parallel Application](../debugger/walkthrough-debugging-a-parallel-application.md)   
- [Debugger Basics](../debugger/debugger-basics.md)   
+ [Debugger Basics](../debugger/getting-started-with-the-debugger.md)   
  [Debugging Managed Code](../debugger/debugging-managed-code.md)   
  [Parallel Programming](/dotnet/standard/parallel-programming/index)   
  [Using the Tasks Window](../debugger/using-the-tasks-window.md)   

--- a/docs/debugger/using-the-tasks-window.md
+++ b/docs/debugger/using-the-tasks-window.md
@@ -90,7 +90,7 @@ The **Switch to Task** command makes the current task the active task. The **Swi
 
 ## See also
 
-- [Debugger Basics](../debugger/debugger-basics.md)
+- [Debugger Basics](../debugger/getting-started-with-the-debugger.md)
 - [Debugging Managed Code](../debugger/debugging-managed-code.md)
 - [Parallel Programming](/dotnet/standard/parallel-programming/index)
 - [Concurrency Runtime](/cpp/parallel/concrt/concurrency-runtime)

--- a/docs/debugger/viewing-data-in-the-debugger.md
+++ b/docs/debugger/viewing-data-in-the-debugger.md
@@ -32,6 +32,6 @@ The [!INCLUDE[vsprvs](../code-quality/includes/vsprvs_md.md)] debugger provides 
  Visualizers enable you to view the contents of an object or variable in a meaningful way. In the Visual Studio debugger, a visualizer refers to the different windows that you can open using the magnifying glass icon ![VisualizerIcon](../debugger/media/dbg-tips-visualizer-icon.png "Visualizer icon"). For example, you can use the HTML visualizer to view an HTML string as it would be interpreted and displayed in a browser. You can access visualizers from DataTips, the **Watch** window, the **Autos** window, the **Locals** window, or the **QuickWatch** dialog box. For more information, see [Create custom visualizers](../debugger/create-custom-visualizers-of-data.md).
   
 ## See Also  
- [Debugger Basics](../debugger/debugger-basics.md)   
+ [Debugger Basics](../debugger/getting-started-with-the-debugger.md)   
  [Command Window](../ide/reference/command-window.md)   
  [Debugger Security](../debugger/debugger-security.md)

--- a/docs/debugger/walkthrough-debugging-a-parallel-application.md
+++ b/docs/debugger/walkthrough-debugging-a-parallel-application.md
@@ -292,7 +292,7 @@ This walkthrough shows how to use the **Parallel Tasks** and **Parallel Stacks**
   
 ## See Also  
  [Debugging Multithreaded Applications](../debugger/walkthrough-debugging-a-parallel-application.md)   
- [Debugger Basics](../debugger/debugger-basics.md)   
+ [Debugger Basics](../debugger/getting-started-with-the-debugger.md)   
  [Debugging Managed Code](../debugger/debugging-managed-code.md)   
  [Parallel Programming](/dotnet/standard/parallel-programming/index)   
  [Concurrency Runtime](/cpp/parallel/concrt/concurrency-runtime)   

--- a/docs/debugger/walkthrough-debugging-at-design-time.md
+++ b/docs/debugger/walkthrough-debugging-at-design-time.md
@@ -97,4 +97,4 @@ It can be helpful to debug code behind from the XAML designer in some declarativ
   
 ## See Also  
  [Debugger Security](../debugger/debugger-security.md)   
- [Debugger Basics](../debugger/debugger-basics.md)
+ [Debugger Basics](../debugger/getting-started-with-the-debugger.md)

--- a/docs/ide/reference/immediate-window.md
+++ b/docs/ide/reference/immediate-window.md
@@ -123,7 +123,7 @@ You cannot use design time expression evaluation in project types that require s
 - [Navigating through Code with the Debugger](../../debugger/navigating-through-code-with-the-debugger.md)
 - [Command Window](../../ide/reference/command-window.md)
 - [Debugging in Visual Studio](../../debugger/debugging-in-visual-studio.md)
-- [Debugger Basics](../../debugger/debugger-basics.md)
+- [Debugger Basics](../../debugger/getting-started-with-the-debugger.md)
 - [Walkthrough: Debugging at Design Time](../../debugger/walkthrough-debugging-at-design-time.md)
 - [Visual Studio Command Aliases](../../ide/reference/visual-studio-command-aliases.md)
 - [Using Regular Expressions in Visual Studio](../../ide/using-regular-expressions-in-visual-studio.md)

--- a/docs/ide/step-2-run-your-program.md
+++ b/docs/ide/step-2-run-your-program.md
@@ -50,7 +50,7 @@ When you created a new solution, you actually built a program that runs. It does
     -   Choose the **X** button in the upper corner of the **Form1** window.
 
     > [!NOTE]
-    >  When you run your program from inside the IDE, it's called debugging because you typically do it to locate and fix bugs (errors) in the program. Although this program is small and doesn't really do anything yet, it's still a real program. You follow the same procedure to run and debug other programs. To learn more about debugging, see [Debugger basics](../debugger/debugger-basics.md).
+    >  When you run your program from inside the IDE, it's called debugging because you typically do it to locate and fix bugs (errors) in the program. Although this program is small and doesn't really do anything yet, it's still a real program. You follow the same procedure to run and debug other programs. To learn more about debugging, see [Debugger basics](../debugger/getting-started-with-the-debugger.md).
 
 ## To continue or review
 

--- a/docs/xml-tools/debugger-user-interface-xslt.md
+++ b/docs/xml-tools/debugger-user-interface-xslt.md
@@ -96,5 +96,5 @@ For more information, see [How to: Evaluate an XPath expression](../xml-tools/ho
 ## See also
 
 - [Debugging XSLT](../xml-tools/debugging-xslt.md)
-- [Debugger basics](../debugger/debugger-basics.md)
+- [Debugger basics](../debugger/getting-started-with-the-debugger.md)
 - [Inspect variables in the autos and locals windows in Visual Studio](../debugger/autos-and-locals-windows.md)

--- a/docs/xml-tools/how-to-start-debugging-xslt.md
+++ b/docs/xml-tools/how-to-start-debugging-xslt.md
@@ -88,4 +88,4 @@ namespace ConsoleApplication
 ## See also
 
 - [Walkthrough: Debug an XSLT style sheet](../xml-tools/walkthrough-debug-an-xslt-style-sheet.md)
-- [Debugger basics](../debugger/debugger-basics.md)
+- [Debugger basics](../debugger/getting-started-with-the-debugger.md)


### PR DESCRIPTION
This is already redirect on the site through the redirection.json, this just makes it nicer for when you're navigating on GitHub or in the IDE