### PR TITLE
Update how-to-add-class-diagrams-to-projects.md

### DIFF
--- a/docs/ide/class-designer/how-to-add-class-diagrams-to-projects.md
+++ b/docs/ide/class-designer/how-to-add-class-diagrams-to-projects.md
@@ -53,11 +53,11 @@ To add multiple class diagrams, repeat the steps in this procedure.
 
 ## Add a class diagram based on existing types
 
-In **Solution Explorer**, open the class file context menu and then choose **View Class Diagram**.
+In the **Solution Explorer** window, open a class file's context menu (right-click) and then choose **View Class Diagram**.
 
 -or-
 
-In **Class View**, open the namespace or type context menu and then choose **View Class Diagram**.
+In the **Class View** window, open the namespace or type context menu and then choose **View Class Diagram**.
 
 ## To display the contents of a complete project in a class diagram
 

--- a/docs/ide/class-designer/how-to-add-class-diagrams-to-projects.md
+++ b/docs/ide/class-designer/how-to-add-class-diagrams-to-projects.md
@@ -53,11 +53,14 @@ To add multiple class diagrams, repeat the steps in this procedure.
 
 ## Add a class diagram based on existing types
 
-In the **Solution Explorer** window, open a class file's context menu (right-click) and then choose **View Class Diagram**.
+In **Solution Explorer**, open a class file's context menu (right-click) and then choose **View Class Diagram**.
 
 -or-
 
-In the **Class View** window, open the namespace or type context menu and then choose **View Class Diagram**.
+In **Class View**, open the namespace or type context menu and then choose **View Class Diagram**.
+
+> [!TIP]
+> If **Class View** is not open, open **Class View** from the **View** menu.
 
 ## To display the contents of a complete project in a class diagram
 


### PR DESCRIPTION
Updated some text for clarity.

I also added something that I think is needed, but maybe not everywhere:

When referring to a window, I see an approach that is succinct, but not always clear. For ex: "In **Solution Explorer**...", and "In **Class View**...". It's short and sweet but not clear if you don't already know VS. The solution explorer can probably be left as is, but saying, "In Class View", I think, is really vague. So I added some text so it reads, "In the **Class View** window, so it's clearly not a class file but a window. It might not be needed for the solution explorer but it's clearer there too. [Of course, that could mean updating everywhere...]