### PR TITLE
Clarification around snaphot capture

### DIFF
--- a/docs/debugger/intellitrace.md
+++ b/docs/debugger/intellitrace.md
@@ -143,6 +143,9 @@ By default, IntelliTrace records only IntelliTrace events: debugger events, exce
 
 You can configure IntelliTrace to capture snapshots at every breakpoint and debugger step event. IntelliTrace records the full application state at each snapshot, which allows you to view complex variables and to evaluate expressions.
 
+> [!NOTE]
+> The [IntelliTrace stand-alone collector](../debugger/using-the-intellitrace-stand-alone-collector.md) does not support capturing snaphots.
+
 See [Inspect previous app states using IntelliTrace](../debugger/view-historical-application-state.md).
 
 **Collect function call information**

--- a/docs/debugger/using-the-intellitrace-stand-alone-collector.md
+++ b/docs/debugger/using-the-intellitrace-stand-alone-collector.md
@@ -24,6 +24,7 @@ The **IntelliTrace stand-alone collector** lets you collect IntelliTrace diagnos
 >  You can also collect the same IntelliTrace data for web and SharePoint apps running on remote machines by using the **Microsoft Monitoring Agent** in **Trace** mode.
 >
 >  You can collect performance-related events in the IntelliTrace data by running the agent in **Monitor** mode. **Monitor** mode has less of a performance impact than **Trace** mode or the **IntelliTrace stand-alone collector**. Microsoft Monitoring Agent does alter the target system's environment when it is installed. See [Using the Microsoft Monitoring Agent](../debugger/using-the-microsoft-monitoring-agent.md).
+>  The IntelliTrace stand-alone collector does not support Process Snapshots.
 
  **Requirements**
 
@@ -228,7 +229,7 @@ The **IntelliTrace stand-alone collector** lets you collect IntelliTrace diagnos
 
 2.  Reproduce the problem.
 
-3.  To take a snapshot of the .iTrace file, use this syntax:
+3.  To create a checkpoint of the .iTrace file, use this syntax:
 
      `Checkpoint-IntelliTraceCollection` `"` *\<ApplicationPool>* `"`
 


### PR DESCRIPTION
We overused the the term "snapshot" to mean multiple things as both a noun and verb.

Our "Process Snapshot" feature is not supported in the IntelliTrace standalone tool so we are removing the term "snaphot" to reduce confusion.

Additionally when we start the discussion about collecting "snapshots" on the main IntelliTrace page we are explicitly stating that the stand-alone collection does not support this type of snapshot.