### PR TITLE
Remove PreEmptive Analytics features from Dotfuscator documentation

### DIFF
--- a/docs/ide/dotfuscator/capabilities.md
+++ b/docs/ide/dotfuscator/capabilities.md
@@ -24,7 +24,7 @@ manager: douge
 This page focuses on the capabilities of Dotfuscator Community Edition (Dotfuscator CE) with some references to advanced options available through [upgrades][upgrades].
 
 Dotfuscator is a *post-build* system for .NET applications.
-With Dotfuscator CE, Visual Studio users are able to [obfuscate assemblies][obfuscation] and inject [active defense][checks] and [analytics tracking][analytics] into the application - all without Dotfuscator needing to access the original source code.
+With Dotfuscator CE, Visual Studio users are able to [obfuscate assemblies][obfuscation] and inject [active defense][checks] into the application - all without Dotfuscator needing to access the original source code.
 Dotfuscator protects your application in multiple ways, creating a layered protection strategy.
 
 Dotfuscator CE supports a wide range of .NET assembly and application types, including [Universal Windows Platform (UWP)][uwp] and [Xamarin][xamarin].
@@ -50,17 +50,9 @@ Attackers can attempt to hijack your application in order to circumvent licensin
 Dotfuscator CE can inject [application validation code][checks] into your assemblies,
 including [anti-tamper][tamper], [anti-debug][debug], and [anti-rooted device][root] measures.
 When an invalid application state is detected, the validation code can [call upon application code to address to the situation in an appropriate way][check-app].
-Or, if you prefer not to write code to handle invalid uses of the application, Dotfuscator can also inject [telemetry reporting][check-telemetry] and [response][check-action] behaviors, without requiring any modification to your source code.
+Or, if you prefer not to write code to handle invalid uses of the application, Dotfuscator can also inject [response][check-action] behaviors, without requiring any modification to your source code.
 
 Many of these same methods may also be used to enforce [end-of-life deadlines][shelflife] for evaluation or trial software.
-
-## Application Monitoring
-
-When developing an application, it is critical to understand the behavior patterns of users, including beta testers and users of prior versions.
-Application analytics allows you to track how frequently the application is used and how it is used, including what errors customers experience.
-
-Dotfuscator CE can inject [exception-tracking][exceptions], [session-tracking][sessions], and [feature-tracking][features] code into your application.
-When run, the processed application will transmit analytics data to a configured [PreEmptive Analytics endpoint][endpoints].
 
 ## See Also
 
@@ -77,9 +69,6 @@ When run, the processed application will transmit analytics data to a configured
 [obfuscation]:  https://www.preemptive.com/dotfuscator/ce/docs/help/obfuscation_overview.html
 [renaming]:  https://www.preemptive.com/dotfuscator/ce/docs/help/obfuscation_renaming.html
 
-[analytics]:  https://www.preemptive.com/dotfuscator/ce/docs/help/instrumentation_overview.html
-[endpoints]:  https://www.preemptive.com/dotfuscator/ce/docs/help/instrumentation_overview.html#endpoints
-
 [checks]:  https://www.preemptive.com/dotfuscator/ce/docs/help/checks_overview.html
 [check-app]:  https://www.preemptive.com/dotfuscator/ce/docs/help/checks_overview.html#app-notification
 [check-action]:  https://www.preemptive.com/dotfuscator/ce/docs/help/checks_overview.html#action
@@ -88,9 +77,5 @@ When run, the processed application will transmit analytics data to a configured
 [debug]:  https://www.preemptive.com/dotfuscator/ce/docs/help/checks_debug.html
 [root]: https://www.preemptive.com/dotfuscator/ce/docs/help/checks_root.html
 [shelflife]:  https://www.preemptive.com/dotfuscator/ce/docs/help/checks_shelflife.html
-[exceptions]:  https://www.preemptive.com/dotfuscator/ce/docs/help/instrumentation_exceptions.html
-[sessions]:  https://www.preemptive.com/dotfuscator/ce/docs/help/instrumentation_sessions.html
-[features]:  https://www.preemptive.com/dotfuscator/ce/docs/help/instrumentation_features.html
-[check-telemetry]:  https://www.preemptive.com/dotfuscator/ce/docs/help/instrumentation_checks.html
 
 [full]:  https://www.preemptive.com/dotfuscator/ce/docs/help/intro_capabilities.html

--- a/docs/ide/dotfuscator/capabilities.md
+++ b/docs/ide/dotfuscator/capabilities.md
@@ -24,7 +24,7 @@ manager: douge
 This page focuses on the capabilities of Dotfuscator Community Edition (Dotfuscator CE) with some references to advanced options available through [upgrades][upgrades].
 
 Dotfuscator is a *post-build* system for .NET applications.
-With Dotfuscator CE, Visual Studio users are able to [obfuscate assemblies][obfuscation] and inject [active defense][checks] into the application - all without Dotfuscator needing to access the original source code.
+With Dotfuscator CE, Visual Studio users are able to [obfuscate assemblies][obfuscation] and inject [active defense measures][checks] into the application - all without Dotfuscator needing to access the original source code.
 Dotfuscator protects your application in multiple ways, creating a layered protection strategy.
 
 Dotfuscator CE supports a wide range of .NET assembly and application types, including [Universal Windows Platform (UWP)][uwp] and [Xamarin][xamarin].

