### PR TITLE
Unit testing section formatting See also sections

### DIFF
--- a/docs/test/create-a-unit-test-project.md
+++ b/docs/test/create-a-unit-test-project.md
@@ -36,9 +36,10 @@ Unit tests often mirror the structure of the code under test. For example, a uni
 5.  If the code that you want to test is in another location, see [Managing references in a project](../ide/managing-references-in-a-project.md) for information about adding references.
 
 ## Next steps
- **Writing unit tests**
 
  See one of the following sections:
+
+**Writing unit tests**
 
 -   [Unit test your code](../test/unit-test-your-code.md)
 
@@ -46,6 +47,6 @@ Unit tests often mirror the structure of the code under test. For example, a uni
 
 -   [Use the MSTest framework in unit tests](using-microsoft-visualstudio-testtools-unittesting-members-in-unit-tests.md)
 
- **Running unit tests**
+**Running unit tests**
 
 - [Run unit tests with Test Explorer](../test/run-unit-tests-with-test-explorer.md)

--- a/docs/test/create-a-unit-test-project.md
+++ b/docs/test/create-a-unit-test-project.md
@@ -41,11 +41,11 @@ Unit tests often mirror the structure of the code under test. For example, a uni
 
 **Writing unit tests**
 
--   [Unit test your code](../test/unit-test-your-code.md)
+- [Unit test your code](../test/unit-test-your-code.md)
 
--   [Writing unit tests for C/C++](writing-unit-tests-for-c-cpp.md)
+- [Writing unit tests for C/C++](writing-unit-tests-for-c-cpp.md)
 
--   [Use the MSTest framework in unit tests](using-microsoft-visualstudio-testtools-unittesting-members-in-unit-tests.md)
+- [Use the MSTest framework in unit tests](using-microsoft-visualstudio-testtools-unittesting-members-in-unit-tests.md)
 
 **Running unit tests**
 

--- a/docs/test/live-unit-testing-faq.md
+++ b/docs/test/live-unit-testing-faq.md
@@ -262,4 +262,4 @@ You can do several things to collect more detailed logs:
 
 ## See also
 
-[Live Unit Testing](live-unit-testing.md)
+- [Live Unit Testing](live-unit-testing.md)

--- a/docs/test/live-unit-testing-intro.md
+++ b/docs/test/live-unit-testing-intro.md
@@ -36,6 +36,6 @@ To learn more about Live Unit Testing:
    > [!VIDEO https://channel9.msdn.com/Events/Visual-Studio/Visual-Studio-2017-Launch/T105/player]
 
 ## Related resources
-[Code testing tools](https://visualstudio.microsoft.com/vs/testing-tools/)
-[Unit test your code](unit-test-your-code.md)
+- [Code testing tools](https://visualstudio.microsoft.com/vs/testing-tools/)
+- [Unit test your code](unit-test-your-code.md)
 

--- a/docs/test/live-unit-testing-start.md
+++ b/docs/test/live-unit-testing-start.md
@@ -379,5 +379,5 @@ This provides enough information for a preliminary investigation of the bug. Eit
 ---
 
 ## See also
-[Live Unit Testing in Visual Studio](live-unit-testing.md)
-[Live Unit Testing Frequently Asked Questions](live-unit-testing-faq.md)
+- [Live Unit Testing in Visual Studio](live-unit-testing.md)
+- [Live Unit Testing Frequently Asked Questions](live-unit-testing-faq.md)

--- a/docs/test/live-unit-testing-whats-new.md
+++ b/docs/test/live-unit-testing-whats-new.md
@@ -59,6 +59,6 @@ In addition to these major additions, Live Unit Testing includes the following e
    - For MSTest: `[TestCategory("SkipWhenLiveUnitTesting")]`
 
 ## See also
-[Introducing Live Unit Testing](live-unit-testing-intro.md)   
-[Live Unit Testing with Visual Studio 2017](live-unit-testing.md)
+- [Introducing Live Unit Testing](live-unit-testing-intro.md)   
+- [Live Unit Testing with Visual Studio 2017](live-unit-testing.md)
 

--- a/docs/test/live-unit-testing.md
+++ b/docs/test/live-unit-testing.md
@@ -182,8 +182,8 @@ You can also use the following attributes to exclude individual methods from Liv
 
 ## See also
 
-[Code testing tools](https://visualstudio.microsoft.com/vs/testing-tools/)  
-[Live Unit Testing blog](https://go.microsoft.com/fwlink/?linkid=842514)  
-[Live Unit Testing FAQ](live-unit-testing-faq.md)  
-[Channel 9 video: Live Unit Testing in Visual Studio 2017](https://channel9.msdn.com/Events/Visual-Studio/Visual-Studio-2017-Launch/T105)  
+- [Code testing tools](https://visualstudio.microsoft.com/vs/testing-tools/)
+- [Live Unit Testing blog](https://go.microsoft.com/fwlink/?linkid=842514)
+- [Live Unit Testing FAQ](live-unit-testing-faq.md)
+- [Channel 9 video: Live Unit Testing in Visual Studio 2017](https://channel9.msdn.com/Events/Visual-Studio/Visual-Studio-2017-Launch/T105)
 

--- a/docs/test/live-unit-testing.md
+++ b/docs/test/live-unit-testing.md
@@ -97,7 +97,7 @@ At any time, you can temporarily pause or completely stop Live Unit Testing. You
 
 - **Options**, which opens the **Options** dialog described in the [Configure Live Unit Testing](#configure-live-unit-testing) section.
 
-##	View coverage visualization in the editor as you type
+## View coverage visualization in the editor as you type
 
 Once enabled, Live Unit Testing updates each line of code in the Visual Studio editor to show you whether the code you're writing is covered by unit tests and whether the tests that cover it are passing.  The following figure shows lines of code with both passing and failing tests, as well as lines of code that are not covered by tests. Lines decorated with a green "✓" are covered only by passing tests, lines decorated with a red "x" are covered by one or more failing tests, and lines decorated by a blue  "➖" are not covered by any test.
 
@@ -182,8 +182,8 @@ You can also use the following attributes to exclude individual methods from Liv
 
 ## See also
 
-[Code testing tools](https://visualstudio.microsoft.com/vs/testing-tools/)
-[Live Unit Testing blog](https://go.microsoft.com/fwlink/?linkid=842514)
-[Live Unit Testing FAQ](live-unit-testing-faq.md)
-[Channel 9 video: Live Unit Testing in Visual Studio 2017](https://channel9.msdn.com/Events/Visual-Studio/Visual-Studio-2017-Launch/T105)
+[Code testing tools](https://visualstudio.microsoft.com/vs/testing-tools/)  
+[Live Unit Testing blog](https://go.microsoft.com/fwlink/?linkid=842514)  
+[Live Unit Testing FAQ](live-unit-testing-faq.md)  
+[Channel 9 video: Live Unit Testing in Visual Studio 2017](https://channel9.msdn.com/Events/Visual-Studio/Visual-Studio-2017-Launch/T105)  
 


### PR DESCRIPTION
Continuing down the rabbit hole of looking through the Unit testing documentation, it seems like there's a little back and forth between no bullets, bullets, and single line for the see also sections. It looks like a lot of other documentation leverage the bullets for this section, which I would agree with. I don't believe we really want the single line.