### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/debugger/debug-interface-access/idiaenumsourcefiles.md
+++ b/docs/debugger/debug-interface-access/idiaenumsourcefiles.md
@@ -2,86 +2,86 @@
 title: "IDiaEnumSourceFiles | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-dev_langs: 
+dev_langs:
   - "C++"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "IDiaEnumSourceFiles interface"
 ms.assetid: 5c0779a6-a2ea-408a-90da-ebdecf2b83c0
 author: "mikejo5000"
 ms.author: "mikejo"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "multiple"
 ---
 # IDiaEnumSourceFiles
-Enumerates the various source files contained in the data source.  
-  
-## Syntax  
-  
-```  
-IDiaEnumSourceFiles : IUnknown  
-```  
-  
-## Methods in Vtable Order  
- The following table shows the methods of `IDiaEnumSourceFiles`.  
-  
-|Method|Description|  
-|------------|-----------------|  
-|[IDiaEnumSourceFiles::get__NewEnum](../../debugger/debug-interface-access/idiaenumsourcefiles-get-newenum.md)|Retrieves the `IEnumVARIANT Interface` version of this enumerator.|  
-|[IDiaEnumSourceFiles::get_Count](../../debugger/debug-interface-access/idiaenumsourcefiles-get-count.md)|Retrieves the number of source files.|  
-|[IDiaEnumSourceFiles::Item](../../debugger/debug-interface-access/idiaenumsourcefiles-item.md)|Retrieves a source file by means of an index.|  
-|[IDiaEnumSourceFiles::Next](../../debugger/debug-interface-access/idiaenumsourcefiles-next.md)|Retrieves a specified number of source files in the enumeration sequence.|  
-|[IDiaEnumSourceFiles::Skip](../../debugger/debug-interface-access/idiaenumsourcefiles-skip.md)|Skips a specified number of source files in an enumeration sequence.|  
-|[IDiaEnumSourceFiles::Reset](../../debugger/debug-interface-access/idiaenumsourcefiles-reset.md)|Resets an enumeration sequence to the beginning.|  
-|[IDiaEnumSourceFiles::Clone](../../debugger/debug-interface-access/idiaenumsourcefiles-clone.md)|Creates an enumerator that contains the same enumeration state as the current enumerator.|  
-  
-## Remarks  
-  
-## Notes for Callers  
- Obtain this interface by calling the `QueryInterface` method on an [IDiaTable](../../debugger/debug-interface-access/idiatable.md) object. See the example for details.  
-  
-## Example  
- This example shows how to obtain the `IDiaEnumSourceFiles` interface from the list of tables in a DIA session object. For an example of accessing source file information, see the [IDiaSourceFile](../../debugger/debug-interface-access/idiasourcefile.md) interface.  
-  
-```C++  
-  
-IDiaEnumSourceFiles* GetEnumSourceFiles(IDiaSession *pSession)  
-{  
-    IDiaEnumSourceFiles * pUnknown    = NULL;  
-    REFIID                iid         = __uuidof(IDiaEnumSourceFiles);  
-    IDiaEnumTables*       pEnumTables = NULL;  
-    IDiaTable*            pTable      = NULL;  
-    ULONG                 celt        = 0;  
-  
-    if (pSession->getEnumTables(&pEnumTables) != S_OK)  
-    {  
-        wprintf(L"ERROR - GetTable() getEnumTables\n");  
-        return NULL;  
-    }  
-    while (pEnumTables->Next(1, &pTable, &celt) == S_OK && celt == 1)  
-    {  
-        // There is only one table that matches the given iid  
-        HRESULT hr = pTable->QueryInterface(iid, (void**)&pUnknown);  
-        pTable->Release();  
-        if (hr == S_OK)  
-        {  
-            break;  
-        }  
-    }  
-    pEnumTables->Release();  
-    return pUnknown;  
-}  
-```  
-  
-## Requirements  
- Header: Dia2.h  
-  
- Library: diaguids.lib  
-  
- DLL: msdia80.dll  
-  
-## See Also  
- [Interfaces (Debug Interface Access SDK)](../../debugger/debug-interface-access/interfaces-debug-interface-access-sdk.md)   
- [IDiaSession::findFile](../../debugger/debug-interface-access/idiasession-findfile.md)   
- [IDiaSession::findLinesByLinenum](../../debugger/debug-interface-access/idiasession-findlinesbylinenum.md)   
- [IDiaTable](../../debugger/debug-interface-access/idiatable.md)
+Enumerates the various source files contained in the data source.
+
+## Syntax
+
+```
+IDiaEnumSourceFiles : IUnknown
+```
+
+## Methods in Vtable Order
+The following table shows the methods of `IDiaEnumSourceFiles`.
+
+|Method|Description|
+|------------|-----------------|
+|[IDiaEnumSourceFiles::get__NewEnum](../../debugger/debug-interface-access/idiaenumsourcefiles-get-newenum.md)|Retrieves the `IEnumVARIANT Interface` version of this enumerator.|
+|[IDiaEnumSourceFiles::get_Count](../../debugger/debug-interface-access/idiaenumsourcefiles-get-count.md)|Retrieves the number of source files.|
+|[IDiaEnumSourceFiles::Item](../../debugger/debug-interface-access/idiaenumsourcefiles-item.md)|Retrieves a source file by means of an index.|
+|[IDiaEnumSourceFiles::Next](../../debugger/debug-interface-access/idiaenumsourcefiles-next.md)|Retrieves a specified number of source files in the enumeration sequence.|
+|[IDiaEnumSourceFiles::Skip](../../debugger/debug-interface-access/idiaenumsourcefiles-skip.md)|Skips a specified number of source files in an enumeration sequence.|
+|[IDiaEnumSourceFiles::Reset](../../debugger/debug-interface-access/idiaenumsourcefiles-reset.md)|Resets an enumeration sequence to the beginning.|
+|[IDiaEnumSourceFiles::Clone](../../debugger/debug-interface-access/idiaenumsourcefiles-clone.md)|Creates an enumerator that contains the same enumeration state as the current enumerator.|
+
+## Remarks
+
+## Notes for Callers
+Obtain this interface by calling the `QueryInterface` method on an [IDiaTable](../../debugger/debug-interface-access/idiatable.md) object. See the example for details.
+
+## Example
+This example shows how to obtain the `IDiaEnumSourceFiles` interface from the list of tables in a DIA session object. For an example of accessing source file information, see the [IDiaSourceFile](../../debugger/debug-interface-access/idiasourcefile.md) interface.
+
+```C++
+
+IDiaEnumSourceFiles* GetEnumSourceFiles(IDiaSession *pSession)
+{
+    IDiaEnumSourceFiles * pUnknown    = NULL;
+    REFIID                iid         = __uuidof(IDiaEnumSourceFiles);
+    IDiaEnumTables*       pEnumTables = NULL;
+    IDiaTable*            pTable      = NULL;
+    ULONG                 celt        = 0;
+
+    if (pSession->getEnumTables(&pEnumTables) != S_OK)
+    {
+        wprintf(L"ERROR - GetTable() getEnumTables\n");
+        return NULL;
+    }
+    while (pEnumTables->Next(1, &pTable, &celt) == S_OK && celt == 1)
+    {
+        // There is only one table that matches the given iid
+        HRESULT hr = pTable->QueryInterface(iid, (void**)&pUnknown);
+        pTable->Release();
+        if (hr == S_OK)
+        {
+            break;
+        }
+    }
+    pEnumTables->Release();
+    return pUnknown;
+}
+```
+
+## Requirements
+Header: Dia2.h
+
+Library: diaguids.lib
+
+DLL: msdia80.dll
+
+## See Also
+[Interfaces (Debug Interface Access SDK)](../../debugger/debug-interface-access/interfaces-debug-interface-access-sdk.md)  
+[IDiaSession::findFile](../../debugger/debug-interface-access/idiasession-findfile.md)  
+[IDiaSession::findLinesByLinenum](../../debugger/debug-interface-access/idiasession-findlinesbylinenum.md)  
+[IDiaTable](../../debugger/debug-interface-access/idiatable.md)


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.