### PR TITLE
Fix minor code example discrepancy: csharp_style_expression_bodied_indexers

### DIFF
--- a/docs/ide/editorconfig-code-style-settings-reference.md
+++ b/docs/ide/editorconfig-code-style-settings-reference.md
@@ -1078,7 +1078,7 @@ Code examples:
 
 ```csharp
 // csharp_style_expression_bodied_indexers = true
-public T this[int i] => _value[i];
+public T this[int i] => _values[i];
 
 // csharp_style_expression_bodied_indexers = false
 public T this[int i] { get { return _values[i]; } }


### PR DESCRIPTION
Fixed minor discrepancy between true/false indexed `_values` example of csharp_style_expression_bodied_indexers