### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/debugger/debug-interface-access/idiainjectedsource.md
+++ b/docs/debugger/debug-interface-access/idiainjectedsource.md
@@ -2,119 +2,119 @@
 title: "IDiaInjectedSource | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-dev_langs: 
+dev_langs:
   - "C++"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "IDiaInjectedSource interface"
 ms.assetid: 75192c5c-812d-4675-9dc5-4c2cff3ba503
 author: "mikejo5000"
 ms.author: "mikejo"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "multiple"
 ---
 # IDiaInjectedSource
-Accesses injected source code stored in the DIA data source.  
-  
-## Syntax  
-  
-```  
-IDiaInjectedSource : IUnknown  
-```  
-  
-## Methods in Vtable Order  
- The following table shows the methods of `IDiaInjectedSource`.  
-  
-|Method|Description|  
-|------------|-----------------|  
-|[IDiaInjectedSource::get_crc](../../debugger/debug-interface-access/idiainjectedsource-get-crc.md)|Retrieves a cyclic redundancy check (CRC) calculated from the bytes of the source code.|  
-|[IDiaInjectedSource::get_length](../../debugger/debug-interface-access/idiainjectedsource-get-length.md)|Retrieves the number of bytes of code.|  
-|[IDiaInjectedSource::get_filename](../../debugger/debug-interface-access/idiainjectedsource-get-filename.md)|Retrieves the file name for the source.|  
-|[IDiaInjectedSource::get_objectFilename](../../debugger/debug-interface-access/idiainjectedsource-get-objectfilename.md)|Retrieves the object file name to which the source was compiled.|  
-|[IDiaInjectedSource::get_virtualFilename](../../debugger/debug-interface-access/idiainjectedsource-get-virtualfilename.md)|Retrieves the name given to non-file source code; that is, code that was injected.|  
-|[IDiaInjectedSource::get_sourceCompression](../../debugger/debug-interface-access/idiainjectedsource-get-sourcecompression.md)|Retrieves the indicator of the source compression used.|  
-|[IDiaInjectedSource::get_source](../../debugger/debug-interface-access/idiainjectedsource-get-source.md)|Retrieves the source code bytes.|  
-  
-## Remarks  
- Injected source is text that is injected during compilation. This does not mean the preprocessor `#include` used in C++.  
-  
-## Notes for Callers  
- Obtain this interface by calling the [IDiaEnumInjectedSources::Item](../../debugger/debug-interface-access/idiaenuminjectedsources-item.md) or [IDiaEnumInjectedSources::Next](../../debugger/debug-interface-access/idiaenuminjectedsources-next.md) methods. See the [IDiaEnumInjectedSources](../../debugger/debug-interface-access/idiaenuminjectedsources.md) interface for an example of obtaining the `IDiaInjectedSource` interface.  
-  
-## Example  
- This example displays the data available from the `IDiaInjectedSource` interface. For an alternative approach using the [IDiaPropertyStorage](../../debugger/debug-interface-access/idiapropertystorage.md) interface, see the example in the [IDiaEnumInjectedSources](../../debugger/debug-interface-access/idiaenuminjectedsources.md) interface.  
-  
-```C++  
-void PrintInjectedSource(IDiaInjectedSource* pSource)  
-{  
-    ULONGLONG codeLength      = 0;  
-    DWORD     crc             = 0;  
-    DWORD     compressionType = 0;  
-    BSTR      sourceFilename  = NULL;  
-    BSTR      objectFilename  = NULL;  
-    BSTR      virtualFilename = NULL;  
-  
-    std::cout << "Injected Source:" << std::endl;  
-    if (pSource != NULL)  
-    {  
-        if (pSource->get_crc(&crc) == S_OK &&  
-            pSource->get_sourceCompression(&compressionType) == S_OK &&  
-            pSource->get_length(&codeLength) == S_OK)  
-        {  
-            wprintf(L"  crc = %lu\n", crc);  
-            wprintf(L"  code length = %I64u\n",codeLength);  
-            wprintf(L"  compression type code = %lu\n", compressionType);  
-        }  
-  
-        wprintf(L"  source filename: ");  
-        if (pSource->get_filename(&sourceFilename) == S_OK)  
-        {  
-            wprintf(L"%s", sourceFilename);  
-        }  
-        else  
-        {  
-            wprintf(L"<none>");  
-        }  
-        wprintf(L"\n");  
-  
-        wprintf(L"  object filename: ");  
-        if (pSource->get_filename(&objectFilename) == S_OK)  
-        {  
-            wprintf(L"%s", objectFilename);  
-        }  
-        else  
-        {  
-            wprintf(L"<none>");  
-        }  
-        wprintf(L"\n");  
-  
-        wprintf(L"  virtual filename: ");  
-        if (pSource->get_filename(&virtualFilename) == S_OK)  
-        {  
-            wprintf(L"%s", virtualFilename);  
-        }  
-        else  
-        {  
-            wprintf(L"<none>");  
-        }  
-        wprintf(L"\n");  
-  
-        SysFreeString(sourceFilename);  
-        SysFreeString(objectFilename);  
-        SysFreeString(virtualFilename);  
-    }  
-}  
-```  
-  
-## Requirements  
- Header: Dia2.h  
-  
- Library: diaguids.lib  
-  
- DLL: msdia80.dll  
-  
-## See Also  
- [Interfaces (Debug Interface Access SDK)](../../debugger/debug-interface-access/interfaces-debug-interface-access-sdk.md)   
- [IDiaEnumInjectedSources::Item](../../debugger/debug-interface-access/idiaenuminjectedsources-item.md)   
- [IDiaEnumInjectedSources::Next](../../debugger/debug-interface-access/idiaenuminjectedsources-next.md)   
- [IDiaEnumInjectedSources](../../debugger/debug-interface-access/idiaenuminjectedsources.md)
+Accesses injected source code stored in the DIA data source.
+
+## Syntax
+
+```
+IDiaInjectedSource : IUnknown
+```
+
+## Methods in Vtable Order
+The following table shows the methods of `IDiaInjectedSource`.
+
+|Method|Description|
+|------------|-----------------|
+|[IDiaInjectedSource::get_crc](../../debugger/debug-interface-access/idiainjectedsource-get-crc.md)|Retrieves a cyclic redundancy check (CRC) calculated from the bytes of the source code.|
+|[IDiaInjectedSource::get_length](../../debugger/debug-interface-access/idiainjectedsource-get-length.md)|Retrieves the number of bytes of code.|
+|[IDiaInjectedSource::get_filename](../../debugger/debug-interface-access/idiainjectedsource-get-filename.md)|Retrieves the file name for the source.|
+|[IDiaInjectedSource::get_objectFilename](../../debugger/debug-interface-access/idiainjectedsource-get-objectfilename.md)|Retrieves the object file name to which the source was compiled.|
+|[IDiaInjectedSource::get_virtualFilename](../../debugger/debug-interface-access/idiainjectedsource-get-virtualfilename.md)|Retrieves the name given to non-file source code; that is, code that was injected.|
+|[IDiaInjectedSource::get_sourceCompression](../../debugger/debug-interface-access/idiainjectedsource-get-sourcecompression.md)|Retrieves the indicator of the source compression used.|
+|[IDiaInjectedSource::get_source](../../debugger/debug-interface-access/idiainjectedsource-get-source.md)|Retrieves the source code bytes.|
+
+## Remarks
+Injected source is text that is injected during compilation. This does not mean the preprocessor `#include` used in C++.
+
+## Notes for Callers
+Obtain this interface by calling the [IDiaEnumInjectedSources::Item](../../debugger/debug-interface-access/idiaenuminjectedsources-item.md) or [IDiaEnumInjectedSources::Next](../../debugger/debug-interface-access/idiaenuminjectedsources-next.md) methods. See the [IDiaEnumInjectedSources](../../debugger/debug-interface-access/idiaenuminjectedsources.md) interface for an example of obtaining the `IDiaInjectedSource` interface.
+
+## Example
+This example displays the data available from the `IDiaInjectedSource` interface. For an alternative approach using the [IDiaPropertyStorage](../../debugger/debug-interface-access/idiapropertystorage.md) interface, see the example in the [IDiaEnumInjectedSources](../../debugger/debug-interface-access/idiaenuminjectedsources.md) interface.
+
+```C++
+void PrintInjectedSource(IDiaInjectedSource* pSource)
+{
+    ULONGLONG codeLength      = 0;
+    DWORD     crc             = 0;
+    DWORD     compressionType = 0;
+    BSTR      sourceFilename  = NULL;
+    BSTR      objectFilename  = NULL;
+    BSTR      virtualFilename = NULL;
+
+    std::cout << "Injected Source:" << std::endl;
+    if (pSource != NULL)
+    {
+        if (pSource->get_crc(&crc) == S_OK &&
+            pSource->get_sourceCompression(&compressionType) == S_OK &&
+            pSource->get_length(&codeLength) == S_OK)
+        {
+            wprintf(L"  crc = %lu\n", crc);
+            wprintf(L"  code length = %I64u\n",codeLength);
+            wprintf(L"  compression type code = %lu\n", compressionType);
+        }
+
+        wprintf(L"  source filename: ");
+        if (pSource->get_filename(&sourceFilename) == S_OK)
+        {
+            wprintf(L"%s", sourceFilename);
+        }
+        else
+        {
+            wprintf(L"<none>");
+        }
+        wprintf(L"\n");
+
+        wprintf(L"  object filename: ");
+        if (pSource->get_filename(&objectFilename) == S_OK)
+        {
+            wprintf(L"%s", objectFilename);
+        }
+        else
+        {
+            wprintf(L"<none>");
+        }
+        wprintf(L"\n");
+
+        wprintf(L"  virtual filename: ");
+        if (pSource->get_filename(&virtualFilename) == S_OK)
+        {
+            wprintf(L"%s", virtualFilename);
+        }
+        else
+        {
+            wprintf(L"<none>");
+        }
+        wprintf(L"\n");
+
+        SysFreeString(sourceFilename);
+        SysFreeString(objectFilename);
+        SysFreeString(virtualFilename);
+    }
+}
+```
+
+## Requirements
+Header: Dia2.h
+
+Library: diaguids.lib
+
+DLL: msdia80.dll
+
+## See Also
+[Interfaces (Debug Interface Access SDK)](../../debugger/debug-interface-access/interfaces-debug-interface-access-sdk.md)  
+[IDiaEnumInjectedSources::Item](../../debugger/debug-interface-access/idiaenuminjectedsources-item.md)  
+[IDiaEnumInjectedSources::Next](../../debugger/debug-interface-access/idiaenuminjectedsources-next.md)  
+[IDiaEnumInjectedSources](../../debugger/debug-interface-access/idiaenuminjectedsources.md)


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.