### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/msbuild/mergelocalizationdirectives-task.md
+++ b/docs/msbuild/mergelocalizationdirectives-task.md
@@ -2,12 +2,12 @@
 title: "MergeLocalizationDirectives Task | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "reference"
-dev_langs: 
+dev_langs:
   - "VB"
   - "CSharp"
   - "C++"
   - "jsharp"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "localizing XAML [WPF MSBuild], moving comments and attributes to a separate file"
   - "MergeLocalizationDirectives task [WPF MSBuild], parameters"
   - "MergeLocalizationDirectives task [WPF MSBuild]"
@@ -16,39 +16,39 @@ ms.assetid: 9095b4f1-88da-4194-914b-ee1456826830
 author: mikejo5000
 ms.author: mikejo
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "multiple"
 ---
 # MergeLocalizationDirectives task
-The <xref:Microsoft.Build.Tasks.Windows.MergeLocalizationDirectives> task merges the localization attributes and comments of one or more [!INCLUDE[TLA2#tla_xaml](../msbuild/includes/tla2sharptla_xaml_md.md)] binary format files into a single file for the whole assembly.  
-  
-## Task parameters  
-  
+The <xref:Microsoft.Build.Tasks.Windows.MergeLocalizationDirectives> task merges the localization attributes and comments of one or more [!INCLUDE[TLA2#tla_xaml](../msbuild/includes/tla2sharptla_xaml_md.md)] binary format files into a single file for the whole assembly.
+
+## Task parameters
+
 | Parameter | Description |
 |------------------------------| - |
 | `GeneratedLocalizationFiles` | Required **ITaskItem[]** parameter.<br /><br /> Specifies the list of localization directives files for individual files in [!INCLUDE[TLA2#tla_xaml](../msbuild/includes/tla2sharptla_xaml_md.md)] binary format. |
 | `OutputFile` | Required **String** output parameter.<br /><br /> Specifies the output path of the compiled localization-directives assembly. |
-  
-## Remarks  
- You can add localization attributes and comments to [!INCLUDE[TLA#tla_xaml](../msbuild/includes/tlasharptla_xaml_md.md)] content. With [!INCLUDE[TLA#tla_wpf](../msbuild/includes/tlasharptla_wpf_md.md)] localization support, you can strip out localization attributes and comments, and put them in a *.loc* file that is separate from the generated assembly. You can do this by using the **LocalizationPropertyStorage** attribute. For more information about localization attributes and comments, and **LocalizationPropertyStorage**, see [Localization attributes and comments](/dotnet/framework/wpf/advanced/localization-attributes-and-comments).  
-  
-## Example  
- The following example merges the localization comments of several [!INCLUDE[TLA2#tla_xaml](../msbuild/includes/tla2sharptla_xaml_md.md)] binary format files into a single *.loc* file.  
-  
-```xml  
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">  
-  <UsingTask   
-    TaskName="Microsoft.Build.Tasks.Windows.MergeLocalizationDirectives"   
-    AssemblyFile="C:\Program Files\Reference Assemblies\Microsoft\Framework\v3.0\PresentationBuildTasks.dll" />  
-  <Target Name="MergeLocalizationDirectivesTask">  
-    <MergeLocalizationDirectives   
-      GeneratedLocalizationFiles="obj\debug\page1.loc;obj\debug\page2.loc;obj\debug\page3.loc"  
-      OutputFile="obj\debug\WPFMSBuildSample.loc" />  
-  </Target>  
-</Project>  
-```  
-  
-## See also  
+
+## Remarks
+You can add localization attributes and comments to [!INCLUDE[TLA#tla_xaml](../msbuild/includes/tlasharptla_xaml_md.md)] content. With [!INCLUDE[TLA#tla_wpf](../msbuild/includes/tlasharptla_wpf_md.md)] localization support, you can strip out localization attributes and comments, and put them in a *.loc* file that is separate from the generated assembly. You can do this by using the **LocalizationPropertyStorage** attribute. For more information about localization attributes and comments, and **LocalizationPropertyStorage**, see [Localization attributes and comments](/dotnet/framework/wpf/advanced/localization-attributes-and-comments).
+
+## Example
+The following example merges the localization comments of several [!INCLUDE[TLA2#tla_xaml](../msbuild/includes/tla2sharptla_xaml_md.md)] binary format files into a single *.loc* file.
+
+```xml
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <UsingTask
+    TaskName="Microsoft.Build.Tasks.Windows.MergeLocalizationDirectives"
+    AssemblyFile="C:\Program Files\Reference Assemblies\Microsoft\Framework\v3.0\PresentationBuildTasks.dll" />
+  <Target Name="MergeLocalizationDirectivesTask">
+    <MergeLocalizationDirectives
+      GeneratedLocalizationFiles="obj\debug\page1.loc;obj\debug\page2.loc;obj\debug\page3.loc"
+      OutputFile="obj\debug\WPFMSBuildSample.loc" />
+  </Target>
+</Project>
+```
+
+## See also
 [WPF MSBuild reference](../msbuild/wpf-msbuild-reference.md)  
 [WPF MSBuild task reference](../msbuild/wpf-msbuild-task-reference.md)  
 [MSBuild reference](../msbuild/msbuild-reference.md)  


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.