### PR TITLE
typo fixes

### DIFF
--- a/docs/deployment/how-to-configure-the-clickonce-trust-prompt-behavior.md
+++ b/docs/deployment/how-to-configure-the-clickonce-trust-prompt-behavior.md
@@ -53,11 +53,11 @@ You can configure the ClickOnce trust prompt to control whether end users are gi
   
     1.  Click **Start**, and then click **Run**.  
   
-    2.  In the **Open** box, type `regedit32`, and then click **OK**.  
+    2.  In the **Open** box, type `regedit`, and then click **OK**.  
   
 2.  Find the following registry key:  
   
-     **\HKEY_LOCAL_MACHINE\SOFTWARE\MICROSOFT\.NETFramework\Security\TrustManager\PromptingLevel**  
+     **\HKEY_LOCAL_MACHINE\SOFTWARE\MICROSOFT\\.NETFramework\Security\TrustManager\PromptingLevel**  
   
      If the key does not exist, create it.  
   
@@ -116,7 +116,7 @@ You can configure the ClickOnce trust prompt to control whether end users are gi
   
 2.  Find the following registry key:  
   
-     **\HKEY_LOCAL_MACHINE\SOFTWARE\MICROSOFT\.NETFramework\Security\TrustManager\PromptingLevel** 
+     **\HKEY_LOCAL_MACHINE\SOFTWARE\MICROSOFT\\.NETFramework\Security\TrustManager\PromptingLevel** 
   
      If the key does not exist, create it.  
   


### PR DESCRIPTION
It had regedit32 in one place and regedit in another. Also, https://github.com/MicrosoftDocs/visualstudio-docs/issues/1106 only fixed one of the three incorrect registry paths. "Previewing" the changes better shows what's really going on as the raw code looks "wrong" even though that's what you apparently need to get the slash dot (\\.) to display correctly. 