### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/debugger/debug-interface-access/idiatable.md
+++ b/docs/debugger/debug-interface-access/idiatable.md
@@ -2,137 +2,137 @@
 title: "IDiaTable | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-dev_langs: 
+dev_langs:
   - "C++"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "IDiaTable interface"
 ms.assetid: c99a2c44-7b72-4e3c-b963-25fe3df3a555
 author: "mikejo5000"
 ms.author: "mikejo"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "multiple"
 ---
 # IDiaTable
-Enumerates a DIA data source table.  
-  
-## Syntax  
-  
-```  
-IDiaTable : IEnumUnknown  
-```  
-  
-## Methods in Vtable Order  
- The following table shows the methods of `IDiaTable`.  
-  
-|Method|Description|  
-|------------|-----------------|  
-|[IDiaTable::get__NewEnum](../../debugger/debug-interface-access/idiatable-get-newenum.md)|Retrieves the [IEnumVARIANT Interface](/previous-versions/windows/desktop/api/oaidl/nn-oaidl-ienumvariant) version of this enumerator.|  
-|[IDiaTable::get_name](../../debugger/debug-interface-access/idiatable-get-name.md)|Retrieves the name of the table.|  
-|[IDiaTable::get_Count](../../debugger/debug-interface-access/idiatable-get-count.md)|Retrieves the number of items in the table.|  
-|[IDiaTable::Item](../../debugger/debug-interface-access/idiatable-item.md)|Retrieves a reference to a particular entry index.|  
-  
-## Remarks  
- This interface implements the `IEnumUnknown` enumeration methods in the Microsoft.VisualStudio.OLE.Interop namespace. The `IEnumUnknown` enumeration interface is much more efficient for iterating over the table contents than the [IDiaTable::get_Count](../../debugger/debug-interface-access/idiatable-get-count.md) and [IDiaTable::Item](../../debugger/debug-interface-access/idiatable-item.md) methods.  
-  
- The interpretation of the `IUnknown` interface returned from either the `IDiaTable::Item` method or the `Next` method (in the Microsoft.VisualStudio.OLE.Interop namespace) is dependent on the type of table. For example, if the `IDiaTable` interface represents a list of injected sources, the `IUnknown` interface should be queried for the [IDiaInjectedSource](../../debugger/debug-interface-access/idiainjectedsource.md) interface.  
-  
-## Notes for Callers  
- Obtain this interface by calling the [IDiaEnumTables::Item](../../debugger/debug-interface-access/idiaenumtables-item.md) or [IDiaEnumTables::Next](../../debugger/debug-interface-access/idiaenumtables-next.md) methods.  
-  
- The following interfaces are implemented with the `IDiaTable` interface (that is, you can query the `IDiaTable` interface for one of the following interfaces):  
-  
--   [IDiaEnumSymbols](../../debugger/debug-interface-access/idiaenumsymbols.md)  
-  
--   [IDiaEnumSourceFiles](../../debugger/debug-interface-access/idiaenumsourcefiles.md)  
-  
--   [IDiaEnumLineNumbers](../../debugger/debug-interface-access/idiaenumlinenumbers.md)  
-  
--   [IDiaEnumSectionContribs](../../debugger/debug-interface-access/idiaenumsectioncontribs.md)  
-  
--   [IDiaEnumSegments](../../debugger/debug-interface-access/idiaenumsegments.md)  
-  
--   [IDiaEnumInjectedSources](../../debugger/debug-interface-access/idiaenuminjectedsources.md)  
-  
--   [IDiaEnumFrameData](../../debugger/debug-interface-access/idiaenumframedata.md)  
-  
-## Example  
- The first function, `ShowTableNames`, displays the names of all the tables in the session. The second function, `GetTable`, searches all of the tables for a table that implements a specified interface. The third function, `UseTable`, shows how to use the `GetTable` function.  
-  
+Enumerates a DIA data source table.
+
+## Syntax
+
+```
+IDiaTable : IEnumUnknown
+```
+
+## Methods in Vtable Order
+The following table shows the methods of `IDiaTable`.
+
+|Method|Description|
+|------------|-----------------|
+|[IDiaTable::get__NewEnum](../../debugger/debug-interface-access/idiatable-get-newenum.md)|Retrieves the [IEnumVARIANT Interface](/previous-versions/windows/desktop/api/oaidl/nn-oaidl-ienumvariant) version of this enumerator.|
+|[IDiaTable::get_name](../../debugger/debug-interface-access/idiatable-get-name.md)|Retrieves the name of the table.|
+|[IDiaTable::get_Count](../../debugger/debug-interface-access/idiatable-get-count.md)|Retrieves the number of items in the table.|
+|[IDiaTable::Item](../../debugger/debug-interface-access/idiatable-item.md)|Retrieves a reference to a particular entry index.|
+
+## Remarks
+This interface implements the `IEnumUnknown` enumeration methods in the Microsoft.VisualStudio.OLE.Interop namespace. The `IEnumUnknown` enumeration interface is much more efficient for iterating over the table contents than the [IDiaTable::get_Count](../../debugger/debug-interface-access/idiatable-get-count.md) and [IDiaTable::Item](../../debugger/debug-interface-access/idiatable-item.md) methods.
+
+The interpretation of the `IUnknown` interface returned from either the `IDiaTable::Item` method or the `Next` method (in the Microsoft.VisualStudio.OLE.Interop namespace) is dependent on the type of table. For example, if the `IDiaTable` interface represents a list of injected sources, the `IUnknown` interface should be queried for the [IDiaInjectedSource](../../debugger/debug-interface-access/idiainjectedsource.md) interface.
+
+## Notes for Callers
+Obtain this interface by calling the [IDiaEnumTables::Item](../../debugger/debug-interface-access/idiaenumtables-item.md) or [IDiaEnumTables::Next](../../debugger/debug-interface-access/idiaenumtables-next.md) methods.
+
+The following interfaces are implemented with the `IDiaTable` interface (that is, you can query the `IDiaTable` interface for one of the following interfaces):
+
+- [IDiaEnumSymbols](../../debugger/debug-interface-access/idiaenumsymbols.md)
+
+- [IDiaEnumSourceFiles](../../debugger/debug-interface-access/idiaenumsourcefiles.md)
+
+- [IDiaEnumLineNumbers](../../debugger/debug-interface-access/idiaenumlinenumbers.md)
+
+- [IDiaEnumSectionContribs](../../debugger/debug-interface-access/idiaenumsectioncontribs.md)
+
+- [IDiaEnumSegments](../../debugger/debug-interface-access/idiaenumsegments.md)
+
+- [IDiaEnumInjectedSources](../../debugger/debug-interface-access/idiaenuminjectedsources.md)
+
+- [IDiaEnumFrameData](../../debugger/debug-interface-access/idiaenumframedata.md)
+
+## Example
+The first function, `ShowTableNames`, displays the names of all the tables in the session. The second function, `GetTable`, searches all of the tables for a table that implements a specified interface. The third function, `UseTable`, shows how to use the `GetTable` function.
+
 > [!NOTE]
