### PR TITLE
Remove 'stopping event' from Load Complete Event

### DIFF
--- a/docs/extensibility/debugger/reference/idebugloadcompleteevent2.md
+++ b/docs/extensibility/debugger/reference/idebugloadcompleteevent2.md
@@ -27,10 +27,7 @@ IDebugLoadCompleteEvent2 : IUnknown
   
 ## Notes for Callers  
  The DE creates and sends this event object to report that a program has been successfully loaded. The event is sent by using the [IDebugEventCallback2](../../../extensibility/debugger/reference/idebugeventcallback2.md) callback function that is supplied by the SDM when it attached to the program being debugged.  
-  
-## Remarks  
- This event is a stopping event and must have the `EVENT_STOPPING` flag set on the event attributes.  
-  
+   
 ## Requirements  
  Header: msdbg.h  
   


### PR DESCRIPTION
The documentation for IDebugLoadCompleteEvent2 indicated that load complete must be a stopping event. While it is allowed for load complete to be a stopping event, there isn't really a reason to do so aside from that fact that this is one way that a debug engine author might want to make sure that they don't continue execution until after the initial set of breakpoints/exception settings are received from the UI. But there are other approaches to this as well, and none of the recent Microsoft-implemented debug engines have done things that way. So this removes the remark.

(You can replace all of this text with your description.)

Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for docs.microsoft.com, see the contributor guide at https://docs.microsoft.com/contribute/.
