### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/debugger/debug-interface-access/idialinenumber.md
+++ b/docs/debugger/debug-interface-access/idialinenumber.md
@@ -118,7 +118,7 @@ void dumpFunctionLines( IDiaSymbol* pSymbol, IDiaSession* pSession )
                             pLine->get_lineNumber( &linenum );
                             printf( "\t\tfound line %d at 0x%x:0x%x\n", linenum, seg, offset );
                             pLine = NULL;
-                       }
+                        }
                     }
                     firstLine = false;
                 }

--- a/docs/debugger/debug-interface-access/idialinenumber.md
+++ b/docs/debugger/debug-interface-access/idialinenumber.md
@@ -2,141 +2,141 @@
 title: "IDiaLineNumber | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-dev_langs: 
+dev_langs:
   - "C++"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "IDiaLineNumber interface"
 ms.assetid: 1071f7d0-1f8c-4384-933f-c49c7eb930bd
 author: "mikejo5000"
 ms.author: "mikejo"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "multiple"
 ---
 # IDiaLineNumber
-Accesses information that describes the process of mapping from a block of bytes of image text to a source file line number.  
-  
-## Syntax  
-  
-```  
-IDiaLineNumber : IUnknown  
-```  
-  
-## Methods in Vtable Order  
- The following table shows the methods of `IDiaLineNumber`.  
-  
-|Method|Description|  
-|------------|-----------------|  
-|[IDiaLineNumber::get_compiland](../../debugger/debug-interface-access/idialinenumber-get-compiland.md)|Retrieves a reference to the symbol for the compiland that contributed the bytes of image text.|  
-|[IDiaLineNumber::get_sourceFile](../../debugger/debug-interface-access/idialinenumber-get-sourcefile.md)|Retrieves a reference to the source file object.|  
-|[IDiaLineNumber::get_lineNumber](../../debugger/debug-interface-access/idialinenumber-get-linenumber.md)|Retrieves the line number in the source file.|  
-|[IDiaLineNumber::get_lineNumberEnd](../../debugger/debug-interface-access/idialinenumber-get-linenumberend.md)|Retrieves the one-based source line number where the statement or expression ends.|  
-|[IDiaLineNumber::get_columnNumber](../../debugger/debug-interface-access/idialinenumber-get-columnnumber.md)|Retrieves the column number where the expression or statement begins.|  
-|[IDiaLineNumber::get_columnNumberEnd](../../debugger/debug-interface-access/idialinenumber-get-columnnumberend.md)|Retrieves the column number where the expression or statement ends.|  
-|[IDiaLineNumber::get_addressSection](../../debugger/debug-interface-access/idialinenumber-get-addresssection.md)|Retrieves the section part of the memory address where a block begins.|  
-|[IDiaLineNumber::get_addressOffset](../../debugger/debug-interface-access/idialinenumber-get-addressoffset.md)|Retrieves the offset part of the memory address where a block begins.|  
-|[IDiaLineNumber::get_relativeVirtualAddress](../../debugger/debug-interface-access/idialinenumber-get-relativevirtualaddress.md)|Retrieves the image relative virtual address (RVA) of a block.|  
-|[IDiaLineNumber::get_virtualAddress](../../debugger/debug-interface-access/idialinenumber-get-virtualaddress.md)|Retrieves the virtual address (VA) of a block.|  
-|[IDiaLineNumber::get_length](../../debugger/debug-interface-access/idialinenumber-get-length.md)|Retrieves the number of bytes in a block.|  
-|[IDiaLineNumber::get_sourceFileId](../../debugger/debug-interface-access/idialinenumber-get-sourcefileid.md)|Retrieves a unique source file identifier for the source file that contributed this line.|  
-|[IDiaLineNumber::get_statement](../../debugger/debug-interface-access/idialinenumber-get-statement.md)|Retrieves a flag indicating that this line information describes the beginning of a statement in the program source.|  
-|[IDiaLineNumber::get_compilandId](../../debugger/debug-interface-access/idialinenumber-get-compilandid.md)|Retrieves the unique identifier for the compiland that contributed this line.|  
-  
-## Remarks  
-  
-## Notes for Callers  
- Obtain this interface by calling the [IDiaEnumLineNumbers::Item](../../debugger/debug-interface-access/idiaenumlinenumbers-item.md) or [IDiaEnumLineNumbers::Next](../../debugger/debug-interface-access/idiaenumlinenumbers-next.md) methods.  
-  
-## Example  
- The following function displays line numbers used in a function (represented by `pSymbol`).  
-  
-```C++  
-void dumpFunctionLines( IDiaSymbol* pSymbol, IDiaSession* pSession )  
-{  
-    ULONGLONG length = 0;  
-    DWORD     isect  = 0;  
-    DWORD     offset = 0;  
-  
-    pSymbol->get_addressSection( &isect );  
-    pSymbol->get_addressOffset( &offset );  
-    pSymbol->get_length( &length );  
-    if ( isect != 0 && length > 0 )  
-    {  
-        CComPtr< IDiaEnumLineNumbers > pLines;  
-        if ( SUCCEEDED( pSession->findLinesByAddr(  
-                                      isect,  
-                                      offset,  
-                                      static_cast<DWORD>( length ),  
-                                      &pLines)  
-                      )  
-           )  
-        {  
-            CComPtr< IDiaLineNumber > pLine;  
-            DWORD celt      = 0;  
-            bool  firstLine = true;  
-  
-            while ( SUCCEEDED( pLines->Next( 1, &pLine, &celt ) ) &&  
-                    celt == 1 )  
-            {  
-                DWORD offset;  
-                DWORD seg;  
-                DWORD linenum;  
-                CComPtr< IDiaSymbol >     pComp;  
-                CComPtr< IDiaSourceFile > pSrc;  
-  
-                pLine->get_compiland( &pComp );  
-                pLine->get_sourceFile( &pSrc );  
-                pLine->get_addressSection( &seg );  
-                pLine->get_addressOffset( &offset );  
-                pLine->get_lineNumber( &linenum );  
-                printf( "\tline %d at 0x%x:0x%x\n", linenum, seg, offset );  
-                pLine = NULL;  
-                if ( firstLine )  
-                {  
-                    // sanity check  
-                    CComPtr< IDiaEnumLineNumbers > pLinesByLineNum;  
-                    if ( SUCCEEDED( pSession->findLinesByLinenum(  
-                                                  pComp,  
-                                                  pSrc,  
-                                                  linenum,  
-                                                  0,  
-                                                  &pLinesByLineNum)  
-                                  )  
-                       )  
-                    {  
-                        CComPtr< IDiaLineNumber > pLine;  
-                        DWORD celt;  
-                        while ( SUCCEEDED( pLinesByLineNum->Next( 1, &pLine, &celt ) ) &&  
-                                celt == 1 )  
-                        {  
-                            DWORD offset;  
-                            DWORD seg;  
-                            DWORD linenum;  
-  
-                            pLine->get_addressSection( &seg );  
-                            pLine->get_addressOffset( &offset );  
-                            pLine->get_lineNumber( &linenum );  
-                            printf( "\t\tfound line %d at 0x%x:0x%x\n", linenum, seg, offset );  
-                            pLine = NULL;  
-                       }  
-                    }  
-                    firstLine = false;  
-                }  
-            }  
-        }  
-    }  
-}  
-```  
-  
-## Requirements  
- Header: Dia2.h  
-  
- Library: diaguids.lib  
-  
- DLL: msdia80.dll  
-  
-## See Also  
- [Interfaces (Debug Interface Access SDK)](../../debugger/debug-interface-access/interfaces-debug-interface-access-sdk.md)   
- [IDiaEnumLineNumbers](../../debugger/debug-interface-access/idiaenumlinenumbers.md)   
- [IDiaEnumLineNumbers::Item](../../debugger/debug-interface-access/idiaenumlinenumbers-item.md)   
- [IDiaEnumLineNumbers::Next](../../debugger/debug-interface-access/idiaenumlinenumbers-next.md)
+Accesses information that describes the process of mapping from a block of bytes of image text to a source file line number.
+
+## Syntax
+
+```
+IDiaLineNumber : IUnknown
+```
+
+## Methods in Vtable Order
+The following table shows the methods of `IDiaLineNumber`.
+
+|Method|Description|
+|------------|-----------------|
+|[IDiaLineNumber::get_compiland](../../debugger/debug-interface-access/idialinenumber-get-compiland.md)|Retrieves a reference to the symbol for the compiland that contributed the bytes of image text.|
+|[IDiaLineNumber::get_sourceFile](../../debugger/debug-interface-access/idialinenumber-get-sourcefile.md)|Retrieves a reference to the source file object.|
+|[IDiaLineNumber::get_lineNumber](../../debugger/debug-interface-access/idialinenumber-get-linenumber.md)|Retrieves the line number in the source file.|
+|[IDiaLineNumber::get_lineNumberEnd](../../debugger/debug-interface-access/idialinenumber-get-linenumberend.md)|Retrieves the one-based source line number where the statement or expression ends.|
+|[IDiaLineNumber::get_columnNumber](../../debugger/debug-interface-access/idialinenumber-get-columnnumber.md)|Retrieves the column number where the expression or statement begins.|
+|[IDiaLineNumber::get_columnNumberEnd](../../debugger/debug-interface-access/idialinenumber-get-columnnumberend.md)|Retrieves the column number where the expression or statement ends.|
+|[IDiaLineNumber::get_addressSection](../../debugger/debug-interface-access/idialinenumber-get-addresssection.md)|Retrieves the section part of the memory address where a block begins.|
+|[IDiaLineNumber::get_addressOffset](../../debugger/debug-interface-access/idialinenumber-get-addressoffset.md)|Retrieves the offset part of the memory address where a block begins.|
+|[IDiaLineNumber::get_relativeVirtualAddress](../../debugger/debug-interface-access/idialinenumber-get-relativevirtualaddress.md)|Retrieves the image relative virtual address (RVA) of a block.|
+|[IDiaLineNumber::get_virtualAddress](../../debugger/debug-interface-access/idialinenumber-get-virtualaddress.md)|Retrieves the virtual address (VA) of a block.|
+|[IDiaLineNumber::get_length](../../debugger/debug-interface-access/idialinenumber-get-length.md)|Retrieves the number of bytes in a block.|
+|[IDiaLineNumber::get_sourceFileId](../../debugger/debug-interface-access/idialinenumber-get-sourcefileid.md)|Retrieves a unique source file identifier for the source file that contributed this line.|
+|[IDiaLineNumber::get_statement](../../debugger/debug-interface-access/idialinenumber-get-statement.md)|Retrieves a flag indicating that this line information describes the beginning of a statement in the program source.|
+|[IDiaLineNumber::get_compilandId](../../debugger/debug-interface-access/idialinenumber-get-compilandid.md)|Retrieves the unique identifier for the compiland that contributed this line.|
+
+## Remarks
+
+## Notes for Callers
+Obtain this interface by calling the [IDiaEnumLineNumbers::Item](../../debugger/debug-interface-access/idiaenumlinenumbers-item.md) or [IDiaEnumLineNumbers::Next](../../debugger/debug-interface-access/idiaenumlinenumbers-next.md) methods.
+
+## Example
+The following function displays line numbers used in a function (represented by `pSymbol`).
+
+```C++
+void dumpFunctionLines( IDiaSymbol* pSymbol, IDiaSession* pSession )
+{
+    ULONGLONG length = 0;
+    DWORD     isect  = 0;
+    DWORD     offset = 0;
+
+    pSymbol->get_addressSection( &isect );
+    pSymbol->get_addressOffset( &offset );
+    pSymbol->get_length( &length );
+    if ( isect != 0 && length > 0 )
+    {
+        CComPtr< IDiaEnumLineNumbers > pLines;
+        if ( SUCCEEDED( pSession->findLinesByAddr(
+                                      isect,
+                                      offset,
+                                      static_cast<DWORD>( length ),
+                                      &pLines)
+                      )
+           )
+        {
+            CComPtr< IDiaLineNumber > pLine;
+            DWORD celt      = 0;
+            bool  firstLine = true;
+
+            while ( SUCCEEDED( pLines->Next( 1, &pLine, &celt ) ) &&
+                    celt == 1 )
+            {
+                DWORD offset;
+                DWORD seg;
+                DWORD linenum;
+                CComPtr< IDiaSymbol >     pComp;
+                CComPtr< IDiaSourceFile > pSrc;
+
+                pLine->get_compiland( &pComp );
+                pLine->get_sourceFile( &pSrc );
+                pLine->get_addressSection( &seg );
+                pLine->get_addressOffset( &offset );
+                pLine->get_lineNumber( &linenum );
+                printf( "\tline %d at 0x%x:0x%x\n", linenum, seg, offset );
+                pLine = NULL;
+                if ( firstLine )
+                {
+                    // sanity check
+                    CComPtr< IDiaEnumLineNumbers > pLinesByLineNum;
+                    if ( SUCCEEDED( pSession->findLinesByLinenum(
+                                                  pComp,
+                                                  pSrc,
+                                                  linenum,
+                                                  0,
+                                                  &pLinesByLineNum)
+                                  )
+                       )
+                    {
+                        CComPtr< IDiaLineNumber > pLine;
+                        DWORD celt;
+                        while ( SUCCEEDED( pLinesByLineNum->Next( 1, &pLine, &celt ) ) &&
+                                celt == 1 )
+                        {
+                            DWORD offset;
+                            DWORD seg;
+                            DWORD linenum;
+
+                            pLine->get_addressSection( &seg );
+                            pLine->get_addressOffset( &offset );
+                            pLine->get_lineNumber( &linenum );
+                            printf( "\t\tfound line %d at 0x%x:0x%x\n", linenum, seg, offset );
+                            pLine = NULL;
+                       }
+                    }
+                    firstLine = false;
+                }
+            }
+        }
+    }
+}
+```
+
+## Requirements
+Header: Dia2.h
+
+Library: diaguids.lib
+
+DLL: msdia80.dll
+
+## See Also
+[Interfaces (Debug Interface Access SDK)](../../debugger/debug-interface-access/interfaces-debug-interface-access-sdk.md)  
+[IDiaEnumLineNumbers](../../debugger/debug-interface-access/idiaenumlinenumbers.md)  
+[IDiaEnumLineNumbers::Item](../../debugger/debug-interface-access/idiaenumlinenumbers-item.md)  
+[IDiaEnumLineNumbers::Next](../../debugger/debug-interface-access/idiaenumlinenumbers-next.md)


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.