### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/debugger/debug-interface-access/idiasession-findlinesbyva.md
+++ b/docs/debugger/debug-interface-access/idiasession-findlinesbyva.md
@@ -2,59 +2,59 @@
 title: "IDiaSession::findLinesByVA | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-dev_langs: 
+dev_langs:
   - "C++"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "IDiaSession::findLinesByVA method"
 ms.assetid: f647eee9-a73c-483b-9fe9-21f42e560a7b
 author: "mikejo5000"
 ms.author: "mikejo"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "multiple"
 ---
 # IDiaSession::findLinesByVA
-Retrieves the line number information for lines contained in a specified virtual address (VA) range.  
-  
-## Syntax  
-  
-```C++  
-HRESULT findLinesByVA (   
-   ULONGLONG             va,  
-   DWORD                 length,  
-   IDiaEnumLineNumbers** ppResult  
-);  
-```  
-  
-#### Parameters  
- `va`  
- [in] Specifies the address as a VA.  
-  
- `length`  
- [in] Specifies the number of bytes of address range to cover with this query.  
-  
- `ppResult`  
- [out] Returns an [IDiaEnumLineNumbers](../../debugger/debug-interface-access/idiaenumlinenumbers.md) object that contains a list of all the line numbers that cover the specified address range.  
-  
-## Example  
- This example shows a function that obtains all line numbers contained in a function using the function's virtual address and length.  
-  
-```C++  
-IDiaEnumLineNumbers *GetLineNumbersByVA(IDiaSymbol *pFunc, IDiaSession *pSession)  
-{  
-    IDiaEnumLineNumbers* pEnum = NULL;  
-    ULONGLONG            va;  
-    ULONGLONG            length;  
-  
-    if (pFunc->get_virtualAddress ( &va ) == S_OK)  
-    {  
-        pFunc->get_length( &length );  
-        pSession->findLinesByVA( va, static_cast<DWORD>( length ), &pEnum );  
-    }  
-    return(pEnum);  
-}  
-```  
-  
-## See Also  
- [IDiaEnumLineNumbers](../../debugger/debug-interface-access/idiaenumlinenumbers.md)   
- [IDiaSession](../../debugger/debug-interface-access/idiasession.md)
+Retrieves the line number information for lines contained in a specified virtual address (VA) range.
+
+## Syntax
+
+```C++
+HRESULT findLinesByVA ( 
+   ULONGLONG             va,
+   DWORD                 length,
+   IDiaEnumLineNumbers** ppResult
+);
+```
+
+#### Parameters
+`va`  
+[in] Specifies the address as a VA.
+
+`length`  
+[in] Specifies the number of bytes of address range to cover with this query.
+
+`ppResult`  
+[out] Returns an [IDiaEnumLineNumbers](../../debugger/debug-interface-access/idiaenumlinenumbers.md) object that contains a list of all the line numbers that cover the specified address range.
+
+## Example
+This example shows a function that obtains all line numbers contained in a function using the function's virtual address and length.
+
+```C++
+IDiaEnumLineNumbers *GetLineNumbersByVA(IDiaSymbol *pFunc, IDiaSession *pSession)
+{
+    IDiaEnumLineNumbers* pEnum = NULL;
+    ULONGLONG            va;
+    ULONGLONG            length;
+
+    if (pFunc->get_virtualAddress ( &va ) == S_OK)
+    {
+        pFunc->get_length( &length );
+        pSession->findLinesByVA( va, static_cast<DWORD>( length ), &pEnum );
+    }
+    return(pEnum);
+}
+```
+
+## See Also
+[IDiaEnumLineNumbers](../../debugger/debug-interface-access/idiaenumlinenumbers.md)  
+[IDiaSession](../../debugger/debug-interface-access/idiasession.md)

--- a/docs/debugger/debug-interface-access/idiasession-findlinesbyva.md
+++ b/docs/debugger/debug-interface-access/idiasession-findlinesbyva.md
@@ -19,10 +19,10 @@ Retrieves the line number information for lines contained in a specified virtual
 ## Syntax
 
 ```C++
-HRESULT findLinesByVA ( 
-   ULONGLONG             va,
-   DWORD                 length,
-   IDiaEnumLineNumbers** ppResult
+HRESULT findLinesByVA (
+    ULONGLONG             va,
+    DWORD                 length,
+    IDiaEnumLineNumbers** ppResult
 );
 ```
 


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.