### PR TITLE
Fix incorrect closing parenthesis

### DIFF
--- a/docs/msbuild/zipdirectory-task.md
+++ b/docs/msbuild/zipdirectory-task.md
@@ -52,8 +52,7 @@ Creates a *.zip* archive from the contents of a directory.
     <Target Name="ZipOutputPath" AfterTargets="Build">
         <ZipDirectory
             SourceDirectory="$(OutputPath)"
-            DestinationFile="$(MSBuildProjectDirectory)\output.zip">
-        />
+            DestinationFile="$(MSBuildProjectDirectory)\output.zip" />
     </Target>
 
 </Project>


### PR DESCRIPTION
Remove duplicate closing of ZipDirectory element in [example code](https://docs.microsoft.com/en-us/visualstudio/msbuild/zipdirectory-task?view=vs-2017#example)

## Issue
#1776 
