### PR TITLE
fix small "Creatr" typo

### DIFF
--- a/docs/extensibility/creating-a-basic-project-system-part-2.md
+++ b/docs/extensibility/creating-a-basic-project-system-part-2.md
@@ -333,7 +333,7 @@ ZipProjects:
     }  
     ```  
   
-## Creatr a project property page  
+## Create a project property page  
  You can create a property page for your project type so that users can view and change properties in projects that are based on your template. This section shows you how to create a configuration-independent property page. This basic property page uses a properties grid to display the public properties that you expose in your property page class.  
   
  Derive your property page class from the `SettingsPage` base class. The properties grid provided by the `SettingsPage` class is aware of most primitive data types and knows how to display them.  In addition, the `SettingsPage` class knows how to persist property values to the project file.  


### PR DESCRIPTION
fixes small typo in a Header.

No idea why there are 2 changed lines. I am doing this on the GitHub Web Interface and I only changed the one char in line 336.