### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/debugger/debug-interface-access/idiastackframe.md
+++ b/docs/debugger/debug-interface-access/idiastackframe.md
@@ -64,13 +64,13 @@ void PrintStackFrame(IDiaStackFrame* pFrame)
         if (pFrame->get_base(&bottom) == S_OK &&
             pFrame->get_registerValue( CV_REG_ESP, &top ) == S_OK )
         {
-             printf("range = 0x%08I64x - 0x%08I64x\n", bottom, top);
+            printf("range = 0x%08I64x - 0x%08I64x\n", bottom, top);
         }
 
         ULONGLONG returnAddress = 0;
         if (pFrame->get_returnAddress(&returnAddress) == S_OK)
         {
-             printf("return address = 0x%08I64x\n", returnAddress);
+            printf("return address = 0x%08I64x\n", returnAddress);
         }
 
         DWORD lengthFrame     = 0;

--- a/docs/debugger/debug-interface-access/idiastackframe.md
+++ b/docs/debugger/debug-interface-access/idiastackframe.md
@@ -2,107 +2,107 @@
 title: "IDiaStackFrame | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-dev_langs: 
+dev_langs:
   - "C++"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "IDiaStackFrame interface"
 ms.assetid: 486d25b8-a590-41c1-bdb5-faff3ae35632
 author: "mikejo5000"
 ms.author: "mikejo"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "multiple"
 ---
 # IDiaStackFrame
