### PR TITLE
Fix `GetHostPid` sample code

### DIFF
--- a/docs/extensibility/debugger/reference/idebugprogramnode2-gethostpid.md
+++ b/docs/extensibility/debugger/reference/idebugprogramnode2-gethostpid.md
@@ -41,17 +41,15 @@ int GetHostPid ( 
  The following example shows how to implement this method for a simple `CProgram` object that implements the [IDebugProgramNode2](../../../extensibility/debugger/reference/idebugprogramnode2.md) interface.  
   
 ```cpp  
-HRESULT CProgram::GetHostPid(DWORD* pdwHostPid) {    
-    // Check for valid argument.    
-   if (pdwHostPid)    
-    {    
-        // Get the process identifier of the calling process.    
-      *pdwHostPid = GetCurrentProcessId();    
-  
-        return S_OK;    
-    }    
-  
-    return E_INVALIDARG;    
+HRESULT CProgram::GetHostPid(AD_PROCESS_ID* pdwHostPid) {
+   // Check for valid argument.
+   if (pdwHostPid == NULL)
+     return E_INVALIDARG;
+
+   // Get the process identifier of the calling process.
+   pdwHostPid->ProcessIdType = AD_PROCESS_ID_SYSTEM;
+   pdwHostPid->ProcessId.dwProcessId = GetCurrentProcessId();
+   return S_OK; 
 }    
 ```  
   


### PR DESCRIPTION
Update the `GetHostPid` function sample code.

- fix the signature, the parameter type is `AD_PROCESS_ID *`, not `DWORD *`
- use an early return to reduce indentation
- fill in the out parameter with the appropriate fields