### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/debugger/debug-interface-access/idiaenumlinenumbers.md
+++ b/docs/debugger/debug-interface-access/idiaenumlinenumbers.md
@@ -2,95 +2,95 @@
 title: "IDiaEnumLineNumbers | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-dev_langs: 
+dev_langs:
   - "C++"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "IDiaEnumLineNumbers interface"
 ms.assetid: cdf07b4f-19e4-4dcd-8af8-c2dbca586a7c
 author: "mikejo5000"
 ms.author: "mikejo"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "multiple"
 ---
 # IDiaEnumLineNumbers
-Enumerates the various line numbers contained in the data source.  
-  
-## Syntax  
-  
-```  
-IDiaEnumLineNumbers : IUnknown  
-```  
-  
-## Methods in Vtable Order  
- The following table shows the methods of `IDiaEnumLineNumbers`.  
-  
-|Method|Description|  
-|------------|-----------------|  
-|[IDiaEnumLineNumbers::get__NewEnum](../../debugger/debug-interface-access/idiaenumlinenumbers-get-newenum.md)|Retrieves the [IEnumVARIANT Interface](/previous-versions/windows/desktop/api/oaidl/nn-oaidl-ienumvariant) version of this enumerator.|  
-|[IDiaEnumLineNumbers::get_Count](../../debugger/debug-interface-access/idiaenumlinenumbers-get-count.md)|Retrieves the number of line numbers.|  
-|[IDiaEnumLineNumbers::Item](../../debugger/debug-interface-access/idiaenumlinenumbers-item.md)|Retrieves a line number by means of an index.|  
-|[IDiaEnumLineNumbers::Next](../../debugger/debug-interface-access/idiaenumlinenumbers-next.md)|Retrieves a specified number of line numbers in the enumeration sequence.|  
-|[IDiaEnumLineNumbers::Skip](../../debugger/debug-interface-access/idiaenumlinenumbers-skip.md)|Skips a specified number of line numbers in an enumeration sequence.|  
-|[IDiaEnumLineNumbers::Reset](../../debugger/debug-interface-access/idiaenumlinenumbers-reset.md)|Resets an enumeration sequence to the beginning.|  
-|[IDiaEnumLineNumbers::Clone](../../debugger/debug-interface-access/idiaenumlinenumbers-clone.md)|Creates an enumerator that contains the same enumeration state as the current enumerator.|  
-  
-## Remarks  
-  
-## Notes for Callers  
- This interface is obtained by calling one of the following methods in the [IDiaSession](../../debugger/debug-interface-access/idiasession.md) interface:  
-  
--   [IDiaSession::findLines](../../debugger/debug-interface-access/idiasession-findlines.md)  
-  
--   [IDiaSession::findLinesByAddr](../../debugger/debug-interface-access/idiasession-findlinesbyaddr.md)  
-  
--   [IDiaSession::findLinesByRVA](../../debugger/debug-interface-access/idiasession-findlinesbyrva.md)  
-  
--   [IDiaSession::findLinesByVA](../../debugger/debug-interface-access/idiasession-findlinesbyva.md)  
-  
--   [IDiaSession::findLinesByLinenum](../../debugger/debug-interface-access/idiasession-findlinesbylinenum.md)  
-  
-## Example  
- This example shows how to obtain the `IDiaEnumLineNumbers` interface from a session. In this case, the example shows how to get the line number enumeration for a function (represented by `pSymbol`). For a more complete example of using line numbers, see the [IDiaLineNumber](../../debugger/debug-interface-access/idialinenumber.md) interface.  
-  
-```C++  
-void dumpFunctionLines( IDiaSymbol* pSymbol, IDiaSession* pSession )  
-{  
-    ULONGLONG length = 0;  
-    DWORD isect = 0;  
-    DWORD offset = 0;  
-    pSymbol->get_addressSection( &isect );  
-    pSymbol->get_addressOffset( &offset );  
-    pSymbol->get_length( &length );  
-    if ( isect != 0 && length > 0 )  
-    {  
-        CComPtr< IDiaEnumLineNumbers > pLines;  
-        if ( SUCCEEDED( pSession->findLinesByAddr(  
-                                      isect,  
-                                      offset,  
-                                      static_cast<DWORD>( length ),  
-                                      &pLines )  
-                      )  
-           )  
-        {  
-            // Do something with the enumeration  
-        }  
-    }  
-}  
-```  
-  
-## Requirements  
- Header: Dia2.h  
-  
- Library: diaguids.lib  
-  
- DLL: msdia80.dll  
-  
-## See Also  
- [Interfaces (Debug Interface Access SDK)](../../debugger/debug-interface-access/interfaces-debug-interface-access-sdk.md)   
- [IDiaSession](../../debugger/debug-interface-access/idiasession.md)   
- [IDiaSession::findLinesByLinenum](../../debugger/debug-interface-access/idiasession-findlinesbylinenum.md)   
- [IDiaSession::findLinesByRVA](../../debugger/debug-interface-access/idiasession-findlinesbyrva.md)   
- [IDiaSession::findLinesByVA](../../debugger/debug-interface-access/idiasession-findlinesbyva.md)   
- [IDiaSession::findLines](../../debugger/debug-interface-access/idiasession-findlines.md)   
- [IDiaSession::findLinesByAddr](../../debugger/debug-interface-access/idiasession-findlinesbyaddr.md)
+Enumerates the various line numbers contained in the data source.
+
+## Syntax
+
+```
+IDiaEnumLineNumbers : IUnknown
+```
+
+## Methods in Vtable Order
+The following table shows the methods of `IDiaEnumLineNumbers`.
+
+|Method|Description|
+|------------|-----------------|
+|[IDiaEnumLineNumbers::get__NewEnum](../../debugger/debug-interface-access/idiaenumlinenumbers-get-newenum.md)|Retrieves the [IEnumVARIANT Interface](/previous-versions/windows/desktop/api/oaidl/nn-oaidl-ienumvariant) version of this enumerator.|
+|[IDiaEnumLineNumbers::get_Count](../../debugger/debug-interface-access/idiaenumlinenumbers-get-count.md)|Retrieves the number of line numbers.|
+|[IDiaEnumLineNumbers::Item](../../debugger/debug-interface-access/idiaenumlinenumbers-item.md)|Retrieves a line number by means of an index.|
+|[IDiaEnumLineNumbers::Next](../../debugger/debug-interface-access/idiaenumlinenumbers-next.md)|Retrieves a specified number of line numbers in the enumeration sequence.|
+|[IDiaEnumLineNumbers::Skip](../../debugger/debug-interface-access/idiaenumlinenumbers-skip.md)|Skips a specified number of line numbers in an enumeration sequence.|
+|[IDiaEnumLineNumbers::Reset](../../debugger/debug-interface-access/idiaenumlinenumbers-reset.md)|Resets an enumeration sequence to the beginning.|
+|[IDiaEnumLineNumbers::Clone](../../debugger/debug-interface-access/idiaenumlinenumbers-clone.md)|Creates an enumerator that contains the same enumeration state as the current enumerator.|
+
+## Remarks
+
+## Notes for Callers
+This interface is obtained by calling one of the following methods in the [IDiaSession](../../debugger/debug-interface-access/idiasession.md) interface:
+
+- [IDiaSession::findLines](../../debugger/debug-interface-access/idiasession-findlines.md)
+
+- [IDiaSession::findLinesByAddr](../../debugger/debug-interface-access/idiasession-findlinesbyaddr.md)
+
+- [IDiaSession::findLinesByRVA](../../debugger/debug-interface-access/idiasession-findlinesbyrva.md)
+
+- [IDiaSession::findLinesByVA](../../debugger/debug-interface-access/idiasession-findlinesbyva.md)
+
+- [IDiaSession::findLinesByLinenum](../../debugger/debug-interface-access/idiasession-findlinesbylinenum.md)
+
+## Example
+This example shows how to obtain the `IDiaEnumLineNumbers` interface from a session. In this case, the example shows how to get the line number enumeration for a function (represented by `pSymbol`). For a more complete example of using line numbers, see the [IDiaLineNumber](../../debugger/debug-interface-access/idialinenumber.md) interface.
+
+```C++
+void dumpFunctionLines( IDiaSymbol* pSymbol, IDiaSession* pSession )
+{
+    ULONGLONG length = 0;
+    DWORD isect = 0;
+    DWORD offset = 0;
+    pSymbol->get_addressSection( &isect );
+    pSymbol->get_addressOffset( &offset );
+    pSymbol->get_length( &length );
+    if ( isect != 0 && length > 0 )
+    {
+        CComPtr< IDiaEnumLineNumbers > pLines;
+        if ( SUCCEEDED( pSession->findLinesByAddr(
+                                      isect,
+                                      offset,
+                                      static_cast<DWORD>( length ),
+                                      &pLines )
+                      )
+           )
+        {
+            // Do something with the enumeration
+        }
+    }
+}
+```
+
+## Requirements
+Header: Dia2.h
+
+Library: diaguids.lib
+
+DLL: msdia80.dll
+
+## See Also
+[Interfaces (Debug Interface Access SDK)](../../debugger/debug-interface-access/interfaces-debug-interface-access-sdk.md)  
+[IDiaSession](../../debugger/debug-interface-access/idiasession.md)  
+[IDiaSession::findLinesByLinenum](../../debugger/debug-interface-access/idiasession-findlinesbylinenum.md)  
+[IDiaSession::findLinesByRVA](../../debugger/debug-interface-access/idiasession-findlinesbyrva.md)  
+[IDiaSession::findLinesByVA](../../debugger/debug-interface-access/idiasession-findlinesbyva.md)  
+[IDiaSession::findLines](../../debugger/debug-interface-access/idiasession-findlines.md)  
+[IDiaSession::findLinesByAddr](../../debugger/debug-interface-access/idiasession-findlinesbyaddr.md)


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.