### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/debugger/debug-interface-access/idiaenumsymbolsbyaddr.md
+++ b/docs/debugger/debug-interface-access/idiaenumsymbolsbyaddr.md
@@ -2,99 +2,99 @@
 title: "IDiaEnumSymbolsByAddr | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-dev_langs: 
+dev_langs:
   - "C++"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "IDiaEnumSymbolsbyAddr interface"
 ms.assetid: 37d3dcdf-e4fa-4354-b5e1-8843566b52ac
 author: "mikejo5000"
 ms.author: "mikejo"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "multiple"
 ---
 # IDiaEnumSymbolsByAddr
-Enumerates by address the various symbols contained in the data source.  
-  
-## Syntax  
-  
-```  
-IDiaEnumSymbolsByAddr : IUnknown  
-```  
-  
-## Methods in Vtable Order  
- The following table shows the methods of `IDiaEnumSymbolsByAddr`.  
-  
-|Method|Description|  
-|------------|-----------------|  
-|[IDiaEnumSymbolsByAddr::symbolByAddr](../../debugger/debug-interface-access/idiaenumsymbolsbyaddr-symbolbyaddr.md)|Positions the enumerator by performing a lookup by section and offset.|  
-|[IDiaEnumSymbolsByAddr::symbolByRVA](../../debugger/debug-interface-access/idiaenumsymbolsbyaddr-symbolbyrva.md)|Positions the enumerator by performing a lookup by relative virtual address (RVA).|  
-|[IDiaEnumSymbolsByAddr::symbolByVA](../../debugger/debug-interface-access/idiaenumsymbolsbyaddr-symbolbyva.md)|Positions the enumerator by performing a lookup by virtual address (VA).|  
-|[IDiaEnumSymbolsByAddr::Next](../../debugger/debug-interface-access/idiaenumsymbolsbyaddr-next.md)|Retrieves the next symbols in order by address. Updates the enumerator position by number of elements fetched.|  
-|[IDiaEnumSymbolsByAddr::Prev](../../debugger/debug-interface-access/idiaenumsymbolsbyaddr-prev.md)|Retrieves the previous symbols in order by address. Updates the enumerator position by number of elements fetched.|  
-|[IDiaEnumSymbolsByAddr::Clone](../../debugger/debug-interface-access/idiaenumsymbolsbyaddr-clone.md)|Makes a copy of an object.|  
-  
-## Remarks  
- This interface provides symbols grouped by address. To work with symbols grouped by type, for example `SymTagUDT` (user-defined type) or `SymTagBaseClass`, use the [IDiaEnumSymbols](../../debugger/debug-interface-access/idiaenumsymbols.md) interface.  
-  
-## Notes for Callers  
- Obtain this interface by calling the [IDiaSession::getSymbolsByAddr](../../debugger/debug-interface-access/idiasession-getsymbolsbyaddr.md) method.  
-  
-## Example  
- This function displays the name and address of all symbols ordered by relative virtual address.  
-  
-```C++  
-void ShowSymbolsByAddress(IDiaSession *pSession)  
-{  
-    CComPtr<IDiaEnumSymbolsByAddr> pEnumByAddr;  
-    if ( FAILED( psession->getSymbolsByAddr( &pEnumByAddr ) ) )  
-    {  
-        Fatal( "getSymbolsByAddr" );  
-    }  
-    CComPtr<IDiaSymbol> pSym;  
-    if ( FAILED( pEnumByAddr->symbolByAddr( 1, 0, &pSym ) ) )  
-    {  
-        Fatal( "symbolByAddr" );  
-    }  
-    DWORD rvaLast = 0;  
-    if ( pSym->get_relativeVirtualAddress( &rvaLast ) == S_OK )  
-    {  
-        pSym = 0;  
-        if ( FAILED( pEnumByAddr->symbolByRVA( rvaLast, &pSym ) ) )  
-        {  
-            Fatal( "symbolByAddr" );  
-        }  
-        printf( "Symbols in order\n" );  
-        do  
-        {   
-            CDiaBSTR name;  
-            if ( pSym->get_name( &name ) != S_OK )  
-            {  
-                printf( "\t0x%08X (%ws) <no name>\n", rvaLast );  
-            }  
-            else  
-            {  
-               printf( "\t0x%08X %ws\n", rvaLast, name );  
-            }  
-            pSym = 0;  
-            celt = 0;  
-            if ( FAILED( hr = pEnumByAddr->Next( 1, &pSym, &celt ) ) )  
-            {  
-                break;  
-            }  
-        } while ( celt == 1 );  
-    }  
-}  
-```  
-  
-## Requirements  
- Header: Dia2.h  
-  
- Library: diaguids.lib  
-  
- DLL: msdia80.dll  
-  
-## See Also  
- [Interfaces (Debug Interface Access SDK)](../../debugger/debug-interface-access/interfaces-debug-interface-access-sdk.md)   
- [IDiaSession::getSymbolsByAddr](../../debugger/debug-interface-access/idiasession-getsymbolsbyaddr.md)   
- [IDiaEnumSymbols](../../debugger/debug-interface-access/idiaenumsymbols.md)
+Enumerates by address the various symbols contained in the data source.
+
+## Syntax
+
+```
+IDiaEnumSymbolsByAddr : IUnknown
+```
+
+## Methods in Vtable Order
+The following table shows the methods of `IDiaEnumSymbolsByAddr`.
+
+|Method|Description|
+|------------|-----------------|
+|[IDiaEnumSymbolsByAddr::symbolByAddr](../../debugger/debug-interface-access/idiaenumsymbolsbyaddr-symbolbyaddr.md)|Positions the enumerator by performing a lookup by section and offset.|
+|[IDiaEnumSymbolsByAddr::symbolByRVA](../../debugger/debug-interface-access/idiaenumsymbolsbyaddr-symbolbyrva.md)|Positions the enumerator by performing a lookup by relative virtual address (RVA).|
+|[IDiaEnumSymbolsByAddr::symbolByVA](../../debugger/debug-interface-access/idiaenumsymbolsbyaddr-symbolbyva.md)|Positions the enumerator by performing a lookup by virtual address (VA).|
+|[IDiaEnumSymbolsByAddr::Next](../../debugger/debug-interface-access/idiaenumsymbolsbyaddr-next.md)|Retrieves the next symbols in order by address. Updates the enumerator position by number of elements fetched.|
+|[IDiaEnumSymbolsByAddr::Prev](../../debugger/debug-interface-access/idiaenumsymbolsbyaddr-prev.md)|Retrieves the previous symbols in order by address. Updates the enumerator position by number of elements fetched.|
+|[IDiaEnumSymbolsByAddr::Clone](../../debugger/debug-interface-access/idiaenumsymbolsbyaddr-clone.md)|Makes a copy of an object.|
+
+## Remarks
+This interface provides symbols grouped by address. To work with symbols grouped by type, for example `SymTagUDT` (user-defined type) or `SymTagBaseClass`, use the [IDiaEnumSymbols](../../debugger/debug-interface-access/idiaenumsymbols.md) interface.
+
+## Notes for Callers
+Obtain this interface by calling the [IDiaSession::getSymbolsByAddr](../../debugger/debug-interface-access/idiasession-getsymbolsbyaddr.md) method.
+
+## Example
+This function displays the name and address of all symbols ordered by relative virtual address.
+
+```C++
+void ShowSymbolsByAddress(IDiaSession *pSession)
+{
+    CComPtr<IDiaEnumSymbolsByAddr> pEnumByAddr;
+    if ( FAILED( psession->getSymbolsByAddr( &pEnumByAddr ) ) )
+    {
+        Fatal( "getSymbolsByAddr" );
+    }
+    CComPtr<IDiaSymbol> pSym;
+    if ( FAILED( pEnumByAddr->symbolByAddr( 1, 0, &pSym ) ) )
+    {
+        Fatal( "symbolByAddr" );
+    }
+    DWORD rvaLast = 0;
+    if ( pSym->get_relativeVirtualAddress( &rvaLast ) == S_OK )
+    {
+        pSym = 0;
+        if ( FAILED( pEnumByAddr->symbolByRVA( rvaLast, &pSym ) ) )
+        {
+            Fatal( "symbolByAddr" );
+        }
+        printf( "Symbols in order\n" );
+        do
+        {
+            CDiaBSTR name;
+            if ( pSym->get_name( &name ) != S_OK )
+            {
+                printf( "\t0x%08X (%ws) <no name>\n", rvaLast );
+            }
+            else
+            {
+               printf( "\t0x%08X %ws\n", rvaLast, name );
+            }
+            pSym = 0;
+            celt = 0;
+            if ( FAILED( hr = pEnumByAddr->Next( 1, &pSym, &celt ) ) )
+            {
+                break;
+            }
+        } while ( celt == 1 );
+    }
+}
+```
+
+## Requirements
+Header: Dia2.h
+
+Library: diaguids.lib
+
+DLL: msdia80.dll
+
+## See Also
+[Interfaces (Debug Interface Access SDK)](../../debugger/debug-interface-access/interfaces-debug-interface-access-sdk.md)  
+[IDiaSession::getSymbolsByAddr](../../debugger/debug-interface-access/idiasession-getsymbolsbyaddr.md)  
+[IDiaEnumSymbols](../../debugger/debug-interface-access/idiaenumsymbols.md)

--- a/docs/debugger/debug-interface-access/idiaenumsymbolsbyaddr.md
+++ b/docs/debugger/debug-interface-access/idiaenumsymbolsbyaddr.md
@@ -74,7 +74,7 @@ void ShowSymbolsByAddress(IDiaSession *pSession)
             }
             else
             {
-               printf( "\t0x%08X %ws\n", rvaLast, name );
+                printf( "\t0x%08X %ws\n", rvaLast, name );
             }
             pSym = 0;
             celt = 0;


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.