### PR TITLE
Fix typo in .editorconfig code style settings reference

### DIFF
--- a/docs/ide/editorconfig-code-style-settings-reference.md
+++ b/docs/ide/editorconfig-code-style-settings-reference.md
@@ -1813,7 +1813,7 @@ The following table shows the rule names, applicable languages, default values, 
 | ----------- | -------------------- | ----------------------| ---------------- |
 | csharp_space_after_cast | C# | false | 15.3 |
 | csharp_space_after_keywords_in_control_flow_statements | C# | true | 15.3 |
-| csharp_space_between_method_declaration_parameter_ list_parentheses | C# | false | 15.3 |
+| csharp_space_between_method_declaration_parameter_list_parentheses | C# | false | 15.3 |
 | csharp_space_between_method_call_parameter_list_parentheses | C# | false | 15.3 |
 | csharp_space_between_parentheses | C# | false | 15.3 |
 | csharp_space_before_colon_in_inheritance_clause | C# | true | 15.7 |


### PR DESCRIPTION
This PR fixes a tiny errant space in `csharp_space_between_method_declaration_parameter_list_parentheses` that prevents double-click to select all on this table entry.