### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/msbuild/how-to-escape-special-characters-in-msbuild.md
+++ b/docs/msbuild/how-to-escape-special-characters-in-msbuild.md
@@ -2,7 +2,7 @@
 title: "How to: Escape Special Characters in MSBuild | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "special characters, escaping"
   - "characters, escapes"
   - "escape characters"
@@ -11,28 +11,28 @@ ms.assetid: 1aa3669c-1647-4960-b770-752e2532102f
 author: mikejo5000
 ms.author: mikejo
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "multiple"
 ---
 # How to: Escape special characters in MSBuild
 
 Certain characters have special meaning in [!INCLUDE[vstecmsbuild](../extensibility/internals/includes/vstecmsbuild_md.md)] project files. Examples of the characters include semicolons (`;`) and asterisks (`*`). For a complete list of these special characters, see [MSBuild special characters](../msbuild/msbuild-special-characters.md).
-  
+
 In order to use these special characters as literals in a project file, they must be specified by using the syntax `%<xx>`, where `<xx>` represents the ASCII hexadecimal value of the character.
-  
+
 ## MSBuild special characters
 
- One example of where special characters are used is in the `Include` attribute of item lists. For example, the following item list declares two items: *MyFile.cs* and *MyClass.cs*.  
-  
-```xml  
-<Compile Include="MyFile.cs;MyClass.cs"/>  
-```  
-  
+One example of where special characters are used is in the `Include` attribute of item lists. For example, the following item list declares two items: *MyFile.cs* and *MyClass.cs*.
+
+```xml
+<Compile Include="MyFile.cs;MyClass.cs"/>
+```
+
 If you want to declare an item that contains a semicolon in the name, you must use the `%<xx>` syntax to escape the semicolon and prevent [!INCLUDE[vstecmsbuild](../extensibility/internals/includes/vstecmsbuild_md.md)] from declaring two separate items. For example, the following item escapes the semicolon and declares one item named `MyFile.cs;MyClass.cs`.
-  
-```xml  
-<Compile Include="MyFile.cs%3BMyClass.cs"/>  
-```  
+
+```xml
+<Compile Include="MyFile.cs%3BMyClass.cs"/>
+```
 
 You can also use a [property function](../msbuild/property-functions.md) to escape strings. For example, this is equivalent to the example above.
 
@@ -44,8 +44,7 @@ You can also use a [property function](../msbuild/property-functions.md) to esca
 
 Use the notation `%<xx>` in place of the special character, where `<xx>` represents the hexadecimal value of the ASCII character. For example, to use an asterisk (`*`) as a literal character, use the value `%2A`.
 
- 
-## See also  
- [MSBuild concepts](../msbuild/msbuild-concepts.md)   
- [MSBuild](../msbuild/msbuild.md)   
- [Items](../msbuild/msbuild-items.md)   
+## See also
+[MSBuild concepts](../msbuild/msbuild-concepts.md)  
+[MSBuild](../msbuild/msbuild.md)  
+[Items](../msbuild/msbuild-items.md)


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.