### PR TITLE
typo: overrided -> override

### DIFF
--- a/docs/vs-2015/snippets/visualbasic/VS_Snippets_Wpf/StrokeSnippets/VisualBasic/CustomRenderedStroke.vb
+++ b/docs/vs-2015/snippets/visualbasic/VS_Snippets_Wpf/StrokeSnippets/VisualBasic/CustomRenderedStroke.vb
@@ -55,13 +55,13 @@ Namespace StrokeSnippets_VB
 
 
         Protected Overrides Sub DrawCore(ByVal context As System.Windows.Media.DrawingContext, _
-                    ByVal overridedAttributes As DrawingAttributes)
-            Dim strokeBrush As New SolidColorBrush(overridedAttributes.Color)
+                    ByVal overriddenAttributes As DrawingAttributes)
+            Dim strokeBrush As New SolidColorBrush(overriddenAttributes.Color)
 
             ' If strokeMode it set to Solid, draw the strokes regularly.
             ' Otherwise, draw the stylus points.
             If strokeMode = DrawingMode.Solid Then
-                Dim geometry As Geometry = GetGeometry(overridedAttributes)
+                Dim geometry As Geometry = GetGeometry(overriddenAttributes)
                 context.DrawGeometry(strokeBrush, Nothing, geometry)
                 ' strokeMode == DrawingMode.StylusPoints
             Else

--- a/docs/vs-2015/snippets/visualbasic/VS_Snippets_Wpf/StrokeSnippets/VisualBasic/MyStroke.vb
+++ b/docs/vs-2015/snippets/visualbasic/VS_Snippets_Wpf/StrokeSnippets/VisualBasic/MyStroke.vb
@@ -91,11 +91,11 @@ Namespace StrokeSnippets_VB
 
         '<Snippet23>
         Protected Overrides Sub DrawCore(ByVal context As DrawingContext, _
-                ByVal overridedAttributes As DrawingAttributes)
+                ByVal overriddenAttributes As DrawingAttributes)
 
             ' Draw the stroke. Calling base.DrawCore accomplishes the same thing.
-            Dim geometry As Geometry = GetGeometry(overridedAttributes)
-            context.DrawGeometry(New SolidColorBrush(overridedAttributes.Color), Nothing, geometry)
+            Dim geometry As Geometry = GetGeometry(overriddenAttributes)
+            context.DrawGeometry(New SolidColorBrush(overriddenAttributes.Color), Nothing, geometry)
 
             Dim points As StylusPointCollection
 
@@ -116,7 +116,7 @@ Namespace StrokeSnippets_VB
         End Sub 'DrawCore
 
         '</Snippet23>
-        Private Sub DrawSelectedStrokeAndPoints(ByVal context As DrawingContext, ByVal overridedAttributes As DrawingAttributes)
+        Private Sub DrawSelectedStrokeAndPoints(ByVal context As DrawingContext, ByVal overriddenAttributes As DrawingAttributes)
 
         End Sub 'DrawSelectedStrokeAndPoints
 


### PR DESCRIPTION
Could also be "overridden"