### PR TITLE
Fix Image Description in addressing-dpi-issues2

### DIFF
--- a/docs/extensibility/addressing-dpi-issues2.md
+++ b/docs/extensibility/addressing-dpi-issues2.md
@@ -72,7 +72,7 @@ ImageList_Create(VsUI::DpiHelper::LogicalToDeviceUnitsX(16),VsUI::DpiHelper::Log
   
  Consult the <xref:Microsoft.VisualStudio.PlatformUI.DpiHelper> documentation on MSDN.  
   
- The following table shows examples of how images should be scaled at corresponding DPI scaling factors. The images in green denote our best practice as of Visual Studio 2013 (100%-200% DPI scaling):  
+ The following table shows examples of how images should be scaled at corresponding DPI scaling factors. The images bordered in orange denote our best practice as of Visual Studio 2013 (100%-200% DPI scaling):  
   
  ![DPI Issues Scaling](../extensibility/media/dpi-issues-scaling.png "DPI Issues Scaling")  
   

--- a/docs/extensibility/addressing-dpi-issues2.md
+++ b/docs/extensibility/addressing-dpi-issues2.md
@@ -72,7 +72,7 @@ ImageList_Create(VsUI::DpiHelper::LogicalToDeviceUnitsX(16),VsUI::DpiHelper::Log
   
  Consult the <xref:Microsoft.VisualStudio.PlatformUI.DpiHelper> documentation on MSDN.  
   
- The following table shows examples of how images should be scaled at corresponding DPI scaling factors. The images bordered in orange denote our best practice as of Visual Studio 2013 (100%-200% DPI scaling):  
+ The following table shows examples of how images should be scaled at corresponding DPI scaling factors. The images outlined in orange denote our best practice as of Visual Studio 2013 (100%-200% DPI scaling):  
   
  ![DPI Issues Scaling](../extensibility/media/dpi-issues-scaling.png "DPI Issues Scaling")  
   


### PR DESCRIPTION
Fixes the description for an image in the "Addressing DPI Issues" document. The description did not match the highlighted item's color for the "DPI scaling best practices" image.