### PR TITLE
Clarify that verification only works for the latest patch level release

### DIFF
--- a/docs/install/update-a-network-installation-of-visual-studio.md
+++ b/docs/install/update-a-network-installation-of-visual-studio.md
@@ -93,7 +93,7 @@ The vs_enterprise.exe can be invoked inside the layoutDir.
 Microsoft ships updates to Visual Studio periodically, so the new layout that you create might not be the same version as the initial layout.
 
 > [!NOTE]
-> Verification works only for the latest version of a specific minor version of Visual Studio. As soon as a new version is released verification won't work for earlier patch level releases of the same minor version.
+> Verification works only for the latest version of a specific minor version of Visual Studio. As soon as a new version is released, verification won't work for earlier patch level releases of the same minor version.
 
 ## How to fix a layout
 

--- a/docs/install/update-a-network-installation-of-visual-studio.md
+++ b/docs/install/update-a-network-installation-of-visual-studio.md
@@ -92,6 +92,9 @@ The vs_enterprise.exe can be invoked inside the layoutDir.
 
 Microsoft ships updates to Visual Studio periodically, so the new layout that you create might not be the same version as the initial layout.
 
+> [!NOTE]
+> Verification works only for the latest version of a specific minor version of Visual Studio. As soon as a new version is released verification won't work for earlier patch level releases of the same minor version.
+
 ## How to fix a layout
 
 Use `--fix` to perform the same verification as `--verify` and also try to fix the identified issues. The `--fix` process needs an Internet connection, so make sure your machine is connected to the Internet before you invoke `--fix`.


### PR DESCRIPTION
Clarify that verification only works for the latest patch level release. E.g. verification is no longer possible for 15.9.0 once 15.9.1 is released, based on information from Microsoft support