### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/debugger/debug-interface-access/idiaenumdebugstreams.md
+++ b/docs/debugger/debug-interface-access/idiaenumdebugstreams.md
@@ -2,83 +2,83 @@
 title: "IDiaEnumDebugStreams | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-dev_langs: 
+dev_langs:
   - "C++"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "IDiaEnumDebugStreams interface"
 ms.assetid: 611caf4f-7a5f-4aa4-b909-52feeb3cc752
 author: "mikejo5000"
 ms.author: "mikejo"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "multiple"
 ---
 # IDiaEnumDebugStreams
-Enumerates the various debug streams contained in the data source.  
-  
-## Syntax  
-  
-```  
-IDiaEnumDebugStreams : IUnknown  
-```  
-  
-## Methods in Vtable Order  
- The following table shows the methods of `IDiaEnumDebugStreams`.  
-  
-|Method|Description|  
-|------------|-----------------|  
-|[IDiaEnumDebugStreams::get__NewEnum](../../debugger/debug-interface-access/idiaenumdebugstreams-get-newenum.md)|Retrieves the `IEnumVARIANT` version of this enumerator.|  
-|[IDiaEnumDebugStreams::get_Count](../../debugger/debug-interface-access/idiaenumdebugstreams-get-count.md)|Retrieves the number of debug streams.|  
-|[IDiaEnumDebugStreams::Item](../../debugger/debug-interface-access/idiaenumdebugstreams-item.md)|Retrieves a debug stream by means of an index.|  
-|[IDiaEnumDebugStreams::Next](../../debugger/debug-interface-access/idiaenumdebugstreams-next.md)|Retrieves a specified number of debug streams in the enumeration sequence.|  
-|[IDiaEnumDebugStreams::Skip](../../debugger/debug-interface-access/idiaenumdebugstreams-skip.md)|Skips a specified number of debug streams in an enumeration sequence.|  
-|[IDiaEnumDebugStreams::Reset](../../debugger/debug-interface-access/idiaenumdebugstreams-reset.md)|Resets an enumeration sequence to the beginning.|  
-|[IDiaEnumDebugStreams::Clone](../../debugger/debug-interface-access/idiaenumdebugstreams-clone.md)|Creates an enumerator that contains the same enumeration state as the current enumerator.|  
-  
-## Remarks  
- The content of debug streams is implementation-dependent and the data formats are undocumented.  
-  
-## Notes for Callers  
- Call the [IDiaSession::getEnumDebugStreams](../../debugger/debug-interface-access/idiasession-getenumdebugstreams.md) method to obtain an `IDiaEnumDebugStreams` object.  
-  
-## Example  
- This example shows how to access the data streams available from this interface. See the [IDiaEnumDebugStreamData](../../debugger/debug-interface-access/idiaenumdebugstreamdata.md) interface for an implementation of the `PrintStreamData` function.  
-  
-```C++  
-void DumpAllDebugStreams( IDiaSession* pSession)  
-{  
-    IDiaEnumDebugStreams* pEnumStreams;  
-  
-    wprintf(L"\n\n*** DEBUG STREAMS\n\n");  
-    // Retrieve an enumerated sequence of debug data streams  
-    if(pSession->getEnumDebugStreams(&pEnumStreams) == S_OK)  
-    {  
-        IDiaEnumDebugStreamData* pStream;  
-        ULONG celt = 0;  
-  
-        for(; pEnumStreams->Next(1, &pStream, &celt) == S_OK; pStream = NULL)  
-        {  
-            PrintStreamData(pStream);  
-            pStream->Release();  
-        }  
-        pEnumStreams->Release();  
-    }  
-    else  
-    {  
-      wprintf(L"Failed to get any debug streams!\n");  
-    }  
-    wprintf(L"\n");  
-}  
-```  
-  
-## Requirements  
- Header: Dia2.h  
-  
- Library: diaguids.lib  
-  
- DLL: msdia80.dll  
-  
-## See Also  
- [Interfaces (Debug Interface Access SDK)](../../debugger/debug-interface-access/interfaces-debug-interface-access-sdk.md)   
- [IDiaEnumDebugStreamData](../../debugger/debug-interface-access/idiaenumdebugstreamdata.md)   
- [IDiaSession::getEnumDebugStreams](../../debugger/debug-interface-access/idiasession-getenumdebugstreams.md)
+Enumerates the various debug streams contained in the data source.
+
+## Syntax
+
+```
+IDiaEnumDebugStreams : IUnknown
+```
+
+## Methods in Vtable Order
+The following table shows the methods of `IDiaEnumDebugStreams`.
+
+|Method|Description|
+|------------|-----------------|
+|[IDiaEnumDebugStreams::get__NewEnum](../../debugger/debug-interface-access/idiaenumdebugstreams-get-newenum.md)|Retrieves the `IEnumVARIANT` version of this enumerator.|
+|[IDiaEnumDebugStreams::get_Count](../../debugger/debug-interface-access/idiaenumdebugstreams-get-count.md)|Retrieves the number of debug streams.|
+|[IDiaEnumDebugStreams::Item](../../debugger/debug-interface-access/idiaenumdebugstreams-item.md)|Retrieves a debug stream by means of an index.|
+|[IDiaEnumDebugStreams::Next](../../debugger/debug-interface-access/idiaenumdebugstreams-next.md)|Retrieves a specified number of debug streams in the enumeration sequence.|
+|[IDiaEnumDebugStreams::Skip](../../debugger/debug-interface-access/idiaenumdebugstreams-skip.md)|Skips a specified number of debug streams in an enumeration sequence.|
+|[IDiaEnumDebugStreams::Reset](../../debugger/debug-interface-access/idiaenumdebugstreams-reset.md)|Resets an enumeration sequence to the beginning.|
+|[IDiaEnumDebugStreams::Clone](../../debugger/debug-interface-access/idiaenumdebugstreams-clone.md)|Creates an enumerator that contains the same enumeration state as the current enumerator.|
+
+## Remarks
+The content of debug streams is implementation-dependent and the data formats are undocumented.
+
+## Notes for Callers
+Call the [IDiaSession::getEnumDebugStreams](../../debugger/debug-interface-access/idiasession-getenumdebugstreams.md) method to obtain an `IDiaEnumDebugStreams` object.
+
+## Example
+This example shows how to access the data streams available from this interface. See the [IDiaEnumDebugStreamData](../../debugger/debug-interface-access/idiaenumdebugstreamdata.md) interface for an implementation of the `PrintStreamData` function.
+
+```C++
+void DumpAllDebugStreams( IDiaSession* pSession)
+{
+    IDiaEnumDebugStreams* pEnumStreams;
+
+    wprintf(L"\n\n*** DEBUG STREAMS\n\n");
+    // Retrieve an enumerated sequence of debug data streams
+    if(pSession->getEnumDebugStreams(&pEnumStreams) == S_OK)
+    {
+        IDiaEnumDebugStreamData* pStream;
+        ULONG celt = 0;
+
+        for(; pEnumStreams->Next(1, &pStream, &celt) == S_OK; pStream = NULL)
+        {
+            PrintStreamData(pStream);
+            pStream->Release();
+        }
+        pEnumStreams->Release();
+    }
+    else
+    {
+      wprintf(L"Failed to get any debug streams!\n");
+    }
+    wprintf(L"\n");
+}
+```
+
+## Requirements
+Header: Dia2.h
+
+Library: diaguids.lib
+
+DLL: msdia80.dll
+
+## See Also
+[Interfaces (Debug Interface Access SDK)](../../debugger/debug-interface-access/interfaces-debug-interface-access-sdk.md)  
+[IDiaEnumDebugStreamData](../../debugger/debug-interface-access/idiaenumdebugstreamdata.md)  
+[IDiaSession::getEnumDebugStreams](../../debugger/debug-interface-access/idiasession-getenumdebugstreams.md)

--- a/docs/debugger/debug-interface-access/idiaenumdebugstreams.md
+++ b/docs/debugger/debug-interface-access/idiaenumdebugstreams.md
@@ -65,7 +65,7 @@ void DumpAllDebugStreams( IDiaSession* pSession)
     }
     else
     {
-      wprintf(L"Failed to get any debug streams!\n");
+        wprintf(L"Failed to get any debug streams!\n");
     }
     wprintf(L"\n");
 }


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.