### PR TITLE
Update to fix InvokeAsync usage

### DIFF
--- a/docs/extensibility/adding-an-lsp-extension.md
+++ b/docs/extensibility/adding-an-lsp-extension.md
@@ -193,7 +193,7 @@ namespace MockLanguageExtension
 
         public async Task OnLoadedAsync()
         {
-            await StartAsync?.InvokeAsync(this, EventArgs.Empty);
+            await StartAsync.InvokeAsync(this, EventArgs.Empty);
         }
 
         public async Task OnServerInitializeFailedAsync(Exception e)


### PR DESCRIPTION
InvokeAsync extension method internally handles the event handler being null, per recommendation patterns like "await StartAsync?.InvokeAsync" should be awaited since it will cause NullReferenceException in case StartAsync is null. Removing "?" and letting InvokeAsync handle it does the expected action which is a no-op

Before creating your pull request, please check your content against these quality criteria:

- For new articles, did you add it to the TOC?
- Did you update ms.date for new or significantly updated articles?
- Did you consider [SEO](https://review.docs.microsoft.com/en-us/help/contribute/contribute-how-to-write-seo-basics?branch=master) when you chose the title in the metadata, the H1 heading (displayed title), and summary (first paragraph)?
- Is the content concise and conversational?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Do screenshots display any personally identifiable information?
- Do all the images you added have [alt text](https://review.docs.microsoft.com/en-us/help/contribute/contribute-alt-text?branch=master)?
- Should this page be linked to from other pages or Microsoft web sites?

After you create the pull request and the Acrolinx and build checks have run, please:

- Check the Acrolinx report and make sure the score is at least 80.
- Review the staged content to see how it looks when built.

Additional resources:

- [Contributor Guide](https://review.docs.microsoft.com/en-us/help/contribute/?branch=master)
- [Microsoft Style Guide](https://worldready.cloudapp.net/StyleGuide/Read?id=2696)
