### PR TITLE
T4 Code Snippets Exception Fix

### DIFF
--- a/docs/modeling/design-time-code-generation-by-using-t4-text-templates.md
+++ b/docs/modeling/design-time-code-generation-by-using-t4-text-templates.md
@@ -266,7 +266,7 @@ Design-time T4 text templates let you generate program code and other files in y
 ### Getting data from Visual Studio
  To use services provided in Visual Studio, set the `hostSpecific` attribute and load the `EnvDTE` assembly. Import `Microsoft.VisualStudio.TextTemplating`, which contains the `GetCOMService()` extension method.  You can then use IServiceProvider.GetCOMService() to access DTE and other services. For example:
 
-```csharp
+```src
 <#@ template hostspecific="true" language="C#" #>
 <#@ output extension=".txt" #>
 <#@ assembly name="EnvDTE" #>

--- a/docs/modeling/design-time-code-generation-by-using-t4-text-templates.md
+++ b/docs/modeling/design-time-code-generation-by-using-t4-text-templates.md
@@ -147,7 +147,7 @@ Design-time T4 text templates let you generate program code and other files in y
 
     ```csharp
 
-              <#@ template debug="false" hostspecific="false" language="C#" #>
+    <#@ template debug="false" hostspecific="false" language="C#" #>
     <#@ output extension=".cs" #>
     <# var properties = new string [] {"P1", "P2", "P3"}; #>
     // This is generated code:
@@ -219,7 +219,7 @@ Design-time T4 text templates let you generate program code and other files in y
 
 ```csharp
 
-      <# var properties = File.ReadLines("C:\\propertyList.txt");#>
+<# var properties = File.ReadLines("C:\\propertyList.txt");#>
 ...
 <# foreach (string propertyName in properties) { #>
 ...
@@ -264,12 +264,13 @@ Design-time T4 text templates let you generate program code and other files in y
  The type of `this.Host` (in VB, `Me.Host`) is `Microsoft.VisualStudio.TextTemplating.ITextTemplatingEngineHost`.
 
 ### Getting data from Visual Studio
- To use services provided in Visual Studio, set the `hostSpecific` attribute and load the `EnvDTE` assembly. You can then use IServiceProvider.GetCOMService() to access DTE and other services. For example:
+ To use services provided in Visual Studio, set the `hostSpecific` attribute and load the `EnvDTE` assembly. Import `Microsoft.VisualStudio.TextTemplating`, which contains the `GetCOMService()` extension method.  You can then use IServiceProvider.GetCOMService() to access DTE and other services. For example:
 
-```scr
+```csharp
 <#@ template hostspecific="true" language="C#" #>
 <#@ output extension=".txt" #>
 <#@ assembly name="EnvDTE" #>
+<#@ import namespace="Microsoft.VisualStudio.TextTemplating" #>
 <#
   IServiceProvider serviceProvider = (IServiceProvider)this.Host;
   EnvDTE.DTE dte = (EnvDTE.DTE) serviceProvider.GetCOMService(typeof(EnvDTE.DTE));

--- a/docs/modeling/t4-template-directive.md
+++ b/docs/modeling/t4-template-directive.md
@@ -82,6 +82,7 @@ hostspecific="true"
 <#@ assembly name="EnvDTE" #>
 <#@ import namespace="EnvDTE" #>
 <#@ import namespace="System.IO" #>
+<#@ import namespace="Microsoft.VisualStudio.TextTemplating" #>
 <# // Get the Visual Studio API as a service:
  DTE dte = ((IServiceProvider)this.Host).GetCOMService(typeof(DTE)) as DTE;
 #>


### PR DESCRIPTION
T4 Snippets using `GetCOMService()`  don't import `Microsoft.VisualStudio.TextTemplating` causing "Compiling Transformation" Exception.

- Adds correct import directive to the snippets
- Adds sentence explaining the import
- Fixes inconsistent indentation