->  `CDiaBSTR` is a class that wraps a `BSTR` and automatically handles freeing the string when the instantiation goes out of scope.  
-  
-```C++  
-void ShowTableNames(IDiaSession *pSession)  
-{  
-    CComPtr<IDiaEnumTables> pTables;  
-    if ( FAILED( psession->getEnumTables( &pTables ) ) )  
-    {  
-        Fatal( "getEnumTables" );  
-    }  
-    CComPtr< IDiaTable > pTable;  
-    while ( SUCCEEDED( hr = pTables->Next( 1, &pTable, &celt ) )  
-            && celt == 1 )  
-    {  
-        CDiaBSTR bstrTableName;  
-        if ( pTable->get_name( &bstrTableName ) != 0 )  
-        {  
-            Fatal( "get_name" );  
-        }  
-        printf( "Found table: %ws\n", bstrTableName );  
-    }  
-  
-// Searches the list of all tables for a table that supports  
-// the specified interface.  Use this function to obtain an  
-// enumeration interface.  
-HRESULT GetTable(IDiaSession* pSession,  
-                 REFIID       iid,  
-                 void**       ppUnk)  
-{  
-    CComPtr<IDiaEnumTables> pEnumTables;  
-    HRESULT hResult;  
-  
-    if (FAILED(pSession->getEnumTables(&pEnumTables)))  
-        Fatal("getEnumTables");  
-  
-    CComPtr<IDiaTable> pTable;  
-    ULONG celt = 0;  
-    while (SUCCEEDED(hResult = pEnumTables->Next(1, &pTable, &celt)) &&  
-           celt == 1)  
-    {  
-        if (pTable->QueryInterface(iid, (void**)ppUnk) == S_OK)  
-        {  
-            return S_OK;  
-        }  
-        pTable = NULL;  
-    }  
-  
-    if (FAILED(hResult))  
-        Fatal("EnumTables->Next");  
-  
-    return E_FAIL;  
-}  
-  
-// This function shows how to use the GetTable function.  
-void UseTable(IDiaSession *pSession)  
-{  
-    CComPtr<IDiaEnumSegments> pEnumSegments;  
-    if (SUCCEEDED(GetTable(pSession, __uuidof(IDiaEnumSegments), &pEnumSegments)))  
-    {  
-        // Do something with pEnumSegments.  
-    }  
-}  
-```  
-  
-## Requirements  
- Header: Dia2.h  
-  
- Library: diaguids.lib  
-  
- DLL: msdia80.dll  
-  
-## See Also  
- [Interfaces (Debug Interface Access SDK)](../../debugger/debug-interface-access/interfaces-debug-interface-access-sdk.md)   
- [IDiaEnumTables](../../debugger/debug-interface-access/idiaenumtables.md)   
- [IDiaEnumTables::Item](../../debugger/debug-interface-access/idiaenumtables-item.md)   
- [IDiaEnumTables::Next](../../debugger/debug-interface-access/idiaenumtables-next.md)
+> `CDiaBSTR` is a class that wraps a `BSTR` and automatically handles freeing the string when the instantiation goes out of scope.
+
+```C++
+void ShowTableNames(IDiaSession *pSession)
+{
+    CComPtr<IDiaEnumTables> pTables;
+    if ( FAILED( psession->getEnumTables( &pTables ) ) )
+    {
+        Fatal( "getEnumTables" );
+    }
+    CComPtr< IDiaTable > pTable;
+    while ( SUCCEEDED( hr = pTables->Next( 1, &pTable, &celt ) )
+            && celt == 1 )
+    {
+        CDiaBSTR bstrTableName;
+        if ( pTable->get_name( &bstrTableName ) != 0 )
+        {
+            Fatal( "get_name" );
+        }
+        printf( "Found table: %ws\n", bstrTableName );
+    }
+
+// Searches the list of all tables for a table that supports
+// the specified interface.  Use this function to obtain an
+// enumeration interface.
+HRESULT GetTable(IDiaSession* pSession,
+                 REFIID       iid,
+                 void**       ppUnk)
+{
+    CComPtr<IDiaEnumTables> pEnumTables;
+    HRESULT hResult;
+
+    if (FAILED(pSession->getEnumTables(&pEnumTables)))
+        Fatal("getEnumTables");
+
+    CComPtr<IDiaTable> pTable;
+    ULONG celt = 0;
+    while (SUCCEEDED(hResult = pEnumTables->Next(1, &pTable, &celt)) &&
+           celt == 1)
+    {
+        if (pTable->QueryInterface(iid, (void**)ppUnk) == S_OK)
+        {
+            return S_OK;
+        }
+        pTable = NULL;
+    }
+
+    if (FAILED(hResult))
+        Fatal("EnumTables->Next");
+
+    return E_FAIL;
+}
+
+// This function shows how to use the GetTable function.
+void UseTable(IDiaSession *pSession)
+{
+    CComPtr<IDiaEnumSegments> pEnumSegments;
+    if (SUCCEEDED(GetTable(pSession, __uuidof(IDiaEnumSegments), &pEnumSegments)))
+    {
+        // Do something with pEnumSegments.
+    }
+}
+```
+
+## Requirements
+Header: Dia2.h
+
+Library: diaguids.lib
+
+DLL: msdia80.dll
+
+## See Also
+[Interfaces (Debug Interface Access SDK)](../../debugger/debug-interface-access/interfaces-debug-interface-access-sdk.md)  
+[IDiaEnumTables](../../debugger/debug-interface-access/idiaenumtables.md)  
+[IDiaEnumTables::Item](../../debugger/debug-interface-access/idiaenumtables-item.md)  
+[IDiaEnumTables::Next](../../debugger/debug-interface-access/idiaenumtables-next.md)


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.