### PR TITLE
fix error in example for import-group element

### DIFF
--- a/docs/msbuild/importgroup-element.md
+++ b/docs/msbuild/importgroup-element.md
@@ -61,8 +61,8 @@ Contains a collection of `Import` elements that are grouped under an optional co
 ```xml  
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">  
     <ImportGroup>  
-        <Import Project="$(Targets1.targets) />  
-        <Import Project="$(Targets2.targets) />  
+        <Import Project="$(Targets1.targets)" />  
+        <Import Project="$(Targets2.targets)" />  
     </ImportGroup>  
 ...  
 </Project>  


### PR DESCRIPTION
This fixes an error in the [example](https://docs.microsoft.com/en-us/visualstudio/msbuild/importgroup-element?view=vs-2017#example) for the `ImportGroup` Element.