### PR TITLE
CC88205: Changing &#39; to '

### DIFF
--- a/scripting-docs/javascript/misc/expected-left-curly-brace.md
+++ b/scripting-docs/javascript/misc/expected-left-curly-brace.md
@@ -1,5 +1,5 @@
 ---
-title: "Expected &#39;{&#39; | Microsoft Docs"
+title: "Expected '{' | Microsoft Docs"
 ms.custom: ""
 ms.date: "01/18/2017"
 ms.prod: "windows-client-threshold"
@@ -21,7 +21,7 @@ author: "mikejo5000"
 ms.author: "mikejo"
 manager: "ghogen"
 ---
-# Expected &#39;{&#39;
+# Expected '{'
 You did not include the left brace that marks the beginning of the function body. Code that makes up the body of a function, even if it is a single line, must be contained within left and right braces. Notice that the use of braces in function bodies is stricter than in loops.  
   
 ### To correct this error  


### PR DESCRIPTION
Hello, @Saisang, @Mikejo5000,
This proposed file change comes from https://github.com/MicrosoftDocs/visualstudio-docs.ja-jp/pull/124 .
Could you review this contribution and help to merge if agreed?
Many thanks in advance.

(You can replace all of this text with your description.)

Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for docs.microsoft.com, see the contributor guide at https://docs.microsoft.com/contribute/.
