### PR TITLE
Correct the criteria for `DependsOnTargets`

### DIFF
--- a/docs/msbuild/target-build-order.md
+++ b/docs/msbuild/target-build-order.md
@@ -108,7 +108,7 @@ Targets must be ordered if the input to one target depends on the output of anot
 
     Targets that list the conditional target in `BeforeTargets` or `AfterTargets` still execute in the prescribed order
   
-4.  Before a target is executed, its `DependsOnTargets` targets are run.  
+4.  Before a target is executed or skipped, if its `Condition` attribute was absent or did not evaluate to `false`, its `DependsOnTargets` targets are run.  
   
 5.  Before a target is executed or skipped, any target that lists it in a `BeforeTargets` attribute is run.  
   

--- a/docs/msbuild/target-build-order.md
+++ b/docs/msbuild/target-build-order.md
@@ -1,7 +1,7 @@
 ---
 title: "Target Build Order | Microsoft Docs"
 ms.custom: ""
-ms.date: "06/06/2018"
+ms.date: "09/04/2018"
 ms.technology: msbuild
 ms.topic: "conceptual"
 helpviewer_keywords: 


### PR DESCRIPTION
# Change

Under "Determining the Target Build Order", added "or skipped, if its `Condition` attribute was absent or did not evaluate to `false`," to the criteria regarding when targets listed in `DependsOnTargets` are run.

# Tests verifying the revised criteria is accurate

## When outputs are up to date, MSBuild executes the target specified in `DependsOnTargets`

  Code:
```
<Target Name="Default" DependsOnTargets="BeforeDefault" Inputs="c:\install.ini" Outputs="c:\install.ini">
  <Message Text="Target 'Default' is executing." />
</Target>

<Target Name="BeforeDefault">
  <Message Text="Target 'BeforeDefault' is executing." />
</Target>
```
  Log:

>     Target "BeforeDefault" (target "Default" depends on it):
>       Task "Message"
>         Target 'BeforeDefault' is executing.
>       Done executing task "Message".
>     Done building target "BeforeDefault" in project "temp.proj".
>     Target "Default" (entry point):
>       Skipping target "Default" because all output files are up-to-date with respect to the input files.
>       Done building target "Default" in project "temp.proj".


## When `Condition` evaluates to `false`, MSBuild does not execute the target specified in `DependsOnTargets`

  Code:
```
<Target Name="Default" DependsOnTargets="BeforeDefault" Condition="false">
  <Message Text="Target 'Default' is executing." />
</Target>

<Target Name="BeforeDefault">
  <Message Text="Target 'BeforeDefault' is executing." />
</Target>
```
  Log:

>     Target "Default" skipped, due to false condition; (false) was evaluated as (false).
>     Done Building Project "temp.proj" (default targets).


## Note

These corrected criteria for `DependsOnTargets` are also consistent with the test results documented in https://github.com/MicrosoftDocs/visualstudio-docs/pull/1082#issue-193071202