### PR TITLE
Update msbuild-target-framework-and-target-platform.md

### DIFF
--- a/docs/msbuild/msbuild-target-framework-and-target-platform.md
+++ b/docs/msbuild/msbuild-target-framework-and-target-platform.md
@@ -39,7 +39,7 @@ A project can be built to run on a *target framework*, which is a particular ver
 
 The versions of the .NET Framework differ from one another in the list of assemblies that each makes available to reference. For example, you cannot build Windows Presentation Foundation (WPF) applications unless your project targets the .NET Framework version 3.0 or above.  
 
-The target framework is specified in the `TargetFrameworkVersion` property in the project file. You can change the target framework for a project by using the project property pages in the Visual Studio integrated development environment (IDE). For more information, see [How to: Target a version of the .NET Framework](../ide/how-to-target-a-version-of-the-dotnet-framework.md). The available values for `TargetFrameworkVersion` are `v2.0`, `v3.0`, `v3.5`, `v4.5.2`, `v4.6`, `v.4.6.1`, `v4.6.2`, `4.7`, and `4.7.1`.  
+The target framework is specified in the `TargetFrameworkVersion` property in the project file. You can change the target framework for a project by using the project property pages in the Visual Studio integrated development environment (IDE). For more information, see [How to: Target a version of the .NET Framework](../ide/how-to-target-a-version-of-the-dotnet-framework.md). The available values for `TargetFrameworkVersion` are `v2.0`, `v3.0`, `v3.5`, `v4.5.2`, `v4.6`, `v4.6.1`, `v4.6.2`, `4.7`, and `4.7.1`.  
   
 ```xml  
 <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>  


### PR DESCRIPTION
I assume `v4.6.1` is the correct version text and not `v.4.6.1`. 

Q: do 4.7 or 4.7.1 need a `v` in front too?