### PR TITLE
Improved formatting in Writing a T4 Text Template

### DIFF
--- a/docs/modeling/writing-a-t4-text-template.md
+++ b/docs/modeling/writing-a-t4-text-template.md
@@ -27,7 +27,7 @@ A text template contains the text that will be generated from it. For example, a
 
 -   **Control blocks** - program code that inserts variable values into the text, and controls conditional or repeated parts of the text.
 
- To try the examples in this topic, copy them into a template file as described in [Design-Time Code Generation by using T4 Text Templates](../modeling/design-time-code-generation-by-using-t4-text-templates.md). After editing the template file, save it, and then inspect the output **.txt** file.
+To try the examples in this topic, copy them into a template file as described in [Design-Time Code Generation by using T4 Text Templates](../modeling/design-time-code-generation-by-using-t4-text-templates.md). After editing the template file, save it, and then inspect the output **.txt** file.
 
 ## Directives
  Text template directives provide general instructions to the text templating engine about how to generate the transformation code and the output file.
@@ -35,7 +35,6 @@ A text template contains the text that will be generated from it. For example, a
  For example, the following directive specifies that the output file should have a .txt extension:
 
 ```
-
 <#@ output extension=".txt" #>
 ```
 
@@ -66,8 +65,7 @@ Hello
  For example, the following control block and text block cause the output file to contain the line "0, 1, 2, 3, 4 Hello!":
 
 ```
-
-      <#
+<#
     for(int i = 0; i < 4; i++)
     {
         Write(i + ", ");
@@ -207,7 +205,9 @@ private void WriteSquareLine(int i)
 ###  <a name="Include"></a> Including code and text
  The `include` directive inserts text from another template file. For example, this directive inserts the content of `test.txt`.
 
- `<#@ include file="c:\test.txt" #>`
+```
+<#@ include file="c:\test.txt" #>
+```
 
  The included content is processed almost as if it were part of the including text template. However, you can include a file that contains a class feature block `<#+...#>` even if the include directive is followed by ordinary text and standard control blocks.
 
@@ -239,7 +239,7 @@ private void WriteSquareLine(int i)
 ### Relative file paths in design-time templates
  In a [design-time text template](../modeling/design-time-code-generation-by-using-t4-text-templates.md), if you want to reference a file in a location relative to the text template, use `this.Host.ResolvePath()`. You must also set `hostspecific="true"` in the `template` directive:
 
-```csharp
+```
 <#@ template hostspecific="true" language="C#" #>
 <#@ output extension=".txt" #>
 <#@ import namespace="System.IO" #>


### PR DESCRIPTION
This PR contains few small improvements:

* Unindent a line so that it's not shown as part of a list it doesn't belong to.
* Remove unnecessary starting whitespace from code blocks.
* Convert a code line to code block.
* Remove C# syntax highlighting, it doesn't work that well for T4 code.