### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/debugger/debug-interface-access/idiaenumsymbols.md
+++ b/docs/debugger/debug-interface-access/idiaenumsymbols.md
@@ -2,92 +2,92 @@
 title: "IDiaEnumSymbols | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-dev_langs: 
+dev_langs:
   - "C++"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "IDiaEnumSymbols interface"
 ms.assetid: 649f7bfd-86ac-49a5-8533-aff77e1bc62e
 author: "mikejo5000"
 ms.author: "mikejo"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "multiple"
 ---
 # IDiaEnumSymbols
-Enumerates the various symbols contained in the data source.  
-  
-## Syntax  
-  
-```  
-IDiaEnumSymbols : IUnknown  
-```  
-  
-## Methods in Vtable Order  
- The following table shows the methods of `IDiaEnumSymbols`.  
-  
-|Method|Description|  
-|------------|-----------------|  
-|[IDiaEnumSymbols::get__NewEnum](../../debugger/debug-interface-access/idiaenumsymbols-get-newenum.md)|Retrieves the `IEnumVARIANT Interface` version of this enumerator.|  
-|[IDiaEnumSymbols::get_Count](../../debugger/debug-interface-access/idiaenumsymbols-get-count.md)|Retrieves the number of symbols.|  
-|[IDiaEnumSymbols::Item](../../debugger/debug-interface-access/idiaenumsymbols-item.md)|Retrieves a symbol by means of an index.|  
-|[IDiaEnumSymbols::Next](../../debugger/debug-interface-access/idiaenumsymbols-next.md)|Retrieves a specified number of symbols in the enumeration sequence.|  
-|[IDiaEnumSymbols::Skip](../../debugger/debug-interface-access/idiaenumsymbols-skip.md)|Skips a specified number of symbols in an enumeration sequence.|  
-|[IDiaEnumSymbols::Reset](../../debugger/debug-interface-access/idiaenumsymbols-reset.md)|Resets an enumeration sequence to the beginning.|  
-|[IDiaEnumSymbols::Clone](../../debugger/debug-interface-access/idiaenumsymbols-clone.md)|Creates an enumerator that contains the same enumeration state as the current enumerator.|  
-  
-## Remarks  
- This interface provides symbols grouped by a specific type of symbol, for example, `SymTagUDT` (user-defined types) or `SymTagBaseClass`. To work with symbols grouped by address, use the [IDiaEnumSymbolsByAddr](../../debugger/debug-interface-access/idiaenumsymbolsbyaddr.md) interface.  
-  
-## Notes for Callers  
- Obtain this interface by calling the following methods:  
-  
--   [IDiaSession::findChildren](../../debugger/debug-interface-access/idiasession-findchildren.md)  
-  
--   [IDiaSymbol::findChildren](../../debugger/debug-interface-access/idiasymbol-findchildren.md)  
-  
--   [IDiaSourceFile::get_compilands](../../debugger/debug-interface-access/idiasourcefile-get-compilands.md)  
-  
-## Example  
- This example shows how to obtain the `IDiaEnumSymbols` interface and then use that enumeration to list user-defined types (UDTs).  
-  
+Enumerates the various symbols contained in the data source.
+
+## Syntax
+
+```
+IDiaEnumSymbols : IUnknown
+```
+
+## Methods in Vtable Order
+The following table shows the methods of `IDiaEnumSymbols`.
+
+|Method|Description|
+|------------|-----------------|
+|[IDiaEnumSymbols::get__NewEnum](../../debugger/debug-interface-access/idiaenumsymbols-get-newenum.md)|Retrieves the `IEnumVARIANT Interface` version of this enumerator.|
+|[IDiaEnumSymbols::get_Count](../../debugger/debug-interface-access/idiaenumsymbols-get-count.md)|Retrieves the number of symbols.|
+|[IDiaEnumSymbols::Item](../../debugger/debug-interface-access/idiaenumsymbols-item.md)|Retrieves a symbol by means of an index.|
+|[IDiaEnumSymbols::Next](../../debugger/debug-interface-access/idiaenumsymbols-next.md)|Retrieves a specified number of symbols in the enumeration sequence.|
+|[IDiaEnumSymbols::Skip](../../debugger/debug-interface-access/idiaenumsymbols-skip.md)|Skips a specified number of symbols in an enumeration sequence.|
+|[IDiaEnumSymbols::Reset](../../debugger/debug-interface-access/idiaenumsymbols-reset.md)|Resets an enumeration sequence to the beginning.|
+|[IDiaEnumSymbols::Clone](../../debugger/debug-interface-access/idiaenumsymbols-clone.md)|Creates an enumerator that contains the same enumeration state as the current enumerator.|
+
+## Remarks
+This interface provides symbols grouped by a specific type of symbol, for example, `SymTagUDT` (user-defined types) or `SymTagBaseClass`. To work with symbols grouped by address, use the [IDiaEnumSymbolsByAddr](../../debugger/debug-interface-access/idiaenumsymbolsbyaddr.md) interface.
+
+## Notes for Callers
+Obtain this interface by calling the following methods:
+
+- [IDiaSession::findChildren](../../debugger/debug-interface-access/idiasession-findchildren.md)
+
+- [IDiaSymbol::findChildren](../../debugger/debug-interface-access/idiasymbol-findchildren.md)
+
+- [IDiaSourceFile::get_compilands](../../debugger/debug-interface-access/idiasourcefile-get-compilands.md)
+
+## Example
+This example shows how to obtain the `IDiaEnumSymbols` interface and then use that enumeration to list user-defined types (UDTs).
+
 > [!NOTE]
