### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/debugger/debug-interface-access/idiasession-symbolbyid.md
+++ b/docs/debugger/debug-interface-access/idiasession-symbolbyid.md
@@ -20,8 +20,8 @@ Retrieves a symbol by its unique identifier.
 
 ```C++
 HRESULT symbolById (
-   DWORD        id,
-   IDiaSymbol** ppSymbol
+    DWORD        id,
+    IDiaSymbol** ppSymbol
 );
 ```
 

--- a/docs/debugger/debug-interface-access/idiasession-symbolbyid.md
+++ b/docs/debugger/debug-interface-access/idiasession-symbolbyid.md
@@ -2,62 +2,62 @@
 title: "IDiaSession::symbolById | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-dev_langs: 
+dev_langs:
   - "C++"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "IDiaSession::symbolById method"
 ms.assetid: 062e4b5a-9c4d-4703-88da-ec13102c2b66
 author: "mikejo5000"
 ms.author: "mikejo"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "multiple"
 ---
 # IDiaSession::symbolById
-Retrieves a symbol by its unique identifier.  
-  
-## Syntax  
-  
-```C++  
-HRESULT symbolById (   
-   DWORD        id,  
-   IDiaSymbol** ppSymbol  
-);  
-```  
-  
-#### Parameters  
- `id`  
- [in] Unique identifier.  
-  
- `ppSymbol`  
- [out] Returns an [IDiaSymbol](../../debugger/debug-interface-access/idiasymbol.md) object that represents the symbol retrieved.  
-  
-## Return Value  
- If successful, returns `S_OK`; otherwise, returns an error code.  
-  
-## Remarks  
- The specified identifier is a unique value used internally by the DIA SDK to make all symbols unique.  
-  
- This method can be used, for example, to retrieve the symbol representing the type of another symbol (see the example).  
-  
-## Example  
- This example retrieves an [IDiaSymbol](../../debugger/debug-interface-access/idiasymbol.md) representing the type of another symbol. This example shows how to use the `symbolById` method in the session. A simpler approach is to call the [IDiaSymbol::get_type](../../debugger/debug-interface-access/idiasymbol-get-type.md) method to retrieve the type symbol directly.  
-  
-```C++  
-IDiaSymbol *GetSymbolType(IDiaSymbol *pSymbol, IDiaSession *pSession)  
-{  
-    IDiaSymbol *pTypeSymbol = NULL;  
-    if (pSymbol != NULL && pSession != NULL)  
-    {  
-        DWORD symbolTypeId;  
-        pSymbol->get_typeId(&symbolTypeId);  
-        pSession->symbolById(symbolTypeId, &pTypeSymbol);  
-    }  
-    return(pTypeSymbol);  
-}  
-```  
-  
-## See Also  
- [IDiaSession](../../debugger/debug-interface-access/idiasession.md)   
- [IDiaSymbol](../../debugger/debug-interface-access/idiasymbol.md)   
- [IDiaSymbol::get_type](../../debugger/debug-interface-access/idiasymbol-get-type.md)
+Retrieves a symbol by its unique identifier.
+
+## Syntax
+
+```C++
+HRESULT symbolById (
+   DWORD        id,
+   IDiaSymbol** ppSymbol
+);
+```
+
+#### Parameters
+`id`  
+[in] Unique identifier.
+
+`ppSymbol`  
+[out] Returns an [IDiaSymbol](../../debugger/debug-interface-access/idiasymbol.md) object that represents the symbol retrieved.
+
+## Return Value
+If successful, returns `S_OK`; otherwise, returns an error code.
+
+## Remarks
+The specified identifier is a unique value used internally by the DIA SDK to make all symbols unique.
+
+This method can be used, for example, to retrieve the symbol representing the type of another symbol (see the example).
+
+## Example
+This example retrieves an [IDiaSymbol](../../debugger/debug-interface-access/idiasymbol.md) representing the type of another symbol. This example shows how to use the `symbolById` method in the session. A simpler approach is to call the [IDiaSymbol::get_type](../../debugger/debug-interface-access/idiasymbol-get-type.md) method to retrieve the type symbol directly.
+
+```C++
+IDiaSymbol *GetSymbolType(IDiaSymbol *pSymbol, IDiaSession *pSession)
+{
+    IDiaSymbol *pTypeSymbol = NULL;
+    if (pSymbol != NULL && pSession != NULL)
+    {
+        DWORD symbolTypeId;
+        pSymbol->get_typeId(&symbolTypeId);
+        pSession->symbolById(symbolTypeId, &pTypeSymbol);
+    }
+    return(pTypeSymbol);
+}
+```
+
+## See Also
+[IDiaSession](../../debugger/debug-interface-access/idiasession.md)  
+[IDiaSymbol](../../debugger/debug-interface-access/idiasymbol.md)  
+[IDiaSymbol::get_type](../../debugger/debug-interface-access/idiasymbol-get-type.md)


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.