### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/debugger/debug-interface-access/memorytypeenum.md
+++ b/docs/debugger/debug-interface-access/memorytypeenum.md
@@ -20,10 +20,10 @@ Specifies the type of memory to access.
 
 ```C++
 enum MemoryTypeEnum {
-   MemTypeCode,
-   MemTypeData,
-   MemTypeStack,
-   MemTypeAny = -1
+    MemTypeCode,
+    MemTypeData,
+    MemTypeStack,
+    MemTypeAny = -1
 };
 ```
 

--- a/docs/debugger/debug-interface-access/memorytypeenum.md
+++ b/docs/debugger/debug-interface-access/memorytypeenum.md
@@ -2,50 +2,50 @@
 title: "MemoryTypeEnum | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-dev_langs: 
+dev_langs:
   - "C++"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "MemoryTypeEnum enumeration"
 ms.assetid: 8778c047-edeb-4495-8f9f-3f8bbb297099
 author: "mikejo5000"
 ms.author: "mikejo"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "multiple"
 ---
 # MemoryTypeEnum
-Specifies the type of memory to access.  
-  
-## Syntax  
-  
-```C++  
-enum MemoryTypeEnum {  
-   MemTypeCode,  
-   MemTypeData,  
-   MemTypeStack,  
-   MemTypeAny = -1  
-};  
-```  
-  
-#### Parameters  
- `MemTypeCode`  
- Accesses only code memory.  
-  
- `MemTypeData`  
- Accesses data or stack memory.  
-  
- `MemTypeStack`  
- Accesses only stack memory.  
-  
- `MemTypeAny`  
- Accesses any kind of memory.  
-  
-## Remarks  
- The values in this enumeration are passed to the [IDiaStackWalkHelper::readMemory](../../debugger/debug-interface-access/idiastackwalkhelper-readmemory.md) method to limit access to different types of memory.  
-  
-## Requirements  
- Header: cvconst.h  
-  
-## See Also  
- [Enumerations and Structures](../../debugger/debug-interface-access/enumerations-and-structures.md)   
- [IDiaStackWalkHelper::readMemory](../../debugger/debug-interface-access/idiastackwalkhelper-readmemory.md)
+Specifies the type of memory to access.
+
+## Syntax
+
+```C++
+enum MemoryTypeEnum {
+   MemTypeCode,
+   MemTypeData,
+   MemTypeStack,
+   MemTypeAny = -1
+};
+```
+
+#### Parameters
+`MemTypeCode`  
+Accesses only code memory.
+
+`MemTypeData`  
+Accesses data or stack memory.
+
+`MemTypeStack`  
+Accesses only stack memory.
+
+`MemTypeAny`  
+Accesses any kind of memory.
+
+## Remarks
+The values in this enumeration are passed to the [IDiaStackWalkHelper::readMemory](../../debugger/debug-interface-access/idiastackwalkhelper-readmemory.md) method to limit access to different types of memory.
+
+## Requirements
+Header: cvconst.h
+
+## See Also
+[Enumerations and Structures](../../debugger/debug-interface-access/enumerations-and-structures.md)  
+[IDiaStackWalkHelper::readMemory](../../debugger/debug-interface-access/idiastackwalkhelper-readmemory.md)


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.