### PR TITLE
Adding ResultsDirectory, Port and ParentProcessId

### DIFF
--- a/docs/test/vstest-console-options.md
+++ b/docs/test/vstest-console-options.md
@@ -48,6 +48,10 @@ The following table lists all the options for *VSTest.Console.exe* and short des
 |**/ListSettingsProviders**|Lists installed test settings providers.|
 |**/Blame**|Tracks the tests as they're executing and, if the test host process crashes, emits the tests names in their sequence of execution up to and including the specific test that was running at the time of the crash. This output makes it easier to isolate the offending test and diagnose further. [More information](https://github.com/Microsoft/vstest-docs/blob/master/docs/extensions/blame-datacollector.md).|
 |**/Diag:[*file name*]**|Writes diagnostic trace logs to the specified file.|
+|**/ResultsDirectory:[*path*]**|Test results directory will be created in specified path if not exists.<br />Example: `/ResultsDirectory:<pathToResultsDirectory>`|
+|**/ParentProcessId:[*parentProcessId*]**|Process Id of the Parent Process responsible for launching current process.|
+|**/Port:[*port*]**|The Port for socket connection and receiving the event messages.|
+|**/Collect:[*dataCollector friendlyName*]**|Enables data collector for the test run. [More information](https://aka.ms/vstest-collect).|
 
 > [!TIP]
 > The options and values are not case-sensitive.


### PR DESCRIPTION
Those arguments seems to be missing from the docs, but are available with this version: Microsoft (R) Test Execution Command Line Tool Version 15.8.0