### PR TITLE
Update ca1012-abstract-types-should-not-have-constructors_2.cs

### DIFF
--- a/docs/code-quality/codesnippet/CSharp/ca1012-abstract-types-should-not-have-constructors_2.cs
+++ b/docs/code-quality/codesnippet/CSharp/ca1012-abstract-types-should-not-have-constructors_2.cs
@@ -2,7 +2,7 @@ using System;
      
 namespace Samples  
 {   
-    // Violates this rule      
+    // Does not violate this rule      
     public abstract class Book      
     {          
         protected Book()          


### PR DESCRIPTION
Abstract class may (must) have a public constructor so it doesn't violate the CA1012 rule any more. The comment was incorrect.

(You can replace all of this text with your description.)

Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for docs.microsoft.com, see the contributor guide at https://docs.microsoft.com/contribute/.
