### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/debugger/debug-interface-access/idiaenumdebugstreams-item.md
+++ b/docs/debugger/debug-interface-access/idiaenumdebugstreams-item.md
@@ -53,7 +53,7 @@ IDiaEnumDebugStreamData *GetStreamData(IDiaEnumDebugStreams *pStreamList,
             vIndex.lVal = whichStream;
             if (pStreamList->Item(vIndex,&pStreamData) != S_OK)
             {
-                 std::cerr << "Error retrieving stream " << whichStream << std::endl;
+                std::cerr << "Error retrieving stream " << whichStream << std::endl;
             }
         }
     }

--- a/docs/debugger/debug-interface-access/idiaenumdebugstreams-item.md
+++ b/docs/debugger/debug-interface-access/idiaenumdebugstreams-item.md
@@ -2,65 +2,65 @@
 title: "IDiaEnumDebugStreams::Item | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-dev_langs: 
+dev_langs:
   - "C++"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "IDiaEnumDebugStreams::Item method"
 ms.assetid: 6b388fe1-eabc-4720-9d59-dc09b0ceaeac
 author: "mikejo5000"
 ms.author: "mikejo"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "multiple"
 ---
 # IDiaEnumDebugStreams::Item
-Retrieves a debug stream by means of an index or name.  
-  
-## Syntax  
-  
-```C++  
-HRESULT Item (   
-   VARIANT                   index,  
-   IDiaEnumDebugStreamData** stream  
-);  
-```  
-  
-#### Parameters  
- index  
- [in] Index or name of the debug stream to be retrieved. If an integer variant is used, it must be in the range 0 to `count`-1, where `count` is as returned by the [IDiaEnumDebugStreams::get_Count](../../debugger/debug-interface-access/idiaenumdebugstreams-get-count.md) method.  
-  
- stream  
- [out] Returns an [IDiaEnumDebugStreamData](../../debugger/debug-interface-access/idiaenumdebugstreamdata.md) object representing the specified debug stream.  
-  
-## Return Value  
- If successful, returns `S_OK`; otherwise, returns an error code.  
-  
-## Example  
-  
-```C++  
-IDiaEnumDebugStreamData *GetStreamData(IDiaEnumDebugStreams *pStreamList,  
-                                       LONG whichStream)  
-{  
-    IDiaEnumDebugStreamData *pStreamData = NULL;  
-    if (pStreamList != NULL)  
-    {  
-        LONG numStreams = 0;  
-        if (pStreamList->get_count(&numStreams) == S_OK &&  
-            whichStream >= 0 && whichStream < numStreams)  
-        {  
-            VARIANT vIndex;  
-            vIndex.vt   = VT_I4;  
-            vIndex.lVal = whichStream;  
-            if (pStreamList->Item(vIndex,&pStreamData) != S_OK)  
-            {  
-                 std::cerr << "Error retrieving stream " << whichStream << std::endl;  
-            }  
-        }  
-    }  
-    return(pStreamData);  
-}  
-```  
-  
-## See Also  
- [IDiaEnumDebugStreamData](../../debugger/debug-interface-access/idiaenumdebugstreamdata.md)   
- [IDiaEnumDebugStreams](../../debugger/debug-interface-access/idiaenumdebugstreams.md)
+Retrieves a debug stream by means of an index or name.
+
+## Syntax
+
+```C++
+HRESULT Item ( 
+   VARIANT                   index,
+   IDiaEnumDebugStreamData** stream
+);
+```
+
+#### Parameters
+index  
+[in] Index or name of the debug stream to be retrieved. If an integer variant is used, it must be in the range 0 to `count`-1, where `count` is as returned by the [IDiaEnumDebugStreams::get_Count](../../debugger/debug-interface-access/idiaenumdebugstreams-get-count.md) method.
+
+stream  
+[out] Returns an [IDiaEnumDebugStreamData](../../debugger/debug-interface-access/idiaenumdebugstreamdata.md) object representing the specified debug stream.
+
+## Return Value
+If successful, returns `S_OK`; otherwise, returns an error code.
+
+## Example
+
+```C++
+IDiaEnumDebugStreamData *GetStreamData(IDiaEnumDebugStreams *pStreamList,
+                                       LONG whichStream)
+{
+    IDiaEnumDebugStreamData *pStreamData = NULL;
+    if (pStreamList != NULL)
+    {
+        LONG numStreams = 0;
+        if (pStreamList->get_count(&numStreams) == S_OK &&
+            whichStream >= 0 && whichStream < numStreams)
+        {
+            VARIANT vIndex;
+            vIndex.vt   = VT_I4;
+            vIndex.lVal = whichStream;
+            if (pStreamList->Item(vIndex,&pStreamData) != S_OK)
+            {
+                 std::cerr << "Error retrieving stream " << whichStream << std::endl;
+            }
+        }
+    }
+    return(pStreamData);
+}
+```
+
+## See Also
+[IDiaEnumDebugStreamData](../../debugger/debug-interface-access/idiaenumdebugstreamdata.md)  
+[IDiaEnumDebugStreams](../../debugger/debug-interface-access/idiaenumdebugstreams.md)


### PR DESCRIPTION
* When copying from the web page, there is an unnecessary space after the code.
* Indentation is misaligned.