### PR TITLE
MSBuild: Remove incorrect Import note

### DIFF
--- a/docs/msbuild/import-element-msbuild.md
+++ b/docs/msbuild/import-element-msbuild.md
@@ -67,10 +67,6 @@ Imports the contents of one project file into another project file.
 
  The schema of an imported project is identical to that of a standard project. Although [!INCLUDE[vstecmsbuild](../extensibility/internals/includes/vstecmsbuild_md.md)] may be able to build an imported project, it is unlikely because an imported project typically does not contain information about which properties to set or the order in which to run targets. The imported project depends on the project into which it is imported to provide that information.  
 
-> [!NOTE]
->  While conditional import statements work in command-line MSBuilds, they do not work with MSBuild in the [!INCLUDE[vsprvs](../code-quality/includes/vsprvs_md.md)] integrated development environment (IDE). Conditional imports are evaluated by using the configuration and platform values that are set when the project is loaded. If changes are subsequently made that require a reevaluation of the conditionals in the project file, for example, changing the platform, [!INCLUDE[vsprvs](../code-quality/includes/vsprvs_md.md)] reevaluates the conditions on properties and items, but not on imports. Because the import conditional is not reevaluated, the import is skipped.  
-> 
->  To work around this, put conditional imports in the *.targets* files or put code in a conditional block such as a [Choose element (MSBuild)](../msbuild/choose-element-msbuild.md) block.  
 
 ## Wildcards  
  In the .NET Framework 4, MSBuild allows wildcards in the Project attribute. When there are wildcards, all matches found are sorted (for reproducibility), and then they are imported in that order as if the order had been explicitly set.  


### PR DESCRIPTION

This note suggested placing Import statements in a Choose/When
construct, but MSBuild does not appear to have ever supported that.

Removing the entire note, because I believe the conditional-import
restrictions in VS are now relaxed.