### PR TITLE
Move snippet #7 down to include missing end braces

### DIFF
--- a/docs/vsto/codesnippet/CSharp/trin_excelworkbookpda/filecopypda/class1.cs
+++ b/docs/vsto/codesnippet/CSharp/trin_excelworkbookpda/filecopypda/class1.cs
@@ -43,7 +43,6 @@ namespace FileCopyPDA
             }
         }
 // </snippet3>
-// </snippet7>
-
     }
 }
+// </snippet7>


### PR DESCRIPTION
This was found while reading [Deploy an Office solution by using ClickOnce](https://github.com/MicrosoftDocs/visualstudio-docs/blob/master/docs/vsto/deploying-an-office-solution-by-using-clickonce.md#create-a-class-that-defines-the-post-deployment-action).