### PR TITLE
Remove extra word "do" in diag. UI delays doc

### DIFF
--- a/docs/extensibility/how-to-diagnose-ui-delays-caused-by-extensions.md
+++ b/docs/extensibility/how-to-diagnose-ui-delays-caused-by-extensions.md
@@ -33,7 +33,7 @@ In the following sections, we will go through these steps in more detail.
 
 ## Identify the trigger scenario
 
-To do diagnose a UI delay, you first need to identify what (sequence of actions) causes Visual Studio to show the notification. This is in order for you to able to trigger the notification later with logging turned on.
+To diagnose a UI delay, you first need to identify what (sequence of actions) causes Visual Studio to show the notification. This is in order for you to able to trigger the notification later with logging turned on.
 
 ## Restart VS with activity logging on
 


### PR DESCRIPTION
Removing the extra word ("do") in how-to-diagnose-ui-delays-caused-by-extensions.md.

