### PR TITLE
MSBuild: Mention escaping item wildcards

### DIFF
--- a/docs/msbuild/how-to-escape-special-characters-in-msbuild.md
+++ b/docs/msbuild/how-to-escape-special-characters-in-msbuild.md
@@ -17,27 +17,36 @@ ms.workload:
   - "multiple"
 ---
 # How to: Escape special characters in MSBuild
-Certain characters have special meaning in [!INCLUDE[vstecmsbuild](../extensibility/internals/includes/vstecmsbuild_md.md)] project files. Examples of the characters include semicolons (;) and asterisks (*). For a complete list of these special characters, see [MSBuild special characters](../msbuild/msbuild-special-characters.md).  
+
+Certain characters have special meaning in [!INCLUDE[vstecmsbuild](../extensibility/internals/includes/vstecmsbuild_md.md)] project files. Examples of the characters include semicolons (`;`) and asterisks (`*`). For a complete list of these special characters, see [MSBuild special characters](../msbuild/msbuild-special-characters.md).
   
- In order to use these special characters as literals in a project file, they must be specified by using the syntax %\<xx>, where \<xx> represents the ASCII hexadecimal value of the character.  
+In order to use these special characters as literals in a project file, they must be specified by using the syntax `%<xx>`, where `<xx>` represents the ASCII hexadecimal value of the character.
   
-## MSBuild special characters  
+## MSBuild special characters
+
  One example of where special characters are used is in the `Include` attribute of item lists. For example, the following item list declares two items: *MyFile.cs* and *MyClass.cs*.  
   
 ```xml  
 <Compile Include="MyFile.cs;MyClass.cs"/>  
 ```  
   
- If you want to declare an item that contains a semicolon in the name, you must use the %\<xx> syntax to escape the semicolon and prevent [!INCLUDE[vstecmsbuild](../extensibility/internals/includes/vstecmsbuild_md.md)] from declaring two separate items. For example, the following item escapes the semicolon and declares one item named *MyFile.cs;MyClass.cs*.  
+If you want to declare an item that contains a semicolon in the name, you must use the `%<xx>` syntax to escape the semicolon and prevent [!INCLUDE[vstecmsbuild](../extensibility/internals/includes/vstecmsbuild_md.md)] from declaring two separate items. For example, the following item escapes the semicolon and declares one item named `MyFile.cs;MyClass.cs`.
   
 ```xml  
 <Compile Include="MyFile.cs%3BMyClass.cs"/>  
 ```  
-  
-#### To use an MSBuild special character as a literal character  
-  
--   Use the notation %\<xx> in place of the special character, where \<xx> represents the hexadecimal value of the ASCII character. For example, to use an asterisk (*) as a literal character, use the value `%2A`.  
-  
+
+You can also use a [property function](../msbuild/property-functions.md) to escape strings. For example, this is equivalent to the example above.
+
+```xml
+<Compile Include="$([MSBuild]::Escape('MyFile.cs;MyClass.cs'))" />
+```
+
+### To use an MSBuild special character as a literal character
+
+Use the notation `%<xx>` in place of the special character, where `<xx>` represents the hexadecimal value of the ASCII character. For example, to use an asterisk (`*`) as a literal character, use the value `%2A`.
+
+ 
 ## See also  
  [MSBuild concepts](../msbuild/msbuild-concepts.md)   
  [MSBuild](../msbuild/msbuild.md)   

--- a/docs/msbuild/msbuild-items.md
+++ b/docs/msbuild/msbuild-items.md
@@ -54,25 +54,26 @@ MSBuild items are inputs into the build system, and they typically represent fil
  By default, the items of an item type are separated by semicolons (;) when it's expanded. You can use the syntax @(\<ItemType>, '\<separator>') to specify a separator other than the default. For more information, see [How to: Display an item list separated with commas](../msbuild/how-to-display-an-item-list-separated-with-commas.md).  
   
 ##  Use wildcards to specify items  
- You can use the **, \*, and ? wildcard characters to specify a group of files as inputs for a build instead of listing each file separately.  
-  
--   The ? wildcard character matches a single character.  
-  
--   The * wildcard character matches zero or more characters.  
-  
--   The ** wildcard character sequence matches a partial path.  
 
-For example, you can specify all the *.cs* files in the directory that contains the project file by using the following element in your project file.  
+You can use the `**`, `*`, and `?` wildcard characters to specify a group of files as inputs for a build instead of listing each file separately.
+  
+- The `?` wildcard character matches a single character.
+- The `*` wildcard character matches zero or more characters.
+- The `**` wildcard character sequence matches a partial path.
+
+For example, you can specify all the `.cs` files in the directory that contains the project file by using the following element in your project file.
 
 ```xml  
 <CSFile Include="*.cs"/>  
 ```  
 
-The following element selects all *.vb* files on the *D:* drive:  
+The following element selects all `.vb` files on the `D:` drive:
 
 ```xml  
 <VBFile Include="D:/**/*.vb"/>  
 ```  
+
+If you would like to include literal `*` or `?` characters in an item without wildcard expansion, you must [escape the wildcard characters](../msbuild/how-to-escape-special-characters-in-msbuild.md).
 
 For more information about wildcard characters, see [How to: Select the files to build](../msbuild/how-to-select-the-files-to-build.md).  
 


### PR DESCRIPTION
The "escaping" doc explicitly mentioned wildcards, but the "using wildcards" doc didn't mention escaping.

cc @tmat (re: https://github.com/Microsoft/msbuild/issues/3791#issuecomment-425281387).