### PR TITLE
Correct typo: Diagnosis => Diagnostics

### DIFF
--- a/docs/code-quality/code-analysis-for-managed-code-overview.md
+++ b/docs/code-quality/code-analysis-for-managed-code-overview.md
@@ -45,7 +45,7 @@ Frequently, it is useful to indicate that a warning is non-applicable. This info
 In-source suppression of warnings is implemented through custom attributes. To suppress a warning, add the attribute `SuppressMessage` to the source code as shown in the following example:
 
 ```csharp
-[System.Diagnosis.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1039:ListsAreStrongTyped")]
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1039:ListsAreStrongTyped")]
 Public class MyClass
 {
    // code

--- a/docs/vs-2015/code-quality/code-analysis-for-managed-code-overview.md
+++ b/docs/vs-2015/code-quality/code-analysis-for-managed-code-overview.md
@@ -42,15 +42,13 @@ Code analysis for managed code analyzes managed assemblies and reports informati
   
  In Source Suppression of warnings is implemented through custom attributes. To suppress a warning, add the attribute `SuppressMessage` to the source code as shown in the following example:  
   
- `[System.Diagnosis.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1039:ListsAreStrongTyped")]`  
-  
- `Public class MyClass`  
-  
- `{`  
-  
- `// code`  
-  
- `}`  
+ ```csharp
+ [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1039:ListsAreStrongTyped")]
+ Public class MyClass
+ {
+     // code
+ }
+ ```
   
  For more information, see [Suppress Warnings By Using the SuppressMessage Attribute](../code-quality/suppress-warnings-by-using-the-suppressmessage-attribute.md).  
   


### PR DESCRIPTION
And correct formatting of example in vs-2015.

Fixes #1941