### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/debugger/debug-interface-access/idiaenumstackframes.md
+++ b/docs/debugger/debug-interface-access/idiaenumstackframes.md
@@ -2,69 +2,69 @@
 title: "IDiaEnumStackFrames | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-dev_langs: 
+dev_langs:
   - "C++"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "IDiaEnumStackFrames interface"
 ms.assetid: 3d1e8403-c9fc-42ff-ae35-0ab9a5ed2ad7
 author: "mikejo5000"
 ms.author: "mikejo"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "multiple"
 ---
 # IDiaEnumStackFrames
-Enumerates the various stack frames available.  
-  
-## Methods in Vtable Order  
-  
-|Method|Description|  
-|------------|-----------------|  
-|[IDiaEnumStackFrames::Next](../../debugger/debug-interface-access/idiaenumstackframes-next.md)|Retrieves a specified number of stack frame elements from the enumeration sequence.|  
-|[IDiaEnumStackFrames::Reset](../../debugger/debug-interface-access/idiaenumstackframes-reset.md)|Resets an enumeration sequence to the beginning.|  
-  
-## Remarks  
-  
-## Notes for Callers  
- Obtain this interface by calling the [IDiaStackWalker::getEnumFrames](../../debugger/debug-interface-access/idiastackwalker-getenumframes.md) or [IDiaStackWalker::getEnumFrames2](../../debugger/debug-interface-access/idiastackwalker-getenumframes2.md) methods.  
-  
-## Example  
- This example shows how to obtain and use the `IDiaEnumStackFrames` interface. See the [IDiaStackFrame](../../debugger/debug-interface-access/idiastackframe.md) interface for an implementation of the `PrintStackFrame` function.  
-  
-```C++  
-void DumpStackFrames(IDiaStackWalker*     pStackWalker,  
-                     IDiaStackWalkHelper* pStackWalkHelper,  
-                     CV_CPU_TYPE_e        cpuType)  
-{  
-    if (pStackWalker != NULL && pStackWalkHelper != NULL)  
-    {  
-        CComPtr<IDiaEnumStackFrames> pEnumsFrames;  
-        HRESULT hr;  
-        hr = pStackWalker->getEnumFrames2(cpuType, pStackWalkHelper, &pEnumFrames);  
-        if (SUCCEEDED(hr) && pEnumFrames != NULL)  
-        {  
-             CComPtr<IDiaStackFrame> pStackFrame;  
-             DWORD celt = 0;  
-  
-             while (pEnumFrames->Next(1, &pStackFrame, &celt) == S_OK)  
-             {  
-                 PrintStackFrame(pStackFrame);  
-             }  
-             pStackFrame = NULL;  
-        }  
-    }  
-}  
-```  
-  
-## Requirements  
- Header: Dia2.h  
-  
- Library: diaguids.lib  
-  
- DLL: msdia80.dll  
-  
-## See Also  
- [Interfaces (Debug Interface Access SDK)](../../debugger/debug-interface-access/interfaces-debug-interface-access-sdk.md)   
- [IDiaStackWalkFrame](../../debugger/debug-interface-access/idiastackwalkframe.md)   
- [IDiaStackWalker::getEnumFrames2](../../debugger/debug-interface-access/idiastackwalker-getenumframes2.md)   
- [IDiaStackWalker::getEnumFrames](../../debugger/debug-interface-access/idiastackwalker-getenumframes.md)
+Enumerates the various stack frames available.
+
+## Methods in Vtable Order
+
+|Method|Description|
+|------------|-----------------|
+|[IDiaEnumStackFrames::Next](../../debugger/debug-interface-access/idiaenumstackframes-next.md)|Retrieves a specified number of stack frame elements from the enumeration sequence.|
+|[IDiaEnumStackFrames::Reset](../../debugger/debug-interface-access/idiaenumstackframes-reset.md)|Resets an enumeration sequence to the beginning.|
+
+## Remarks
+
+## Notes for Callers
+Obtain this interface by calling the [IDiaStackWalker::getEnumFrames](../../debugger/debug-interface-access/idiastackwalker-getenumframes.md) or [IDiaStackWalker::getEnumFrames2](../../debugger/debug-interface-access/idiastackwalker-getenumframes2.md) methods.
+
+## Example
+This example shows how to obtain and use the `IDiaEnumStackFrames` interface. See the [IDiaStackFrame](../../debugger/debug-interface-access/idiastackframe.md) interface for an implementation of the `PrintStackFrame` function.
+
+```C++
+void DumpStackFrames(IDiaStackWalker*     pStackWalker,
+                     IDiaStackWalkHelper* pStackWalkHelper,
+                     CV_CPU_TYPE_e        cpuType)
+{
+    if (pStackWalker != NULL && pStackWalkHelper != NULL)
+    {
+        CComPtr<IDiaEnumStackFrames> pEnumsFrames;
+        HRESULT hr;
+        hr = pStackWalker->getEnumFrames2(cpuType, pStackWalkHelper, &pEnumFrames);
+        if (SUCCEEDED(hr) && pEnumFrames != NULL)
+        {
+             CComPtr<IDiaStackFrame> pStackFrame;
+             DWORD celt = 0;
+
+             while (pEnumFrames->Next(1, &pStackFrame, &celt) == S_OK)
+             {
+                 PrintStackFrame(pStackFrame);
+             }
+             pStackFrame = NULL;
+        }
+    }
+}
+```
+
+## Requirements
+Header: Dia2.h
+
+Library: diaguids.lib
+
+DLL: msdia80.dll
+
+## See Also
+[Interfaces (Debug Interface Access SDK)](../../debugger/debug-interface-access/interfaces-debug-interface-access-sdk.md)  
+[IDiaStackWalkFrame](../../debugger/debug-interface-access/idiastackwalkframe.md)  
+[IDiaStackWalker::getEnumFrames2](../../debugger/debug-interface-access/idiastackwalker-getenumframes2.md)  
+[IDiaStackWalker::getEnumFrames](../../debugger/debug-interface-access/idiastackwalker-getenumframes.md)

--- a/docs/debugger/debug-interface-access/idiaenumstackframes.md
+++ b/docs/debugger/debug-interface-access/idiaenumstackframes.md
@@ -43,14 +43,14 @@ void DumpStackFrames(IDiaStackWalker*     pStackWalker,
         hr = pStackWalker->getEnumFrames2(cpuType, pStackWalkHelper, &pEnumFrames);
         if (SUCCEEDED(hr) && pEnumFrames != NULL)
         {
-             CComPtr<IDiaStackFrame> pStackFrame;
-             DWORD celt = 0;
+            CComPtr<IDiaStackFrame> pStackFrame;
+            DWORD celt = 0;
 
-             while (pEnumFrames->Next(1, &pStackFrame, &celt) == S_OK)
-             {
-                 PrintStackFrame(pStackFrame);
-             }
-             pStackFrame = NULL;
+            while (pEnumFrames->Next(1, &pStackFrame, &celt) == S_OK)
+            {
+                PrintStackFrame(pStackFrame);
+            }
+            pStackFrame = NULL;
         }
     }
 }


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.