### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/debugger/debug-interface-access/idiasession-findlinesbyaddr.md
+++ b/docs/debugger/debug-interface-access/idiasession-findlinesbyaddr.md
@@ -20,10 +20,10 @@ Retrieves the lines in a specified compiland that contain a specified address.
 
 ```C++
 HRESULT findLinesByAddr (
-   DWORD                 seg,
-   DWORD                 offset,
-   DWORD                 length,
-   IDiaEnumLineNumbers** ppResult
+    DWORD                 seg,
+    DWORD                 offset,
+    DWORD                 length,
+    IDiaEnumLineNumbers** ppResult
 );
 ```
 

--- a/docs/debugger/debug-interface-access/idiasession-findlinesbyaddr.md
+++ b/docs/debugger/debug-interface-access/idiasession-findlinesbyaddr.md
@@ -2,70 +2,70 @@
 title: "IDiaSession::findLinesByAddr | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-dev_langs: 
+dev_langs:
   - "C++"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "IDiaSession::findLinesByAddr method"
 ms.assetid: 640403c0-14cf-403c-ad19-38b3bdc28ca8
 author: "mikejo5000"
 ms.author: "mikejo"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "multiple"
 ---
 # IDiaSession::findLinesByAddr
-Retrieves the lines in a specified compiland that contain a specified address.  
-  
-## Syntax  
-  
-```C++  
-HRESULT findLinesByAddr (   
-   DWORD                 seg,  
-   DWORD                 offset,  
-   DWORD                 length,  
-   IDiaEnumLineNumbers** ppResult  
-);  
-```  
-  
-#### Parameters  
- `seg`  
- [in] Specifies the section component of the specific address.  
-  
- `offset`  
- [in] Specifies the offset component of the specific address.  
-  
- `length`  
- [in] Specifies the number of bytes of address range to cover with this query.  
-  
- `ppResult`  
- [out] Returns an [IDiaEnumLineNumbers](../../debugger/debug-interface-access/idiaenumlinenumbers.md) object that contains a list of all the line numbers that cover the specified address range.  
-  
-## Return Value  
- If successful, returns `S_OK`; otherwise, returns an error code.  
-  
-## Example  
- This example shows a function that obtains all line numbers contained in a function using the function's address and length.  
-  
-```C++  
-IDiaEnumLineNumbers* GetLineNumbersByAddr(IDiaSymbol *pFunc,  
-                                          IDiaSession *pSession)  
-{  
-    IDiaEnumLineNumbers* pEnum = NULL;  
-    DWORD                seg;  
-    DWORD                offset;  
-    ULONGLONG            length;  
-  
-    if (pFunc->get_addressSection ( &seg ) == S_OK &&  
-        pFunc->get_addressOffset ( &offset ) == S_OK)  
-    {  
-        pFunc->get_length ( &length );  
-        pSession->findLinesByAddr( seg, offset, static_cast<DWORD>( length ), &pEnum );  
-    }  
-    return(pEnum);  
-}  
-```  
-  
-## See Also  
- [IDiaEnumLineNumbers](../../debugger/debug-interface-access/idiaenumlinenumbers.md)   
- [IDiaSession](../../debugger/debug-interface-access/idiasession.md)   
- [IDiaSession::findLinesByVA](../../debugger/debug-interface-access/idiasession-findlinesbyva.md)
+Retrieves the lines in a specified compiland that contain a specified address.
+
+## Syntax
+
+```C++
+HRESULT findLinesByAddr (
+   DWORD                 seg,
+   DWORD                 offset,
+   DWORD                 length,
+   IDiaEnumLineNumbers** ppResult
+);
+```
+
+#### Parameters
+`seg`  
+[in] Specifies the section component of the specific address.
+
+`offset`  
+[in] Specifies the offset component of the specific address.
+
+`length`  
+[in] Specifies the number of bytes of address range to cover with this query.
+
+`ppResult`  
+[out] Returns an [IDiaEnumLineNumbers](../../debugger/debug-interface-access/idiaenumlinenumbers.md) object that contains a list of all the line numbers that cover the specified address range.
+
+## Return Value
+If successful, returns `S_OK`; otherwise, returns an error code.
+
+## Example
+This example shows a function that obtains all line numbers contained in a function using the function's address and length.
+
+```C++
+IDiaEnumLineNumbers* GetLineNumbersByAddr(IDiaSymbol *pFunc,
+                                          IDiaSession *pSession)
+{
+    IDiaEnumLineNumbers* pEnum = NULL;
+    DWORD                seg;
+    DWORD                offset;
+    ULONGLONG            length;
+
+    if (pFunc->get_addressSection ( &seg ) == S_OK &&
+        pFunc->get_addressOffset ( &offset ) == S_OK)
+    {
+        pFunc->get_length ( &length );
+        pSession->findLinesByAddr( seg, offset, static_cast<DWORD>( length ), &pEnum );
+    }
+    return(pEnum);
+}
+```
+
+## See Also
+[IDiaEnumLineNumbers](../../debugger/debug-interface-access/idiaenumlinenumbers.md)  
+[IDiaSession](../../debugger/debug-interface-access/idiasession.md)  
+[IDiaSession::findLinesByVA](../../debugger/debug-interface-access/idiasession-findlinesbyva.md)


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.