### PR TITLE
Add FAQ on test adapter extension deprecation

### DIFF
--- a/docs/test/test-explorer-faq.md
+++ b/docs/test/test-explorer-faq.md
@@ -71,6 +71,13 @@ manager: douge
 
 The file path filter in the **Test Explorer** search box was removed in Visual Studio 2017 version 15.7 preview 3. This feature had low usage, and the Test Explorer can retrieve test methods faster by excluding this feature. If this change interrupts your development flow, please let us know by submitting feedback on [Developer Community](https://developercommunity.visualstudio.com/).
 
+### 11. In Visual Studio 2017 Update 15.8 my tests are discovered, but will not execute.
+
+All test projects must include their .NET test adapter nuget reference in their csproj. If they do not, this test output will appear on the project if discovery by a test adapter extension is kicked off after a build or if the user tries to run the selected tests: 
+- Test project {} does not reference any .NET NuGet adapter. Test discovery or execution might not work for this project. It is recommended to reference NuGet test adapters in each .NET test project in the solution.
+
+Instead of using test adapter extensions, projects are required to use test adapter nuget packages. This greatly improves performance and causes fewer issues with continuous integration. Read more about .NET Test Adapter Extension deprecation in the [release notes](https://docs.microsoft.com/en-us/visualstudio/releasenotes/vs2017-preview-relnotes#testadapterextension).
+
 ## Features
 
 ### How can I turn on feature flags to try out new testing features?


### PR DESCRIPTION
This was included in the Visual Studio 2017 Update 15.8 release notes:

.NET Test Adapter Extension: breaking change and deprecation
Breaking Change: All test projects must include their .NET test adapter nuget reference in their csproj. If they do not, this test output will appear on the project if discovery by a test adapter extension is kicked off after a build or if the user tries to run the selected tests: 
Test project {} does not reference any .NET NuGet adapter. Test discovery or execution might not work for this project. It is recommended to reference NuGet test adapters in each test project in the solution.
.NET test frameworks have been releasing their adapters in nuget packages and moving away from Visual Studio extensions. In Visual Studio 2017 Update 15.8 Preview 4, support for .NET test adapters delivered through extension is deprecated, but still supported. This means two new options will be available in Tools > Options > Test. 
The first option allows Visual Studio to only use the test adapters it finds in the test assembly folder (populated by the test adapter nuget reference) or as specified in the runsettings file.
The second option allows Visual Studio to "fallback" to the old behavior and search for test adapter extensions for projects that do not have a test adapter nuget reference. Both options are checked by default so no default behavior will change in this release.
Note, non-.NET test adapters are not affected with this change.