->  `CDiaBSTR` is a class that wraps a `BSTR` and automatically handles freeing the string when the instantiation goes out of scope.  
-  
-```C++  
-void ShowUDTs(IDiaSymbol *pGlobals)  
-{  
-    CComPtr<IDiaEnumSymbols> pEnum;  
-    CComPtr<IDiaSymbol> pSymbol;  
-    HRESULT hr;  
-  
-    hr = pGlobals->findChildren(SymTagUDT,  
-                                NULL,  
-                                nsfCaseInsensitive | nsfUndecoratedName,  
-                                &pEnum);  
-    if (hr == S_OK)  
-    {  
-        while ( SUCCEEDED( hr = pEnum->Next( 1, &pSymbol, &celt ) ) &&  
-                celt == 1 )  
-        {  
-            CDiaBSTR name;  
-            if ( pSymbol->get_name( &name ) != S_OK )  
-                Fatal( "get_name" );  
-            printf( "Found UDT: %ws\n", name );  
-            pSymbol = 0;  
-        }  
-    }  
-}  
-```  
-  
-## Requirements  
- Header: Dia2.h  
-  
- Library: diaguids.lib  
-  
- DLL: msdia80.dll  
-  
-## See Also  
- [Interfaces (Debug Interface Access SDK)](../../debugger/debug-interface-access/interfaces-debug-interface-access-sdk.md)   
- [IDiaSession::findChildren](../../debugger/debug-interface-access/idiasession-findchildren.md)   
- [IDiaSourceFile::get_compilands](../../debugger/debug-interface-access/idiasourcefile-get-compilands.md)   
- [IDiaSymbol::findChildren](../../debugger/debug-interface-access/idiasymbol-findchildren.md)
+> `CDiaBSTR` is a class that wraps a `BSTR` and automatically handles freeing the string when the instantiation goes out of scope.
+
+```C++
+void ShowUDTs(IDiaSymbol *pGlobals)
+{
+    CComPtr<IDiaEnumSymbols> pEnum;
+    CComPtr<IDiaSymbol> pSymbol;
+    HRESULT hr;
+
+    hr = pGlobals->findChildren(SymTagUDT,
+                                NULL,
+                                nsfCaseInsensitive | nsfUndecoratedName,
+                                &pEnum);
+    if (hr == S_OK)
+    {
+        while ( SUCCEEDED( hr = pEnum->Next( 1, &pSymbol, &celt ) ) &&
+                celt == 1 )
+        {
+            CDiaBSTR name;
+            if ( pSymbol->get_name( &name ) != S_OK )
+                Fatal( "get_name" );
+            printf( "Found UDT: %ws\n", name );
+            pSymbol = 0;
+        }
+    }
+}
+```
+
+## Requirements
+Header: Dia2.h
+
+Library: diaguids.lib
+
+DLL: msdia80.dll
+
+## See Also
+[Interfaces (Debug Interface Access SDK)](../../debugger/debug-interface-access/interfaces-debug-interface-access-sdk.md)  
+[IDiaSession::findChildren](../../debugger/debug-interface-access/idiasession-findchildren.md)  
+[IDiaSourceFile::get_compilands](../../debugger/debug-interface-access/idiasourcefile-get-compilands.md)  
+[IDiaSymbol::findChildren](../../debugger/debug-interface-access/idiasymbol-findchildren.md)


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.