### PR TITLE
Fix typo: Add closing bracket to class in example

### DIFF
--- a/docs/msbuild/codesnippet/CSharp/build-loggers_1.cs
+++ b/docs/msbuild/codesnippet/CSharp/build-loggers_1.cs
@@ -7,3 +7,4 @@
 			eventSource.TargetStarted += new TargetStartedEventHandler(eventSource_TargetStarted);
 			eventSource.ProjectFinished += new ProjectFinishedEventHandler(eventSource_ProjectFinished);
 		}
+	 }


### PR DESCRIPTION
It looks to have been inadvertently excluded. Saw it while browsing through.

On https://docs.microsoft.com/en-us/visualstudio/msbuild/build-loggers?view=vs-2017: 

![image](https://user-images.githubusercontent.com/2148318/50288081-d5999980-0432-11e9-8414-0e8a486dedbb.png)
