### PR TITLE
chore: Remove ~~~ code fence for content block

### DIFF
--- a/subscriptions/vs-whitesource.md
+++ b/subscriptions/vs-whitesource.md
@@ -35,7 +35,6 @@ Find and fix open source vulnerabilities and generate comprehensive inventory an
    - [Install](https://marketplace.visualstudio.com/items?itemName=whitesource.ws-bolt) the WhiteSource Bolt extension from Microsoft Visual Studio marketplace. If you don’t have permissions to install extensions, see [Install free extensions for Azure DevOps Services](/azure/devops/marketplace/install-vsts-extension?view=vsts).
 
 
-~~~
 Click the green **Install** button if you are using Azure DevOps Services, or the **Download** button for Team Foundation Server.  For this example, we will use Azure DevOps Services.
 > [!div class="mx-imgBorder"]
 > ![WhiteSource Benefit Install Extension](_img\vs-whitesource\vs-whitesource-download-install.png)
@@ -48,7 +47,6 @@ Click the green **Install** button if you are using Azure DevOps Services, or th
 - You’ll receive a confirmation that the extension is installed and ready to use.  Click **Get started** to return to the WhiteSource Bolt page and continue.
 > [!div class="mx-imgBorder"]
 > ![WhiteSource Benefit Install Complete](_img\vs-whitesource\vs-whitesource-install-complete.png)
-~~~
 
 5. Open your Azure DevOps project dashboard, click on the **Azure Pipelines** menu and choose **WhiteSource Bolt**.
    > [!div class="mx-imgBorder"]


### PR DESCRIPTION
Not sure if the intention was for something like a `---` for a horizontal rule, but the block contents don't appear to be indented to be in a code fence