### PR TITLE
Used autoproperties in Task writing

### DIFF
--- a/docs/msbuild/codesnippet/CSharp/task-writing_1.cs
+++ b/docs/msbuild/codesnippet/CSharp/task-writing_1.cs
@@ -6,29 +6,17 @@ namespace SimpleTask3
 {
 	public class SimpleTask3 : Task
 	{
-		private string myProperty;
-
 		// The [Required] attribute indicates a required property.
 		// If a project file invokes this task without passing a value
 		// to this property, the build will fail immediately.
 		[Required]
-		public string MyProperty
-		{
-			get
-			{
-				return myProperty;
-			}
-			set
-			{
-				myProperty = value;
-			}
-		}
+		public string MyProperty { get; set; }
 
 		public override bool Execute()
 		{
 			// Log a high-importance comment
 			Log.LogMessage(MessageImportance.High,
-				"The task was passed \"" + myProperty + "\".");
+				"The task was passed \"" + MyProperty + "\".");
 			return true;
 		}
 	}

--- a/docs/msbuild/task-writing.md
+++ b/docs/msbuild/task-writing.md
@@ -68,14 +68,9 @@ namespace MyTasks
         public override bool Execute()  
         {  
             return true;  
-         }  
-  
-        private string myProperty;  
-        public string MyProperty  
-        {  
-            get { return myProperty; }  
-            set { myProperty = value; }  
         }  
+  
+        public string MyProperty { get; set; }
     }  
 }  
 ```  
@@ -116,12 +111,7 @@ public override bool Execute()
 ```csharp
 public class SimpleTask : ITask  
 {  
-    private IBuildEngine buildEngine;  
-    public IBuildEngine BuildEngine  
-    {  
-        get{ return buildEngine; }  
-        set{ buildEngine = value; }  
-    }  
+    public IBuildEngine BuildEngine { get; set; }
   
     public override bool Execute()  
     {  
@@ -139,14 +129,8 @@ public class SimpleTask : ITask
  You can mark certain task properties as "required" so that any project file that runs the task must set values for these properties or the build fails. Apply the `[Required]` attribute to the .NET property in your task as follows:  
   
 ```csharp
-private string requiredProperty;  
-  
 [Required]  
-public string RequiredProperty  
-{  
-    get { return requiredProperty; }  
-    set { requiredProperty = value; }  
-}  
+public string RequiredProperty { get; set; }
 ```  
   
  The `[Required]` attribute is defined by <xref:Microsoft.Build.Framework.RequiredAttribute> in the <xref:Microsoft.Build.Framework> namespace.  
@@ -194,35 +178,12 @@ namespace SimpleTask2
         //implement a BuildEngine property of type  
         //Microsoft.Build.Framework.IBuildEngine. This is done for  
         //you if you derive from the Task class.  
-        private IBuildEngine buildEngine;  
-        public IBuildEngine BuildEngine  
-        {  
-            get  
-            {  
-                return buildEngine;  
-            }  
-            set  
-            {  
-                buildEngine = value;  
-            }  
-         }  
+        public IBuildEngine BuildEngine { get; set; }
   
         // When implementing the ITask interface, it is necessary to  
-        // implement a HostObject property of type Object.  
+        // implement a HostObject property of type object.  
         // This is done for you if you derive from the Task class.  
-        private Object hostObject;  
-        public Object HostObject  
-        {  
-            get  
-            {  
-                return hostObject;  
-            }  
-  
-            set  
-            {  
-                hostObject = value;  
-            }  
-        }  
+        public object HostObject { get; set; }
   
         public bool Execute()  
         {  


### PR DESCRIPTION
Changed properties to autoproperties to make the code simpler and shorter.

Also changed `Object` to `object` to improve consistency.