### PR TITLE
Argument typo (AccesToken -> AccessToken)

### DIFF
--- a/docs/extensibility/walkthrough-publishing-a-visual-studio-extension-via-command-line.md
+++ b/docs/extensibility/walkthrough-publishing-a-visual-studio-extension-via-command-line.md
@@ -32,7 +32,7 @@ Publishes an extension to the Marketplace. The extension can be a vsix, an exe/m
 |payload (required)                 |  Either a path to the payload to publish or a link to use as the "more info URL".      |
 |publishManifest (required)         |  Path to the publish manifest file to use.       |
 |ignoreWarnings                     |  List of warnings to ignore when publishing an extension. These warnings are shown as command line messages when publishing an extension. (for example, "VSIXValidatorWarning01, VSIXValidatorWarning02")  
-|personalAccesToken                 |  Personal Access Token that is used to authenticate the publisher. If not provided, the pat is acquired from the logged-in users.       |
+|personalAccessToken                 |  Personal Access Token that is used to authenticate the publisher. If not provided, the pat is acquired from the logged-in users.       |
 
 ```
 VsixPublisher.exe publish -payload "{path to vsix}" -publishManifest "{path to vs-publish.json}" -ignoreWarnings "VSIXValidatorWarning01,VSIXValidatorWarning02"


### PR DESCRIPTION
Using the invalid arg when running "VsixPublisher.exe publish..." causes this error:

'-personalAccesToken' is an invalid argument.
  : 
  : 
  -personalAccessToken           The personal access token to use for publishing (if not supplied, the personal access token will be retreived from the logged-in accounts).