### PR TITLE
Missing closing bracket

### DIFF
--- a/docs/msbuild/property-functions.md
+++ b/docs/msbuild/property-functions.md
@@ -138,7 +138,7 @@ $([MSBuild]::Method(Parameters))
 For example, to add together two properties that have numeric values, use the following code.
 
 ```fundamental
-$([MSBuild]::Add($(NumberOne), $(NumberTwo))
+$([MSBuild]::Add($(NumberOne), $(NumberTwo)))
 ```
 
 Here is a list of MSBuild property functions:


### PR DESCRIPTION
Took me a while to work out why [MSBuild]::Add was not working, turns out the example is missing a closing parentheses