### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/debugger/debug-interface-access/idiasourcefile.md
+++ b/docs/debugger/debug-interface-access/idiasourcefile.md
@@ -2,82 +2,82 @@
 title: "IDiaSourceFile | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-dev_langs: 
+dev_langs:
   - "C++"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "IDiaSourceFile interface"
 ms.assetid: 6e9be757-797f-4960-ba62-c14092620bbd
 author: "mikejo5000"
 ms.author: "mikejo"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "multiple"
 ---
 # IDiaSourceFile
-Represents a source file.  
-  
-## Syntax  
-  
-```  
-IDiaSourceFile : IUnknown  
-```  
-  
-## Methods in Vtable Order  
- The following table shows the methods of `IDiaSourceFile`.  
-  
-|Method|Description|  
-|------------|-----------------|  
-|[IDiaSourceFile::get_uniqueId](../../debugger/debug-interface-access/idiasourcefile-get-uniqueid.md)|Retrieves a simple integer key value that is unique for this image.|  
-|[IDiaSourceFile::get_fileName](../../debugger/debug-interface-access/idiasourcefile-get-filename.md)|Retrieves the source file name.|  
-|[IDiaSourceFile::get_checksumType](../../debugger/debug-interface-access/idiasourcefile-get-checksumtype.md)|Retrieves the checksum type.|  
-|[IDiaSourceFile::get_compilands](../../debugger/debug-interface-access/idiasourcefile-get-compilands.md)|Retrieves an enumerator of the compilands with line numbers referencing this file.|  
-|[IDiaSourceFile::get_checksum](../../debugger/debug-interface-access/idiasourcefile-get-checksum.md)|Retrieves the checksum bytes.|  
-  
-## Remarks  
-  
-## Notes for Callers  
- Obtain this interface by calling the [IDiaEnumSourceFiles::Item](../../debugger/debug-interface-access/idiaenumsourcefiles-item.md) or [IDiaEnumSourceFiles::Next](../../debugger/debug-interface-access/idiaenumsourcefiles-next.md) methods. See the example for details.  
-  
-## Example  
- This function displays the names of all source files contributing to the specified table.  
-  
-```C++  
-void ShowSourceFiles(IDiaTable *pTable)  
-{  
-    CComPtr<IDiaEnumSourceFiles> pSourceFiles;  
-    if ( SUCCEEDED( pTable->QueryInterface(  
-                                _uuidof( IDiaEnumSourceFiles ),  
-                               (void**)&pSourceFiles )  
-                  )  
-       )  
-    {  
-        CComPtr<IDiaSourceFile> pSourceFile;  
-        while ( SUCCEEDED( hr = pSourceFiles->Next( 1, &pSourceFile, &celt ) ) &&  
-                celt == 1 )  
-        {  
-            CDiaBSTR fileName;  
-            if ( pSourceFile->get_fileName( &fileName) == S_OK )  
-            {  
-                printf( "file name: %ws\n", fileName );  
-            }  
-            pSourceFile = NULL;  
-        }  
-    }  
-}  
-```  
-  
-## Requirements  
- Header: Dia2.h  
-  
- Library: diaguids.lib  
-  
- DLL: msdia80.dll  
-  
-## See Also  
- [Interfaces (Debug Interface Access SDK)](../../debugger/debug-interface-access/interfaces-debug-interface-access-sdk.md)   
- [IDiaEnumSourceFiles::Item](../../debugger/debug-interface-access/idiaenumsourcefiles-item.md)   
- [IDiaEnumSourceFiles::Next](../../debugger/debug-interface-access/idiaenumsourcefiles-next.md)   
- [IDiaLineNumber::get_sourceFile](../../debugger/debug-interface-access/idialinenumber-get-sourcefile.md)   
- [IDiaSession::findFileById](../../debugger/debug-interface-access/idiasession-findfilebyid.md)   
- [IDiaSession::findLines](../../debugger/debug-interface-access/idiasession-findlines.md)   
- [IDiaSession::findLinesByLinenum](../../debugger/debug-interface-access/idiasession-findlinesbylinenum.md)
+Represents a source file.
+
+## Syntax
+
+```
+IDiaSourceFile : IUnknown
+```
+
+## Methods in Vtable Order
+The following table shows the methods of `IDiaSourceFile`.
+
+|Method|Description|
+|------------|-----------------|
+|[IDiaSourceFile::get_uniqueId](../../debugger/debug-interface-access/idiasourcefile-get-uniqueid.md)|Retrieves a simple integer key value that is unique for this image.|
+|[IDiaSourceFile::get_fileName](../../debugger/debug-interface-access/idiasourcefile-get-filename.md)|Retrieves the source file name.|
+|[IDiaSourceFile::get_checksumType](../../debugger/debug-interface-access/idiasourcefile-get-checksumtype.md)|Retrieves the checksum type.|
+|[IDiaSourceFile::get_compilands](../../debugger/debug-interface-access/idiasourcefile-get-compilands.md)|Retrieves an enumerator of the compilands with line numbers referencing this file.|
+|[IDiaSourceFile::get_checksum](../../debugger/debug-interface-access/idiasourcefile-get-checksum.md)|Retrieves the checksum bytes.|
+
+## Remarks
+
+## Notes for Callers
+Obtain this interface by calling the [IDiaEnumSourceFiles::Item](../../debugger/debug-interface-access/idiaenumsourcefiles-item.md) or [IDiaEnumSourceFiles::Next](../../debugger/debug-interface-access/idiaenumsourcefiles-next.md) methods. See the example for details.
+
+## Example
+This function displays the names of all source files contributing to the specified table.
+
+```C++
+void ShowSourceFiles(IDiaTable *pTable)
+{
+    CComPtr<IDiaEnumSourceFiles> pSourceFiles;
+    if ( SUCCEEDED( pTable->QueryInterface(
+                                _uuidof( IDiaEnumSourceFiles ),
+                               (void**)&pSourceFiles )
+                  )
+       )
+    {
+        CComPtr<IDiaSourceFile> pSourceFile;
+        while ( SUCCEEDED( hr = pSourceFiles->Next( 1, &pSourceFile, &celt ) ) &&
+                celt == 1 )
+        {
+            CDiaBSTR fileName;
+            if ( pSourceFile->get_fileName( &fileName) == S_OK )
+            {
+                printf( "file name: %ws\n", fileName );
+            }
+            pSourceFile = NULL;
+        }
+    }
+}
+```
+
+## Requirements
+Header: Dia2.h
+
+Library: diaguids.lib
+
+DLL: msdia80.dll
+
+## See Also
+[Interfaces (Debug Interface Access SDK)](../../debugger/debug-interface-access/interfaces-debug-interface-access-sdk.md)  
+[IDiaEnumSourceFiles::Item](../../debugger/debug-interface-access/idiaenumsourcefiles-item.md)  
+[IDiaEnumSourceFiles::Next](../../debugger/debug-interface-access/idiaenumsourcefiles-next.md)  
+[IDiaLineNumber::get_sourceFile](../../debugger/debug-interface-access/idialinenumber-get-sourcefile.md)  
+[IDiaSession::findFileById](../../debugger/debug-interface-access/idiasession-findfilebyid.md)  
+[IDiaSession::findLines](../../debugger/debug-interface-access/idiasession-findlines.md)  
+[IDiaSession::findLinesByLinenum](../../debugger/debug-interface-access/idiasession-findlinesbylinenum.md)


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.