### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/debugger/debug-interface-access/idiaenumsectioncontribs.md
+++ b/docs/debugger/debug-interface-access/idiaenumsectioncontribs.md
@@ -2,105 +2,105 @@
 title: "IDiaEnumSectionContribs | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-dev_langs: 
+dev_langs:
   - "C++"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "IDiaEnumSectionContribs interface"
 ms.assetid: 0d6c0632-310f-4a99-8921-58149a1817e3
 author: "mikejo5000"
 ms.author: "mikejo"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "multiple"
 ---
 # IDiaEnumSectionContribs
-Enumerates the various section contributions contained in the data source.  
-  
-## Syntax  
-  
-```  
-IDiaEnumSectionContribs : IUnknown  
-```  
-  
-## Methods in Vtable Order  
- The following table shows the methods of `IDiaEnumSectionContribs`.  
-  
-|Method|Description|  
-|------------|-----------------|  
-|[IDiaEnumSectionContribs::get__NewEnum](../../debugger/debug-interface-access/idiaenumsectioncontribs-get-newenum.md)|Retrieves the [IEnumVARIANT Interface](/previous-versions/windows/desktop/api/oaidl/nn-oaidl-ienumvariant) version of this enumerator.|  
-|[IDiaEnumSectionContribs::get_Count](../../debugger/debug-interface-access/idiaenumsectioncontribs-get-count.md)|Retrieves the number of section contributions.|  
-|[IDiaEnumSectionContribs::Item](../../debugger/debug-interface-access/idiaenumsectioncontribs-item.md)|Retrieves section contributions by means of an index.|  
-|[IDiaEnumSectionContribs::Next](../../debugger/debug-interface-access/idiaenumsectioncontribs-next.md)|Retrieves a specified number of section contributions in the enumeration sequence.|  
-|[IDiaEnumSectionContribs::Skip](../../debugger/debug-interface-access/idiaenumsectioncontribs-skip.md)|Skips a specified number of section contributions in an enumeration sequence.|  
-|[IDiaEnumSectionContribs::Reset](../../debugger/debug-interface-access/idiaenumsectioncontribs-reset.md)|Resets an enumeration sequence to the beginning.|  
-|[IDiaEnumSectionContribs::Clone](../../debugger/debug-interface-access/idiaenumsectioncontribs-clone.md)|Creates an enumerator that contains the same enumeration state as the current enumerator.|  
-  
-## Remarks  
-  
-## Note for Callers  
- Obtain this interface from the [IDiaSession::getEnumTables](../../debugger/debug-interface-access/idiasession-getenumtables.md) method. See the example for details.  
-  
-## Example  
- This example shows how to obtain (the `GetEnumSectionContribs` function) and use (the `ShowSectionContribs` function) the `IDiaEnumSectionContribs` interface. For a more complete example of using section contributions, see the [IDiaSectionContrib](../../debugger/debug-interface-access/idiasectioncontrib.md) interface.  
-  
-```C++  
-  
-      IDiaEnumSectionContribs* GetEnumSectionContribs(IDiaSession *pSession)  
-{  
-    IDiaEnumSectionContribs* pUnknown    = NULL;  
-    REFIID                   iid         = __uuidof(IDiaEnumSectionContribs);  
-    IDiaEnumTables*          pEnumTables = NULL;  
-    IDiaTable*               pTable      = NULL;  
-    ULONG                    celt        = 0;  
-  
-    if (pSession->getEnumTables(&pEnumTables) != S_OK)  
-    {  
-        wprintf(L"ERROR - GetTable() getEnumTables\n");  
-        return NULL;  
-    }  
-    while (pEnumTables->Next(1, &pTable, &celt) == S_OK && celt == 1)  
-    {  
-        // There is only one table that matches the given iid  
-        HRESULT hr = pTable->QueryInterface(iid, (void**)&pUnknown);  
-        pTable->Release();  
-        if (hr == S_OK)  
-        {  
-            break;  
-        }  
-    }  
-    pEnumTables->Release();  
-    return pUnknown;  
-}  
-  
-void ShowSectionContribs(IDiaSession *pSession)  
-{  
-    IDiaEnumSectionContribs* pEnumSectionContribs;  
-  
-    pEnumSectionContribs = GetEnumSectionContribs(pSession);  
-    if (pSectionContrib != NULL)  
-    {  
-        IDiaSectionContrib* pSectionContrib;  
-        ULONG celt = 0;  
-  
-        while(pEnumSectionContribs->Next(1, &pSectionContrib, &celt) == S_OK &&  
-              celt == 1)  
-        {  
-            PrintSectionContrib(pSectionContrib, pSession);  
-            pSectionContrib->Release();  
-        }  
-        pSectionContrib->Release();   
-    }  
-}  
-```  
-  
-## Requirements  
- Header: Dia2.h  
-  
- Library: diaguids.lib  
-  
- DLL: msdia80.dll  
-  
-## See Also  
- [Interfaces (Debug Interface Access SDK)](../../debugger/debug-interface-access/interfaces-debug-interface-access-sdk.md)   
- [IDiaSession::getEnumTables](../../debugger/debug-interface-access/idiasession-getenumtables.md)   
- [IDiaSectionContrib](../../debugger/debug-interface-access/idiasectioncontrib.md)
+Enumerates the various section contributions contained in the data source.
+
+## Syntax
+
+```
+IDiaEnumSectionContribs : IUnknown
+```
+
+## Methods in Vtable Order
+The following table shows the methods of `IDiaEnumSectionContribs`.
+
+|Method|Description|
+|------------|-----------------|
+|[IDiaEnumSectionContribs::get__NewEnum](../../debugger/debug-interface-access/idiaenumsectioncontribs-get-newenum.md)|Retrieves the [IEnumVARIANT Interface](/previous-versions/windows/desktop/api/oaidl/nn-oaidl-ienumvariant) version of this enumerator.|
+|[IDiaEnumSectionContribs::get_Count](../../debugger/debug-interface-access/idiaenumsectioncontribs-get-count.md)|Retrieves the number of section contributions.|
+|[IDiaEnumSectionContribs::Item](../../debugger/debug-interface-access/idiaenumsectioncontribs-item.md)|Retrieves section contributions by means of an index.|
+|[IDiaEnumSectionContribs::Next](../../debugger/debug-interface-access/idiaenumsectioncontribs-next.md)|Retrieves a specified number of section contributions in the enumeration sequence.|
+|[IDiaEnumSectionContribs::Skip](../../debugger/debug-interface-access/idiaenumsectioncontribs-skip.md)|Skips a specified number of section contributions in an enumeration sequence.|
+|[IDiaEnumSectionContribs::Reset](../../debugger/debug-interface-access/idiaenumsectioncontribs-reset.md)|Resets an enumeration sequence to the beginning.|
+|[IDiaEnumSectionContribs::Clone](../../debugger/debug-interface-access/idiaenumsectioncontribs-clone.md)|Creates an enumerator that contains the same enumeration state as the current enumerator.|
+
+## Remarks
+
+## Note for Callers
+Obtain this interface from the [IDiaSession::getEnumTables](../../debugger/debug-interface-access/idiasession-getenumtables.md) method. See the example for details.
+
+## Example
+This example shows how to obtain (the `GetEnumSectionContribs` function) and use (the `ShowSectionContribs` function) the `IDiaEnumSectionContribs` interface. For a more complete example of using section contributions, see the [IDiaSectionContrib](../../debugger/debug-interface-access/idiasectioncontrib.md) interface.
+
+```C++
+
+      IDiaEnumSectionContribs* GetEnumSectionContribs(IDiaSession *pSession)
+{
+    IDiaEnumSectionContribs* pUnknown    = NULL;
+    REFIID                   iid         = __uuidof(IDiaEnumSectionContribs);
+    IDiaEnumTables*          pEnumTables = NULL;
+    IDiaTable*               pTable      = NULL;
+    ULONG                    celt        = 0;
+
+    if (pSession->getEnumTables(&pEnumTables) != S_OK)
+    {
+        wprintf(L"ERROR - GetTable() getEnumTables\n");
+        return NULL;
+    }
+    while (pEnumTables->Next(1, &pTable, &celt) == S_OK && celt == 1)
+    {
+        // There is only one table that matches the given iid
+        HRESULT hr = pTable->QueryInterface(iid, (void**)&pUnknown);
+        pTable->Release();
+        if (hr == S_OK)
+        {
+            break;
+        }
+    }
+    pEnumTables->Release();
+    return pUnknown;
+}
+
+void ShowSectionContribs(IDiaSession *pSession)
+{
+    IDiaEnumSectionContribs* pEnumSectionContribs;
+
+    pEnumSectionContribs = GetEnumSectionContribs(pSession);
+    if (pSectionContrib != NULL)
+    {
+        IDiaSectionContrib* pSectionContrib;
+        ULONG celt = 0;
+
+        while(pEnumSectionContribs->Next(1, &pSectionContrib, &celt) == S_OK &&
+              celt == 1)
+        {
+            PrintSectionContrib(pSectionContrib, pSession);
+            pSectionContrib->Release();
+        }
+        pSectionContrib->Release();
+    }
+}
+```
+
+## Requirements
+Header: Dia2.h
+
+Library: diaguids.lib
+
+DLL: msdia80.dll
+
+## See Also
+[Interfaces (Debug Interface Access SDK)](../../debugger/debug-interface-access/interfaces-debug-interface-access-sdk.md)  
+[IDiaSession::getEnumTables](../../debugger/debug-interface-access/idiasession-getenumtables.md)  
+[IDiaSectionContrib](../../debugger/debug-interface-access/idiasectioncontrib.md)

--- a/docs/debugger/debug-interface-access/idiaenumsectioncontribs.md
+++ b/docs/debugger/debug-interface-access/idiaenumsectioncontribs.md
@@ -45,7 +45,7 @@ This example shows how to obtain (the `GetEnumSectionContribs` function) and use
 
 ```C++
 
-      IDiaEnumSectionContribs* GetEnumSectionContribs(IDiaSession *pSession)
+IDiaEnumSectionContribs* GetEnumSectionContribs(IDiaSession *pSession)
 {
     IDiaEnumSectionContribs* pUnknown    = NULL;
     REFIID                   iid         = __uuidof(IDiaEnumSectionContribs);


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.