### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/debugger/debug-interface-access/idiasession-findlinesbyrva.md
+++ b/docs/debugger/debug-interface-access/idiasession-findlinesbyrva.md
@@ -2,62 +2,62 @@
 title: "IDiaSession::findLinesByRVA | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-dev_langs: 
+dev_langs:
   - "C++"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "IDiaSession::findLinesByRVA method"
 ms.assetid: 06f53b0b-b5b4-42cf-9252-dcee0dbe2d71
 author: "mikejo5000"
 ms.author: "mikejo"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "multiple"
 ---
 # IDiaSession::findLinesByRVA
-Retrieves the lines in a specified compiland that contain a specified relative virtual address (RVA).  
-  
-## Syntax  
-  
-```C++  
-HRESULT findLinesByRVA (   
-   DWORD                 rva,  
-   DWORD                 length,  
-   IDiaEnumLineNumbers** ppResult  
-);  
-```  
-  
-#### Parameters  
- `rva`  
- [in] Specifies the address as an RVA.  
-  
- `length`  
- [in] Specifies the number of bytes of address range to cover with this query.  
-  
- `ppResult`  
- [out] Returns an [IDiaEnumLineNumbers](../../debugger/debug-interface-access/idiaenumlinenumbers.md) object that contains a list of all the line numbers that cover the specified address range.  
-  
-## Return Value  
- If successful, returns `S_OK`; otherwise, returns an error code.  
-  
-## Example  
- This example shows a function that obtains all line numbers contained in the specified function using the function's relative virtual address and length.  
-  
-```C++  
-IDiaEnumLineNumbers* GetLineNumbersByRVA(IDiaSymbol *pFunc, IDiaSession *pSession)  
-{  
-    IDiaEnumLineNumbers* pEnum = NULL;  
-    DWORD                rva;  
-    ULONGLONG            length;  
-  
-    if (pFunc->get_relativeVirtualAddress ( &rva ) == S_OK)  
-    {  
-        pFunc->get_length ( &length );  
-        pSession->findLinesByRVA( rva, static_cast<DWORD>( length ), &pEnum );  
-    }  
-    return(pEnum);  
-}  
-```  
-  
-## See Also  
- [IDiaEnumLineNumbers](../../debugger/debug-interface-access/idiaenumlinenumbers.md)   
- [IDiaSession](../../debugger/debug-interface-access/idiasession.md)
+Retrieves the lines in a specified compiland that contain a specified relative virtual address (RVA).
+
+## Syntax
+
+```C++
+HRESULT findLinesByRVA ( 
+   DWORD                 rva,
+   DWORD                 length,
+   IDiaEnumLineNumbers** ppResult
+);
+```
+
+#### Parameters
+`rva`  
+[in] Specifies the address as an RVA.
+
+`length`  
+[in] Specifies the number of bytes of address range to cover with this query.
+
+`ppResult`  
+[out] Returns an [IDiaEnumLineNumbers](../../debugger/debug-interface-access/idiaenumlinenumbers.md) object that contains a list of all the line numbers that cover the specified address range.
+
+## Return Value
+If successful, returns `S_OK`; otherwise, returns an error code.
+
+## Example
+This example shows a function that obtains all line numbers contained in the specified function using the function's relative virtual address and length.
+
+```C++
+IDiaEnumLineNumbers* GetLineNumbersByRVA(IDiaSymbol *pFunc, IDiaSession *pSession)
+{
+    IDiaEnumLineNumbers* pEnum = NULL;
+    DWORD                rva;
+    ULONGLONG            length;
+
+    if (pFunc->get_relativeVirtualAddress ( &rva ) == S_OK)
+    {
+        pFunc->get_length ( &length );
+        pSession->findLinesByRVA( rva, static_cast<DWORD>( length ), &pEnum );
+    }
+    return(pEnum);
+}
+```
+
+## See Also
+[IDiaEnumLineNumbers](../../debugger/debug-interface-access/idiaenumlinenumbers.md)  
+[IDiaSession](../../debugger/debug-interface-access/idiasession.md)

--- a/docs/debugger/debug-interface-access/idiasession-findlinesbyrva.md
+++ b/docs/debugger/debug-interface-access/idiasession-findlinesbyrva.md
@@ -20,9 +20,9 @@ Retrieves the lines in a specified compiland that contain a specified relative v
 
 ```C++
 HRESULT findLinesByRVA ( 
-   DWORD                 rva,
-   DWORD                 length,
-   IDiaEnumLineNumbers** ppResult
+    DWORD                 rva,
+    DWORD                 length,
+    IDiaEnumLineNumbers** ppResult
 );
 ```
 


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.