-Exposes the properties of a stack frame.  
-  
-## Syntax  
-  
-```  
-IDiaStackFrame : IUnknown  
-```  
-  
-## Methods in Vtable Order  
- The following are methods supported by this interface:  
-  
-|Method|Description|  
-|------------|-----------------|  
-|[IDiaStackFrame::get_allocatesBasePointer](../../debugger/debug-interface-access/idiastackframe-get-allocatesbasepointer.md)|Retrieves a flag indicating that the base pointer is allocated for code in this address range. This method is deprecated.|  
-|[IDiaStackFrame::get_base](../../debugger/debug-interface-access/idiastackframe-get-base.md)|Retrieves the address base of the frame.|  
-|[IDiaStackFrame::get_cplusplusExceptionHandling](../../debugger/debug-interface-access/idiastackframe-get-cplusplusexceptionhandling.md)|Retrieves a flag indicating that C++ exception handling is in effect.|  
-|[IDiaStackFrame::get_functionStart](../../debugger/debug-interface-access/idiastackframe-get-functionstart.md)|Retrieves a flag indicating that the block contains the entry point of a function.|  
-|[IDiaStackFrame::get_lengthLocals](../../debugger/debug-interface-access/idiastackframe-get-lengthlocals.md)|Retrieves the number of bytes of local variables pushed on the stack.|  
-|[IDiaStackFrame::get_lengthParams](../../debugger/debug-interface-access/idiastackframe-get-lengthparams.md)|Retrieves the number of bytes of parameters pushed on the stack.|  
-|[IDiaStackFrame::get_lengthProlog](../../debugger/debug-interface-access/idiastackframe-get-lengthprolog.md)|Retrieves the number of bytes of prologue code in the block|  
-|[IDiaStackFrame::get_lengthSavedRegisters](../../debugger/debug-interface-access/idiastackframe-get-lengthsavedregisters.md)|Retrieves the number of bytes of saved registers pushed on the stack.|  
-|[IDiaStackFrame::get_localsBase](../../debugger/debug-interface-access/idiastackframe-get-localsbase.md)|Retrieves the address base of the locals.|  
-|[IDiaStackFrame::get_maxStack](../../debugger/debug-interface-access/idiastackframe-get-maxstack.md)|Retrieves the maximum number of bytes pushed on the stack in the frame.|  
-|[IDiaStackFrame::get_rawLVarInstanceValue](../../debugger/debug-interface-access/idiastackframe-get-rawlvarinstancevalue.md)|Retrieves the value of the specified local variable as raw bytes.|  
-|[IDiaStackFrame::get_registerValue](../../debugger/debug-interface-access/idiastackframe-get-registervalue.md)|Retrieves the value of a specified register.|  
-|[IDiaStackFrame::get_returnAddress](../../debugger/debug-interface-access/idiastackframe-get-returnaddress.md)|Retrieves the return address of the frame.|  
-|[IDiaStackFrame::get_size](../../debugger/debug-interface-access/idiastackframe-get-size.md)|Retrieves the size of the frame in bytes.|  
-|[IDiaStackFrame::get_systemExceptionHandling](../../debugger/debug-interface-access/idiastackframe-get-systemexceptionhandling.md)|Retrieves a flag indicating that system exception handling is in effect.|  
-|[IDiaStackFrame::get_type](../../debugger/debug-interface-access/idiastackframe-get-type.md)|Retrieves the frame type.|  
-  
-## Remarks  
- A stack frame is an abstraction of a function call during its execution.  
-  
-## Notes for Callers  
- Obtain this interface by calling the [IDiaEnumStackFrames::Next](../../debugger/debug-interface-access/idiaenumstackframes-next.md) method. See the [IDiaEnumStackFrames](../../debugger/debug-interface-access/idiaenumstackframes.md) interface for an example on obtaining the `IDiaStackFrame` interface.  
-  
-## Example  
- This example displays various attributes of a stack frame.  
-  
-```C++  
-void PrintStackFrame(IDiaStackFrame* pFrame)  
-{  
-    if (pFrame != NULL)  
-    {  
-        ULONGLONG bottom = 0;  
-        ULONGLONG top    = 0;  
-  
-        if (pFrame->get_base(&bottom) == S_OK &&  
-            pFrame->get_registerValue( CV_REG_ESP, &top ) == S_OK )  
-        {  
-             printf("range = 0x%08I64x - 0x%08I64x\n", bottom, top);  
-        }  
-  
-        ULONGLONG returnAddress = 0;  
-        if (pFrame->get_returnAddress(&returnAddress) == S_OK)  
-        {  
-             printf("return address = 0x%08I64x\n", returnAddress);  
-        }  
-  
-        DWORD lengthFrame     = 0;  
-        DWORD lengthLocals    = 0;  
-        DWORD lengthParams    = 0;  
-        DWORD lengthProlog    = 0;  
-        DWORD lengthSavedRegs = 0;  
-        if (pFrame->get_size(&lengthFrame) == S_OK &&  
-            pFrame->get_lengthLocals(&lengthLocals) == S_OK &&  
-            pFrame->get_lengthParams(&lengthParams) == S_OK &&  
-            pFrame->get_lengthProlog(&lengthProlog) == S_OK &&  
-            pFrame->get_lengthSavedRegisters(&lengthSavedRegs) == S_OK)  
-        {  
-            printf("stack frame size          = 0x%08lx bytes\n", lengthFrame);  
-            printf("length of locals          = 0x%08lx bytes\n", lengthLocals);  
-            printf("length of parameters      = 0x%08lx bytes\n", lengthParams);  
-            printf("length of prolog          = 0x%08lx bytes\n", lengthProlog);  
-            printf("length of saved registers = 0x%08lx bytes\n", lengthSavedRegs);  
-        }  
-    }  
-}  
-```  
-  
-## Requirements  
- Header: Dia2.h  
-  
- Library: diaguids.lib  
-  
- DLL: msdia80.dll  
-  
-## See Also  
- [Interfaces (Debug Interface Access SDK)](../../debugger/debug-interface-access/interfaces-debug-interface-access-sdk.md)   
- [IDiaEnumStackFrames](../../debugger/debug-interface-access/idiaenumstackframes.md)   
- [IDiaEnumStackFrames::Next](../../debugger/debug-interface-access/idiaenumstackframes-next.md)   
- [IDiaStackWalkFrame](../../debugger/debug-interface-access/idiastackwalkframe.md)
+Exposes the properties of a stack frame.
+
+## Syntax
+
+```
+IDiaStackFrame : IUnknown
+```
+
+## Methods in Vtable Order
+The following are methods supported by this interface:
+
+|Method|Description|
+|------------|-----------------|
+|[IDiaStackFrame::get_allocatesBasePointer](../../debugger/debug-interface-access/idiastackframe-get-allocatesbasepointer.md)|Retrieves a flag indicating that the base pointer is allocated for code in this address range. This method is deprecated.|
+|[IDiaStackFrame::get_base](../../debugger/debug-interface-access/idiastackframe-get-base.md)|Retrieves the address base of the frame.|
+|[IDiaStackFrame::get_cplusplusExceptionHandling](../../debugger/debug-interface-access/idiastackframe-get-cplusplusexceptionhandling.md)|Retrieves a flag indicating that C++ exception handling is in effect.|
+|[IDiaStackFrame::get_functionStart](../../debugger/debug-interface-access/idiastackframe-get-functionstart.md)|Retrieves a flag indicating that the block contains the entry point of a function.|
+|[IDiaStackFrame::get_lengthLocals](../../debugger/debug-interface-access/idiastackframe-get-lengthlocals.md)|Retrieves the number of bytes of local variables pushed on the stack.|
+|[IDiaStackFrame::get_lengthParams](../../debugger/debug-interface-access/idiastackframe-get-lengthparams.md)|Retrieves the number of bytes of parameters pushed on the stack.|
+|[IDiaStackFrame::get_lengthProlog](../../debugger/debug-interface-access/idiastackframe-get-lengthprolog.md)|Retrieves the number of bytes of prologue code in the block|
+|[IDiaStackFrame::get_lengthSavedRegisters](../../debugger/debug-interface-access/idiastackframe-get-lengthsavedregisters.md)|Retrieves the number of bytes of saved registers pushed on the stack.|
+|[IDiaStackFrame::get_localsBase](../../debugger/debug-interface-access/idiastackframe-get-localsbase.md)|Retrieves the address base of the locals.|
+|[IDiaStackFrame::get_maxStack](../../debugger/debug-interface-access/idiastackframe-get-maxstack.md)|Retrieves the maximum number of bytes pushed on the stack in the frame.|
+|[IDiaStackFrame::get_rawLVarInstanceValue](../../debugger/debug-interface-access/idiastackframe-get-rawlvarinstancevalue.md)|Retrieves the value of the specified local variable as raw bytes.|
+|[IDiaStackFrame::get_registerValue](../../debugger/debug-interface-access/idiastackframe-get-registervalue.md)|Retrieves the value of a specified register.|
+|[IDiaStackFrame::get_returnAddress](../../debugger/debug-interface-access/idiastackframe-get-returnaddress.md)|Retrieves the return address of the frame.|
+|[IDiaStackFrame::get_size](../../debugger/debug-interface-access/idiastackframe-get-size.md)|Retrieves the size of the frame in bytes.|
+|[IDiaStackFrame::get_systemExceptionHandling](../../debugger/debug-interface-access/idiastackframe-get-systemexceptionhandling.md)|Retrieves a flag indicating that system exception handling is in effect.|
+|[IDiaStackFrame::get_type](../../debugger/debug-interface-access/idiastackframe-get-type.md)|Retrieves the frame type.|
+
+## Remarks
+A stack frame is an abstraction of a function call during its execution.
+
+## Notes for Callers
+Obtain this interface by calling the [IDiaEnumStackFrames::Next](../../debugger/debug-interface-access/idiaenumstackframes-next.md) method. See the [IDiaEnumStackFrames](../../debugger/debug-interface-access/idiaenumstackframes.md) interface for an example on obtaining the `IDiaStackFrame` interface.
+
+## Example
+This example displays various attributes of a stack frame.
+
+```C++
+void PrintStackFrame(IDiaStackFrame* pFrame)
+{
+    if (pFrame != NULL)
+    {
+        ULONGLONG bottom = 0;
+        ULONGLONG top    = 0;
+
+        if (pFrame->get_base(&bottom) == S_OK &&
+            pFrame->get_registerValue( CV_REG_ESP, &top ) == S_OK )
+        {
+             printf("range = 0x%08I64x - 0x%08I64x\n", bottom, top);
+        }
+
+        ULONGLONG returnAddress = 0;
+        if (pFrame->get_returnAddress(&returnAddress) == S_OK)
+        {
+             printf("return address = 0x%08I64x\n", returnAddress);
+        }
+
+        DWORD lengthFrame     = 0;
+        DWORD lengthLocals    = 0;
+        DWORD lengthParams    = 0;
+        DWORD lengthProlog    = 0;
+        DWORD lengthSavedRegs = 0;
+        if (pFrame->get_size(&lengthFrame) == S_OK &&
+            pFrame->get_lengthLocals(&lengthLocals) == S_OK &&
+            pFrame->get_lengthParams(&lengthParams) == S_OK &&
+            pFrame->get_lengthProlog(&lengthProlog) == S_OK &&
+            pFrame->get_lengthSavedRegisters(&lengthSavedRegs) == S_OK)
+        {
+            printf("stack frame size          = 0x%08lx bytes\n", lengthFrame);
+            printf("length of locals          = 0x%08lx bytes\n", lengthLocals);
+            printf("length of parameters      = 0x%08lx bytes\n", lengthParams);
+            printf("length of prolog          = 0x%08lx bytes\n", lengthProlog);
+            printf("length of saved registers = 0x%08lx bytes\n", lengthSavedRegs);
+        }
+    }
+}
+```
+
+## Requirements
+Header: Dia2.h
+
+Library: diaguids.lib
+
+DLL: msdia80.dll
+
+## See Also
+[Interfaces (Debug Interface Access SDK)](../../debugger/debug-interface-access/interfaces-debug-interface-access-sdk.md)  
+[IDiaEnumStackFrames](../../debugger/debug-interface-access/idiaenumstackframes.md)  
+[IDiaEnumStackFrames::Next](../../debugger/debug-interface-access/idiaenumstackframes-next.md)  
+[IDiaStackWalkFrame](../../debugger/debug-interface-access/idiastackwalkframe.md)


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.