--- a/docs/ide/dotfuscator/index.md
+++ b/docs/ide/dotfuscator/index.md
@@ -52,7 +52,7 @@ Examples of [.NET Obfuscation][obfuscation] and other [Application Protection][a
 * *[Renaming][renaming]* of identifiers to make reverse-engineering of the compiled assemblies more difficult.
 * *[Anti-tamper][tamper]* to detect the execution of tampered applications and terminate or respond to tampered sessions.
 * *[Anti-debug][debug]* to detect the attachment of a debugger to a running application and terminate or respond to debugged sessions.
-* *[Anti-rooted device][root]* to detect if the application is running on a rooted Android device and terminate sessions on these devices.
+* *[Anti-rooted device][root]* to detect if the application is running on a rooted Android device and terminate or respond to sessions on these devices.
 * *[Application expiration behaviors][shelflife]* that encode an "end-of-life" date and terminate expired application sessions.
 
 For details on these features, including how they fit into your application protection strategy, see the [Capabilities page][capabilities].

--- a/docs/ide/dotfuscator/index.md
+++ b/docs/ide/dotfuscator/index.md
@@ -37,7 +37,7 @@ Dotfuscator can [obfuscate][obfuscation] your .NET assemblies to hinder reverse-
 
 It's also important to **protect the integrity of your application**.
 In addition to reverse-engineering, bad actors may attempt to pirate your application, alter the application's behavior at runtime, or manipulate data.
-Dotfuscator can inject your application with the capability to [detect, report, and respond to unauthorized uses][checks], including tampering, third-party debugging, and rooted devices.
+Dotfuscator can inject your application with the capability to [detect and respond to unauthorized uses][checks], including tampering, third-party debugging, and rooted devices.
 
 For more information on how Dotfuscator fits into a secure software development lifecycle, see PreEmptive Solutions' [SDL App Protection page][sdl-protection].
 
@@ -50,12 +50,10 @@ Dotfuscator CE offers a range of [software protection and hardening][software-pr
 Examples of [.NET Obfuscation][obfuscation] and other [Application Protection][app-protection] features included in Dotfuscator CE are:
 
 * *[Renaming][renaming]* of identifiers to make reverse-engineering of the compiled assemblies more difficult.
-* *[Anti-tamper][tamper]* to detect the execution of tampered applications, transmit incident alerts, and terminate tampered sessions.
-* *[Anti-debug][debug]* to detect the attachment of a debugger to a running application, transmit incident alerts, and terminate debugged sessions.
+* *[Anti-tamper][tamper]* to detect the execution of tampered applications and terminate or respond to tampered sessions.
+* *[Anti-debug][debug]* to detect the attachment of a debugger to a running application and terminate or respond to debugged sessions.
 * *[Anti-rooted device][root]* to detect if the application is running on a rooted Android device and terminate sessions on these devices.
-* *[Application expiration behaviors][shelflife]* that encode an "end-of-life" date, transmit alerts when applications are executed after their expiration date, and terminate expired application sessions.
-* *[Exception tracking][exceptions]* to monitor unhandled exceptions occurring within the application.
-* *[Session][sessions] and [feature][features] usage tracking* to determine what applications have been executed, what versions of those applications, and what features are used in those applications.
+* *[Application expiration behaviors][shelflife]* that encode an "end-of-life" date and terminate expired application sessions.
 
 For details on these features, including how they fit into your application protection strategy, see the [Capabilities page][capabilities].
 
@@ -102,9 +100,5 @@ See [the full Dotfuscator CE User Guide at preemptive.com][full] for detailed us
 [debug]:  https://www.preemptive.com/dotfuscator/ce/docs/help/checks_debug.html
 [root]: https://www.preemptive.com/dotfuscator/ce/docs/help/checks_root.html
 [shelflife]:  https://www.preemptive.com/dotfuscator/ce/docs/help/checks_shelflife.html
-
-[exceptions]:  https://www.preemptive.com/dotfuscator/ce/docs/help/instrumentation_exceptions.html
-[sessions]:  https://www.preemptive.com/dotfuscator/ce/docs/help/instrumentation_sessions.html
-[features]:  https://www.preemptive.com/dotfuscator/ce/docs/help/instrumentation_features.html
 
 [full]:  https://www.preemptive.com/dotfuscator/ce/docs/help/index.html

--- a/docs/ide/dotfuscator/upgrades.md
+++ b/docs/ide/dotfuscator/upgrades.md
@@ -54,14 +54,6 @@ While Dotfuscator Community Edition provides a basic level of protection, **_Pre
   * Additional [application defense behaviors][check-actions].
   * The ability to provide a warning period before an application's end-of-life deadline.
   * The ability to notify application code during an end-of-life warning period or after the deadline.
-  * Telemetry encryption.
-* *Application Monitoring*
-  * The ability to collect and save collected information during temporary network outages.
-  * The ability to collect personally identifiable information.
-  * Unlimited use of [feature tracking][features].
-  * The ability to track exceptions caught and thrown by your code, in addition to unhandled exceptions.
-  * The ability to track exceptions in `.dll` assemblies.
-  * Telemetry encryption.
 
 Dotfuscator Professional is the industry standard [.NET Obfuscator][net-obfuscator] and is suitable for enterprise developers requiring ongoing support, maintenance, and product updates.
 Additionally, Dotfuscator Professional offers tighter integration with Visual Studio and is licensed for commercial use.
@@ -82,7 +74,6 @@ For more information about the advanced application protection features of Dotfu
 [pruning]:  https://www.preemptive.com/products/dotfuscator/features#pruning
 
 [check-actions]:  https://www.preemptive.com/dotfuscator/pro/userguide/en/protection_checks_overview.html#actions
-[features]:  https://www.preemptive.com/dotfuscator/pro/userguide/en/instrumentation_features.html
 
 [net-obfuscator]:  https://www.preemptive.com/products/dotfuscator/overview
 [eval]:  https://www.preemptive.com/eval-request


### PR DESCRIPTION
This PR updates documentation to be inline with the version of Dotfuscator Community Edition that was released with Visual Studio 2017 version 15.8 Preview 3.

Specifically, PreEmptive Analytics is now deprecated.