### PR TITLE
Capitalizes "GitHub" on getting-started-roslyn-analyzers

### DIFF
--- a/docs/extensibility/getting-started-with-roslyn-analyzers.md
+++ b/docs/extensibility/getting-started-with-roslyn-analyzers.md
@@ -24,12 +24,12 @@ With live, project-based code analyzers in Visual Studio, API authors can ship d
 
 [Real world Roslyn analyzer](../extensibility/roslyn-analyzers-and-code-aware-library-for-immutablearrays.md) that you can also watch as a [talk](https://channel9.msdn.com/events/Build/2015/3-725)
 
-[Several examples on github, grouped into three kinds of analyzers](https://github.com/dotnet/roslyn/blob/master/docs/analyzers/Analyzer%20Samples.md)
+[Several examples on GitHub, grouped into three kinds of analyzers](https://github.com/dotnet/roslyn/blob/master/docs/analyzers/Analyzer%20Samples.md)
 
 [Introduction and tour of a few analyzers talk](https://channel9.msdn.com/Events/dotnetConf/2015/NET-Compiler-Platform-Roslyn-Analyzers-and-the-Rise-of-Code-Aware-Libraries)
 
 ## See also
 
 - [Roslyn analyzers overview](../code-quality/roslyn-analyzers-overview.md)
-- [More docs on the github OSS site](https://github.com/dotnet/roslyn/tree/master/docs/analyzers)
+- [More docs on the GitHub OSS site](https://github.com/dotnet/roslyn/tree/master/docs/analyzers)
 - [FxCop rules implemented with Roslyn analyzers on GitHub](https://github.com/dotnet/roslyn/tree/master/src/Diagnostics/FxCop)


### PR DESCRIPTION
looked for an existing issue but couldn't find one. per contributing guidelines, not opening an issue given the change is so small