### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/debugger/debug-interface-access/idiapropertystorage.md
+++ b/docs/debugger/debug-interface-access/idiapropertystorage.md
@@ -2,132 +2,132 @@
 title: "IDiaPropertyStorage | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-dev_langs: 
+dev_langs:
   - "C++"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "IDiaPropertyStorage interface"
 ms.assetid: d3197a38-5973-4e56-873e-4f1b84c3f674
 author: "mikejo5000"
 ms.author: "mikejo"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "multiple"
 ---
 # IDiaPropertyStorage
-Allows you to read the persistent properties of a DIA property set.  
-  
-## Syntax  
-  
-```  
-IDiaPropertyStorage : IUnknown  
-```  
-  
-## Methods in Vtable Order  
- The following table shows the methods of `IDiaPropertyStorage`.  
-  
-|Method|Description|  
-|------------|-----------------|  
-|[IDiaPropertyStorage::Enum](../../debugger/debug-interface-access/idiapropertystorage-enum.md)|Gets a pointer to an enumerator for properties within this set.|  
-|[IDiaPropertyStorage::ReadBOOL](../../debugger/debug-interface-access/idiapropertystorage-readbool.md)|Reads `BOOL` values in a property set.|  
-|[IDiaPropertyStorage::ReadBSTR](../../debugger/debug-interface-access/idiapropertystorage-readbstr.md)|Reads `BSTR` values in a property set.|  
-|[IDiaPropertyStorage::ReadDWORD](../../debugger/debug-interface-access/idiapropertystorage-readdword.md)|Reads `DWORD` values in a property set.|  
-|[IDiaPropertyStorage::ReadLONG](../../debugger/debug-interface-access/idiapropertystorage-readlong.md)|Reads `LONG` values in a property set.|  
-|[IDiaPropertyStorage::ReadMultiple](../../debugger/debug-interface-access/idiapropertystorage-readmultiple.md)|Reads property values in a property set.|  
-|[IDiaPropertyStorage::ReadPropertyNames](../../debugger/debug-interface-access/idiapropertystorage-readpropertynames.md)|Gets corresponding string names for given property identifiers.|  
-|[IDiaPropertyStorage::ReadULONGLONG](../../debugger/debug-interface-access/idiapropertystorage-readulonglong.md)|Reads `ULONGLONG` values in a property set.|  
-  
-## Remarks  
- Each property within a property set is identified by a property identifier (ID), a four-byte `ULONG` value unique to that set. The properties exposed through the `IDiaPropertyStorage` interface correspond to the properties available in the parent interface. For example, the properties of the [IDiaSymbol](../../debugger/debug-interface-access/idiasymbol.md) interface can be accessed by name through the `IDiaPropertyStorage` interface (note, however, that even though the property may be accessible, it does not mean the property is valid for a particular `IDiaSymbol` object).  
-  
-## Notes for Callers  
- Obtain this interface by calling the `QueryInterface` method on another interface. The following interfaces can be queried for the `IDiaPropertyStorage` interface:  
-  
--   [IDiaSectionContrib](../../debugger/debug-interface-access/idiasectioncontrib.md)  
-  
--   [IDiaSegment](../../debugger/debug-interface-access/idiasegment.md)  
-  
--   [IDiaInjectedSource](../../debugger/debug-interface-access/idiainjectedsource.md)  
-  
--   [IDiaFrameData](../../debugger/debug-interface-access/idiaframedata.md)  
-  
--   [IDiaSymbol](../../debugger/debug-interface-access/idiasymbol.md)  
-  
--   [IDiaSourceFile](../../debugger/debug-interface-access/idiasourcefile.md)  
-  
--   [IDiaLineNumber](../../debugger/debug-interface-access/idialinenumber.md)  
-  
-## Example  
- This example shows a function that displays all properties exposed by the `IDiaPropertyStorage` object. See the [IDiaEnumInjectedSources](../../debugger/debug-interface-access/idiaenuminjectedsources.md) interface for an example of how the `IDiaPropertyStorage` interface is obtained from the [IDiaInjectedSource](../../debugger/debug-interface-access/idiainjectedsource.md) interface.  
-  
-```C++  
-void PrintPropertyStorage(IDiaPropertyStorage* pPropertyStorage)  
-{  
-    IEnumSTATPROPSTG* pEnumProps;  
-    STATPROPSTG       prop;  
-    DWORD             celt = 1;  
-  
-    if (pPropertyStorage->Enum(&pEnumProps) == S_OK)  
-    {  
-        while (pEnumProps->Next(celt, &prop, &celt) == S_OK)  
-        {  
-            PROPSPEC pspec = { PRSPEC_PROPID, prop.propid };  
-            PROPVARIANT vt = { VT_EMPTY };  
-  
-            if (pPropertyStorage->ReadMultiple( 1, &pspec, &vt) == S_OK)  
-            {  
-                switch( vt.vt ){  
-                    case VT_BOOL:  
-                        wprintf( L"%32s:\t %s\n", prop.lpwstrName, vt.bVal ? L"true" : L"false" );  
-                        break;  
-                    case VT_I2:  
-                        wprintf( L"%32s:\t %d\n", prop.lpwstrName, vt.iVal );  
-                        break;  
-                    case VT_UI2:  
-                        wprintf( L"%32s:\t %d\n", prop.lpwstrName, vt.uiVal );  
-                        break;  
-                    case VT_I4:  
-                        wprintf( L"%32s:\t %d\n", prop.lpwstrName, vt.intVal );  
-                        break;  
-                    case VT_UI4:  
-                        wprintf( L"%32s:\t 0x%0x\n", prop.lpwstrName, vt.uintVal );  
-                        break;  
-                    case VT_UI8:  
-                        wprintf( L"%32s:\t 0x%x\n", prop.lpwstrName, vt.uhVal.QuadPart );  
-                        break;  
-                    case VT_BSTR:  
-                        wprintf( L"%32s:\t %s\n", prop.lpwstrName, vt.bstrVal );  
-                        break;  
-                    case VT_UNKNOWN:  
-                        wprintf( L"%32s:\t %p\n", prop.lpwstrName, vt.punkVal );  
-                        break;  
-                    case VT_SAFEARRAY:  
-                        break;  
-                    default:  
-                       break;  
-                }  
-                VariantClear((VARIANTARG*) &vt);  
-            }  
-        }  
-        pEnumProps->Release();  
-    }  
-}  
-```  
-  
-## Requirements  
- Header: Dia2.h  
-  
- Library: diaguids.lib  
-  
- DLL: msdia80.dll  
-  
-## See Also  
- [Interfaces (Debug Interface Access SDK)](../../debugger/debug-interface-access/interfaces-debug-interface-access-sdk.md)   
- [IDiaSession::getEnumTables](../../debugger/debug-interface-access/idiasession-getenumtables.md)   
- [IDiaSectionContrib](../../debugger/debug-interface-access/idiasectioncontrib.md)   
- [IDiaSegment](../../debugger/debug-interface-access/idiasegment.md)   
- [IDiaInjectedSource](../../debugger/debug-interface-access/idiainjectedsource.md)   
- [IDiaFrameData](../../debugger/debug-interface-access/idiaframedata.md)   
- [IDiaSymbol](../../debugger/debug-interface-access/idiasymbol.md)   
- [IDiaSourceFile](../../debugger/debug-interface-access/idiasourcefile.md)   
- [IDiaLineNumber](../../debugger/debug-interface-access/idialinenumber.md)   
- [IDiaEnumInjectedSources](../../debugger/debug-interface-access/idiaenuminjectedsources.md)
+Allows you to read the persistent properties of a DIA property set.
+
+## Syntax
+
+```
+IDiaPropertyStorage : IUnknown
+```
+
+## Methods in Vtable Order
+The following table shows the methods of `IDiaPropertyStorage`.
+
+|Method|Description|
+|------------|-----------------|
+|[IDiaPropertyStorage::Enum](../../debugger/debug-interface-access/idiapropertystorage-enum.md)|Gets a pointer to an enumerator for properties within this set.|
+|[IDiaPropertyStorage::ReadBOOL](../../debugger/debug-interface-access/idiapropertystorage-readbool.md)|Reads `BOOL` values in a property set.|
+|[IDiaPropertyStorage::ReadBSTR](../../debugger/debug-interface-access/idiapropertystorage-readbstr.md)|Reads `BSTR` values in a property set.|
+|[IDiaPropertyStorage::ReadDWORD](../../debugger/debug-interface-access/idiapropertystorage-readdword.md)|Reads `DWORD` values in a property set.|
+|[IDiaPropertyStorage::ReadLONG](../../debugger/debug-interface-access/idiapropertystorage-readlong.md)|Reads `LONG` values in a property set.|
+|[IDiaPropertyStorage::ReadMultiple](../../debugger/debug-interface-access/idiapropertystorage-readmultiple.md)|Reads property values in a property set.|
+|[IDiaPropertyStorage::ReadPropertyNames](../../debugger/debug-interface-access/idiapropertystorage-readpropertynames.md)|Gets corresponding string names for given property identifiers.|
+|[IDiaPropertyStorage::ReadULONGLONG](../../debugger/debug-interface-access/idiapropertystorage-readulonglong.md)|Reads `ULONGLONG` values in a property set.|
+
+## Remarks
+Each property within a property set is identified by a property identifier (ID), a four-byte `ULONG` value unique to that set. The properties exposed through the `IDiaPropertyStorage` interface correspond to the properties available in the parent interface. For example, the properties of the [IDiaSymbol](../../debugger/debug-interface-access/idiasymbol.md) interface can be accessed by name through the `IDiaPropertyStorage` interface (note, however, that even though the property may be accessible, it does not mean the property is valid for a particular `IDiaSymbol` object).
+
+## Notes for Callers
+Obtain this interface by calling the `QueryInterface` method on another interface. The following interfaces can be queried for the `IDiaPropertyStorage` interface:
+
+- [IDiaSectionContrib](../../debugger/debug-interface-access/idiasectioncontrib.md)
+
+- [IDiaSegment](../../debugger/debug-interface-access/idiasegment.md)
+
+- [IDiaInjectedSource](../../debugger/debug-interface-access/idiainjectedsource.md)
+
+- [IDiaFrameData](../../debugger/debug-interface-access/idiaframedata.md)
+
+- [IDiaSymbol](../../debugger/debug-interface-access/idiasymbol.md)
+
+- [IDiaSourceFile](../../debugger/debug-interface-access/idiasourcefile.md)
+
+- [IDiaLineNumber](../../debugger/debug-interface-access/idialinenumber.md)
+
+## Example
+This example shows a function that displays all properties exposed by the `IDiaPropertyStorage` object. See the [IDiaEnumInjectedSources](../../debugger/debug-interface-access/idiaenuminjectedsources.md) interface for an example of how the `IDiaPropertyStorage` interface is obtained from the [IDiaInjectedSource](../../debugger/debug-interface-access/idiainjectedsource.md) interface.
+
+```C++
+void PrintPropertyStorage(IDiaPropertyStorage* pPropertyStorage)
+{
+    IEnumSTATPROPSTG* pEnumProps;
+    STATPROPSTG       prop;
+    DWORD             celt = 1;
+
+    if (pPropertyStorage->Enum(&pEnumProps) == S_OK)
+    {
+        while (pEnumProps->Next(celt, &prop, &celt) == S_OK)
+        {
+            PROPSPEC pspec = { PRSPEC_PROPID, prop.propid };
+            PROPVARIANT vt = { VT_EMPTY };
+
+            if (pPropertyStorage->ReadMultiple( 1, &pspec, &vt) == S_OK)
+            {
+                switch( vt.vt ){
+                    case VT_BOOL:
+                        wprintf( L"%32s:\t %s\n", prop.lpwstrName, vt.bVal ? L"true" : L"false" );
+                        break;
+                    case VT_I2:
+                        wprintf( L"%32s:\t %d\n", prop.lpwstrName, vt.iVal );
+                        break;
+                    case VT_UI2:
+                        wprintf( L"%32s:\t %d\n", prop.lpwstrName, vt.uiVal );
+                        break;
+                    case VT_I4:
+                        wprintf( L"%32s:\t %d\n", prop.lpwstrName, vt.intVal );
+                        break;
+                    case VT_UI4:
+                        wprintf( L"%32s:\t 0x%0x\n", prop.lpwstrName, vt.uintVal );
+                        break;
+                    case VT_UI8:
+                        wprintf( L"%32s:\t 0x%x\n", prop.lpwstrName, vt.uhVal.QuadPart );
+                        break;
+                    case VT_BSTR:
+                        wprintf( L"%32s:\t %s\n", prop.lpwstrName, vt.bstrVal );
+                        break;
+                    case VT_UNKNOWN:
+                        wprintf( L"%32s:\t %p\n", prop.lpwstrName, vt.punkVal );
+                        break;
+                    case VT_SAFEARRAY:
+                        break;
+                    default:
+                       break;
+                }
+                VariantClear((VARIANTARG*) &vt);
+            }
+        }
+        pEnumProps->Release();
+    }
+}
+```
+
+## Requirements
+Header: Dia2.h
+
+Library: diaguids.lib
+
+DLL: msdia80.dll
+
+## See Also
+[Interfaces (Debug Interface Access SDK)](../../debugger/debug-interface-access/interfaces-debug-interface-access-sdk.md)  
+[IDiaSession::getEnumTables](../../debugger/debug-interface-access/idiasession-getenumtables.md)  
+[IDiaSectionContrib](../../debugger/debug-interface-access/idiasectioncontrib.md)  
+[IDiaSegment](../../debugger/debug-interface-access/idiasegment.md)  
+[IDiaInjectedSource](../../debugger/debug-interface-access/idiainjectedsource.md)  
+[IDiaFrameData](../../debugger/debug-interface-access/idiaframedata.md)  
+[IDiaSymbol](../../debugger/debug-interface-access/idiasymbol.md)  
+[IDiaSourceFile](../../debugger/debug-interface-access/idiasourcefile.md)  
+[IDiaLineNumber](../../debugger/debug-interface-access/idialinenumber.md)  
+[IDiaEnumInjectedSources](../../debugger/debug-interface-access/idiaenuminjectedsources.md)


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.