### PR TITLE
Remove outdated 'Natvis does not work' section

### DIFF
--- a/docs/debugger/create-custom-views-of-native-objects.md
+++ b/docs/debugger/create-custom-views-of-native-objects.md
@@ -20,10 +20,6 @@ The Visual Studio *Natvis* framework customizes the way native types appear in d
 
 Natvis replaces the *autoexp.dat* file in earlier versions of Visual Studio with XML syntax, better diagnostics, versioning, and multiple file support.  
 
-Natvis does not work for:
-
-- C++ Windows desktop projects with **Debugger Type** set to **Mixed** under **Configuration Properties** > **Debugging**. 
-- [Mixed-mode debugging](how-to-debug-in-mixed-mode.md) for Windows desktop apps in managed compatibility mode (**Tools** > **Options** > **Debugging** > **General** > **Use Managed Compatibility Mode**).
 
 ## <a name="BKMK_Why_create_visualizations_"></a>Natvis visualizations
 


### PR DESCRIPTION
The natvis page had a note at the top which was from the Visual Studio 2012 days when Concord was only used as the native engine for select scenarios. As of VS 2017, the old native engine doesn't even exist in the product, so this can just be removed.
