### PR TITLE
Fix typo and delete unnecessary spaces

### DIFF
--- a/docs/vs-2015/extensibility/getting-started-with-roslyn-analyzers.md
+++ b/docs/vs-2015/extensibility/getting-started-with-roslyn-analyzers.md
@@ -17,23 +17,23 @@ manager: "ghogen"
 # Getting Started with Roslyn Analyzers
 [!INCLUDE[vs2017banner](../includes/vs2017banner.md)]
 
-With live, project-based code analyzers in Visual Studio, API authors can ship domain-specific code analysis as part of their NuGet packages.  Because these analyzers are powered by the .NET Compiler Platform (code-named “Roslyn”), they can produce warnings in your code as you type even before you’ve finished the line (no more waiting to build your code to discover issues).  Analyzers can also surface an automatic code fix through the Visual Studio light bulb prompt to let you clean up your code immediately  
-  
-## Getting Started  
- [Roslyn Live Code Analyzers Introduction and Walkthrough](https://msdn.microsoft.com/magazine/dn879356.aspx)  
-  
- [Adding Code Fixes Walkthrough: Provide Users Fixes for Analyzer Issues](https://msdn.microsoft.com/magazine/dn904670.aspx)  
-  
- [Introduction and Walkthrough of Real World Analyzer Talk](http://channel9.msdn.com/events/Build/2015/3-725)  
-  
- [Real World Roslyn Analyzer](../extensibility/roslyn-analyzers-and-code-aware-library-for-immutablearrays.md) that you can also watch as a [talk](http://channel9.msdn.com/events/Build/2015/3-725)  
-  
- [Several examples on github, grouped into three kinds of analyzers](https://github.com/dotnet/roslyn/blob/master/docs/analyzers/Analyzer%20Samples.md)  
-  
- [Introduction and Tour of a Few Analyzers Talk](http://channel9.msdn.com/Events/dotnetConf/2015/NET-Compiler-Platform-Roslyn-Analyzers-and-the-Rise-of-Code-Aware-Libraries)  
-  
-## Other Resources  
- [More docs on the github OSS site](https://github.com/dotnet/roslyn/tree/master/docs/analyzers)  
-  
- [FxCop rules implemented with Roslyn analyzers on github](https://github.com/dotnet/roslyn/tree/master/src/Diagnostics/FxCop)
+With live, project-based code analyzers in Visual Studio, API authors can ship domain-specific code analysis as part of their NuGet packages.  Because these analyzers are powered by the .NET Compiler Platform (code-named “Roslyn”), they can produce warnings in your code as you type even before you’ve finished the line (no more waiting to build your code to discover issues).  Analyzers can also surface an automatic code fix through the Visual Studio light bulb prompt to let you clean up your code immediately
+
+## Getting Started
+[Roslyn Live Code Analyzers Introduction and Walkthrough](https://msdn.microsoft.com/magazine/dn879356.aspx)
+
+[Adding Code Fixes Walkthrough: Provide Users Fixes for Analyzer Issues](https://msdn.microsoft.com/magazine/dn904670.aspx)
+
+[Introduction and Walkthrough of Real World Analyzer Talk](http://channel9.msdn.com/events/Build/2015/3-725)
+
+[Real World Roslyn Analyzer](../extensibility/roslyn-analyzers-and-code-aware-library-for-immutablearrays.md) that you can also watch as a [talk](http://channel9.msdn.com/events/Build/2015/3-725)
+
+[Several examples on GitHub, grouped into three kinds of analyzers](https://github.com/dotnet/roslyn/blob/master/docs/analyzers/Analyzer%20Samples.md)
+
+[Introduction and Tour of a Few Analyzers Talk](http://channel9.msdn.com/Events/dotnetConf/2015/NET-Compiler-Platform-Roslyn-Analyzers-and-the-Rise-of-Code-Aware-Libraries)
+
+## Other Resources
+[More docs on the GitHub OSS site](https://github.com/dotnet/roslyn/tree/master/docs/analyzers)
+
+[FxCop rules implemented with Roslyn analyzers on GitHub](https://github.com/dotnet/roslyn/tree/master/src/Diagnostics/FxCop)
 


### PR DESCRIPTION
* typo: github -> GitHub
* delete unnecessary spaces: As Markdown syntax, there was a large amount of half-width spaces that did not affect the display, so I deleted it