### PR TITLE
Fix "Find component IDs" anchor reference

### DIFF
--- a/docs/extensibility/how-to-migrate-extensibility-projects-to-visual-studio-2017.md
+++ b/docs/extensibility/how-to-migrate-extensibility-projects-to-visual-studio-2017.md
@@ -57,7 +57,7 @@ To ensure that the user's installation of Visual Studio has all the assemblies r
 * Ensure `InstallationTarget` includes 15.0.
 * Add required installation prerequisites (as shown in the example below).
   * We recommend you specify only Component IDs for installation prerequisites.
-  * See the section at the end of this document for [instructions on identifying Component IDs](#finding-component-ids).
+  * See the section at the end of this document for [instructions on identifying Component IDs](#find-component-ids).
 
 Example:
 


### PR DESCRIPTION
Not sure why the backticks at the end there are seen as a modification. I just used the github editor to tweak this file.