### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/debugger/debug-interface-access/idiaenumdebugstreamdata.md
+++ b/docs/debugger/debug-interface-access/idiaenumdebugstreamdata.md
@@ -2,108 +2,108 @@
 title: "IDiaEnumDebugStreamData | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-dev_langs: 
+dev_langs:
   - "C++"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "IDiaEnumDebugStreamData interface"
 ms.assetid: e2023c32-4c05-4d0c-a0be-f016a230c788
 author: "mikejo5000"
 ms.author: "mikejo"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "multiple"
 ---
 # IDiaEnumDebugStreamData
-Provides access to the records in a debug data stream.  
-  
-## Syntax  
-  
-```  
-IDiaEnumDebugStreamData : IUnknown  
-```  
-  
-## Methods in Vtable Order  
- The following table shows the methods of `IDiaEnumDebugStreamData`.  
-  
-|Method|Description|  
-|------------|-----------------|  
-|[IDiaEnumDebugStreamData::get__NewEnum](../../debugger/debug-interface-access/idiaenumdebugstreamdata-get-newenum.md)|Retrieves the [IEnumVARIANT Interface](/previous-versions/windows/desktop/api/oaidl/nn-oaidl-ienumvariant) version of this enumerator.|  
-|[IDiaEnumDebugStreamData::get_Count](../../debugger/debug-interface-access/idiaenumdebugstreamdata-get-count.md)|Retrieves the number of records in the debug data stream.|  
-|[IDiaEnumDebugStreamData::get_name](../../debugger/debug-interface-access/idiaenumdebugstreamdata-get-name.md)|Retrieves the name of the debug data stream.|  
-|[IDiaEnumDebugStreamData::Item](../../debugger/debug-interface-access/idiaenumdebugstreamdata-item.md)|Retrieves the specified record.|  
-|[IDiaEnumDebugStreamData::Next](../../debugger/debug-interface-access/idiaenumdebugstreamdata-next.md)|Retrieves the specified number of records  from the enumerated sequence.|  
-|[IDiaEnumDebugStreamData::Skip](../../debugger/debug-interface-access/idiaenumdebugstreamdata-skip.md)|Skips a specified number of records in an enumerated sequence.|  
-|[IDiaEnumDebugStreamData::Reset](../../debugger/debug-interface-access/idiaenumdebugstreamdata-reset.md)|Resets the enumerated sequence to the beginning.|  
-|[IDiaEnumDebugStreamData::Clone](../../debugger/debug-interface-access/idiaenumdebugstreamdata-clone.md)|Creates an enumerator that contains the same enumerated sequence as the current enumerator.|  
-  
-## Remarks  
- This interface represents a stream of records in a debug data stream. The size and interpretation of each record is dependent on the data stream the record comes from. This interface effectively provides access to the raw data bytes in the symbol file.  
-  
-## Notes for Callers  
- Call the [IDiaEnumDebugStreams::Item](../../debugger/debug-interface-access/idiaenumdebugstreams-item.md) or [IDiaEnumDebugStreams::Next](../../debugger/debug-interface-access/idiaenumdebugstreams-next.md) methods to obtain an `IDiaEnumDebugStreamData` object.  
-  
-## Example  
- This example shows how to access a single data stream and its records.  
-  
-```C++  
-void PrintStreamData(IDiaEnumDebugStreamData* pStream)  
-{  
-    BSTR  wszName;  
-    LONG  dwElem;  
-    ULONG celt    = 0;  
-    DWORD cbData;  
-    DWORD cbTotal = 0;  
-    BYTE  data[1024];  
-  
-    if(pStream->get_name(&wszName) != S_OK)  
-    {  
-        wprintf_s(L"ERROR - PrintStreamData() get_name\n");  
-    }  
-    else  
-    {  
-        wprintf_s(L"Stream: %s", wszName);  
-        SysFreeString(wszName);  
-    }  
-    if(pStream->get_Count(&dwElem) != S_OK)  
-    {  
-        wprintf(L"ERROR - PrintStreamData() get_Count\n");  
-    }  
-    else  
-    {  
-        wprintf(L"(%d)\n", dwElem);  
-    }  
-    while(pStream->Next(1, sizeof(data), &cbData, (BYTE *)&data, &celt) == S_OK)  
-    {  
-        DWORD i;  
-        for (i = 0; i < cbData; i++)  
-        {  
-            wprintf(L"%02X ", data[i]);  
-            if(i && i % 8 == 7 && i+1 < cbData)  
-            {  
-                wprintf(L"- ");  
-            }  
-        }  
-        wprintf(L"| ");  
-        for(i = 0; i < cbData; i++)  
-        {  
-            wprintf(L"%c", iswprint(data[i]) ? data[i] : '.');  
-        }  
-        wprintf(L"\n");  
-        cbTotal += cbData;  
-    }  
-    wprintf(L"Summary :\n\tSizeof(Elem) = %d\n\tNo of Elems = %d\n\n",  
-            cbTotal/dwElem, dwElem);  
-}  
-```  
-  
-## Requirements  
- Header: Dia2.h  
-  
- Library: diaguids.lib  
-  
- DLL: msdia80.dll  
-  
-## See Also  
- [Interfaces (Debug Interface Access SDK)](../../debugger/debug-interface-access/interfaces-debug-interface-access-sdk.md)   
- [IDiaEnumDebugStreams::Item](../../debugger/debug-interface-access/idiaenumdebugstreams-item.md)   
- [IDiaEnumDebugStreams::Next](../../debugger/debug-interface-access/idiaenumdebugstreams-next.md)
+Provides access to the records in a debug data stream.
+
+## Syntax
+
+```
+IDiaEnumDebugStreamData : IUnknown
+```
+
+## Methods in Vtable Order
+The following table shows the methods of `IDiaEnumDebugStreamData`.
+
+|Method|Description|
+|------------|-----------------|
+|[IDiaEnumDebugStreamData::get__NewEnum](../../debugger/debug-interface-access/idiaenumdebugstreamdata-get-newenum.md)|Retrieves the [IEnumVARIANT Interface](/previous-versions/windows/desktop/api/oaidl/nn-oaidl-ienumvariant) version of this enumerator.|
+|[IDiaEnumDebugStreamData::get_Count](../../debugger/debug-interface-access/idiaenumdebugstreamdata-get-count.md)|Retrieves the number of records in the debug data stream.|
+|[IDiaEnumDebugStreamData::get_name](../../debugger/debug-interface-access/idiaenumdebugstreamdata-get-name.md)|Retrieves the name of the debug data stream.|
+|[IDiaEnumDebugStreamData::Item](../../debugger/debug-interface-access/idiaenumdebugstreamdata-item.md)|Retrieves the specified record.|
+|[IDiaEnumDebugStreamData::Next](../../debugger/debug-interface-access/idiaenumdebugstreamdata-next.md)|Retrieves the specified number of records from the enumerated sequence.|
+|[IDiaEnumDebugStreamData::Skip](../../debugger/debug-interface-access/idiaenumdebugstreamdata-skip.md)|Skips a specified number of records in an enumerated sequence.|
+|[IDiaEnumDebugStreamData::Reset](../../debugger/debug-interface-access/idiaenumdebugstreamdata-reset.md)|Resets the enumerated sequence to the beginning.|
+|[IDiaEnumDebugStreamData::Clone](../../debugger/debug-interface-access/idiaenumdebugstreamdata-clone.md)|Creates an enumerator that contains the same enumerated sequence as the current enumerator.|
+
+## Remarks
+This interface represents a stream of records in a debug data stream. The size and interpretation of each record is dependent on the data stream the record comes from. This interface effectively provides access to the raw data bytes in the symbol file.
+
+## Notes for Callers
+Call the [IDiaEnumDebugStreams::Item](../../debugger/debug-interface-access/idiaenumdebugstreams-item.md) or [IDiaEnumDebugStreams::Next](../../debugger/debug-interface-access/idiaenumdebugstreams-next.md) methods to obtain an `IDiaEnumDebugStreamData` object.
+
+## Example
+ This example shows how to access a single data stream and its records.
+
+```C++
+void PrintStreamData(IDiaEnumDebugStreamData* pStream)
+{
+    BSTR  wszName;
+    LONG  dwElem;
+    ULONG celt    = 0;
+    DWORD cbData;
+    DWORD cbTotal = 0;
+    BYTE  data[1024];
+
+    if(pStream->get_name(&wszName) != S_OK)
+    {
+        wprintf_s(L"ERROR - PrintStreamData() get_name\n");
+    }
+    else
+    {
+        wprintf_s(L"Stream: %s", wszName);
+        SysFreeString(wszName);
+    }
+    if(pStream->get_Count(&dwElem) != S_OK)
+    {
+        wprintf(L"ERROR - PrintStreamData() get_Count\n");
+    }
+    else
+    {
+        wprintf(L"(%d)\n", dwElem);
+    }
+    while(pStream->Next(1, sizeof(data), &cbData, (BYTE *)&data, &celt) == S_OK)
+    {
+        DWORD i;
+        for (i = 0; i < cbData; i++)
+        {
+            wprintf(L"%02X ", data[i]);
+            if(i && i % 8 == 7 && i+1 < cbData)
+            {
+                wprintf(L"- ");
+            }
+        }
+        wprintf(L"| ");
+        for(i = 0; i < cbData; i++)
+        {
+            wprintf(L"%c", iswprint(data[i]) ? data[i] : '.');
+        }
+        wprintf(L"\n");
+        cbTotal += cbData;
+    }
+    wprintf(L"Summary :\n\tSizeof(Elem) = %d\n\tNo of Elems = %d\n\n",
+            cbTotal/dwElem, dwElem);
+}
+```
+
+## Requirements
+Header: Dia2.h
+
+Library: diaguids.lib
+
+DLL: msdia80.dll
+
+## See Also
+[Interfaces (Debug Interface Access SDK)](../../debugger/debug-interface-access/interfaces-debug-interface-access-sdk.md)  
+[IDiaEnumDebugStreams::Item](../../debugger/debug-interface-access/idiaenumdebugstreams-item.md)  
+[IDiaEnumDebugStreams::Next](../../debugger/debug-interface-access/idiaenumdebugstreams-next.md)


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.