### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/debugger/debug-interface-access/idiasymbol-get-type.md
+++ b/docs/debugger/debug-interface-access/idiasymbol-get-type.md
@@ -2,55 +2,55 @@
 title: "IDiaSymbol::get_type | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-dev_langs: 
+dev_langs:
   - "C++"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "IDiaSymbol::get_type method"
 ms.assetid: 1c6a4176-dd4e-4c22-8b8f-0e559fc078ba
 author: "mikejo5000"
 ms.author: "mikejo"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "multiple"
 ---
 # IDiaSymbol::get_type
-Retrieves the symbol that represents the type for this symbol.  
-  
-## Syntax  
-  
-```C++  
-HRESULT get_type (   
-   IDiaSymbol** pRetVal  
-);  
-```  
-  
-#### Parameters  
- `pRetVal`  
- [out] Returns an [IDiaSymbol](../../debugger/debug-interface-access/idiasymbol.md) object that represents the type of this symbol.  
-  
-## Return Value  
- If successful, returns `S_OK`; otherwise, returns `S_FALSE` or an error code.  
-  
+Retrieves the symbol that represents the type for this symbol.
+
+## Syntax
+
+```C++
+HRESULT get_type ( 
+   IDiaSymbol** pRetVal
+);
+```
+
+#### Parameters
+`pRetVal`  
+[out] Returns an [IDiaSymbol](../../debugger/debug-interface-access/idiasymbol.md) object that represents the type of this symbol.
+
+## Return Value
+If successful, returns `S_OK`; otherwise, returns `S_FALSE` or an error code.
+
 > [!NOTE]
->  A return value of `S_FALSE` means the property is not available for the symbol.  
-  
-## Remarks  
- To determine the type a symbol has, you must call this method and examine the resulting [IDiaSymbol](../../debugger/debug-interface-access/idiasymbol.md) object. Note that it is possible for a symbol to not have a type. For example, the name of a structure has no type but it might have children symbols (use the [IDiaSymbol::findChildren](../../debugger/debug-interface-access/idiasymbol-findchildren.md) method to examine those children).  
-  
-## Example  
-  
-```C++  
-IDiaSymbol*         pType;  
-CComPtr<IDiaSymbol> pBaseType;  
-if (SUCCEEDED(pType->get_type( &pBaseType ))) {  
-    BasicType btBaseType;  
-    if (SUCCEEDED(pBaseType->get_baseType((DWORD *)&btBaseType))) {  
-        // Do something with basic type.  
-    }  
-}  
-```  
-  
-## See Also  
- [IDiaSymbol](../../debugger/debug-interface-access/idiasymbol.md)   
- [IDiaSymbol::get_baseType](../../debugger/debug-interface-access/idiasymbol-get-basetype.md)   
- [IDiaSymbol::findChildren](../../debugger/debug-interface-access/idiasymbol-findchildren.md)
+> A return value of `S_FALSE` means the property is not available for the symbol.
+
+## Remarks
+To determine the type a symbol has, you must call this method and examine the resulting [IDiaSymbol](../../debugger/debug-interface-access/idiasymbol.md) object. Note that it is possible for a symbol to not have a type. For example, the name of a structure has no type but it might have children symbols (use the [IDiaSymbol::findChildren](../../debugger/debug-interface-access/idiasymbol-findchildren.md) method to examine those children).
+
+## Example
+
+```C++
+IDiaSymbol*         pType;
+CComPtr<IDiaSymbol> pBaseType;
+if (SUCCEEDED(pType->get_type( &pBaseType ))) {
+    BasicType btBaseType;
+    if (SUCCEEDED(pBaseType->get_baseType((DWORD *)&btBaseType))) {
+        // Do something with basic type.
+    }
+}
+```
+
+## See Also
+[IDiaSymbol](../../debugger/debug-interface-access/idiasymbol.md)  
+[IDiaSymbol::get_baseType](../../debugger/debug-interface-access/idiasymbol-get-basetype.md)  
+[IDiaSymbol::findChildren](../../debugger/debug-interface-access/idiasymbol-findchildren.md)

--- a/docs/debugger/debug-interface-access/idiasymbol-get-type.md
+++ b/docs/debugger/debug-interface-access/idiasymbol-get-type.md
@@ -19,8 +19,8 @@ Retrieves the symbol that represents the type for this symbol.
 ## Syntax
 
 ```C++
-HRESULT get_type ( 
-   IDiaSymbol** pRetVal
+HRESULT get_type (
+    IDiaSymbol** pRetVal
 );
 ```
 


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.