### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/debugger/debug-interface-access/querying-the-dot-pdb-file.md
+++ b/docs/debugger/debug-interface-access/querying-the-dot-pdb-file.md
@@ -80,7 +80,7 @@ A program database file (extension .pdb) is a binary file that contains type and
     CComPtr< IDiaTable > pTable;
     while ( SUCCEEDED( hr = pTables->Next( 1, &pTable, &celt ) ) && celt == 1 )
     {
-         // Do something with each IDiaTable.
+        // Do something with each IDiaTable.
     }
     ```
 

--- a/docs/debugger/debug-interface-access/querying-the-dot-pdb-file.md
+++ b/docs/debugger/debug-interface-access/querying-the-dot-pdb-file.md
@@ -2,87 +2,87 @@
 title: "Querying the .Pdb File | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-dev_langs: 
+dev_langs:
   - "C++"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "PDB files"
   - ".pdb files, querying"
 ms.assetid: 8da07d1c-2712-45f9-8fbf-f34040408a8a
 author: "mikejo5000"
 ms.author: "mikejo"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "multiple"
 ---
 # Querying the .Pdb File
-A program database file (extension .pdb) is a binary file that contains type and symbolic debugging information gathered over the course of compiling and linking the project. A PDB file is created when you compile a C/C++ program with **/ZI** or **/Zi** or a [!INCLUDE[vbprvb](../../code-quality/includes/vbprvb_md.md)], [!INCLUDE[csprcs](../../data-tools/includes/csprcs_md.md)], or [!INCLUDE[jsprjscript](../../debugger/debug-interface-access/includes/jsprjscript_md.md)] program with the **/debug** option. Object files contain references into the .pdb file for debugging information. For more information on pdb files, see [PDB Files](https://docs.microsoft.com/previous-versions/visualstudio/visual-studio-2010/yd4f8bd1(v=vs.100)). A DIA application can use the following general steps to obtain details about the various symbols, objects, and data elements within an executable image.  
-  
-### To query the .pdb file  
-  
-1.  Acquire a data source by creating an [IDiaDataSource](../../debugger/debug-interface-access/idiadatasource.md) interface.  
-  
-    ```C++  
-    CComPtr<IDiaDataSource> pSource;  
-    hr = CoCreateInstance( CLSID_DiaSource,  
-                           NULL,  
-                           CLSCTX_INPROC_SERVER,  
-                           __uuidof( IDiaDataSource ),  
-                          (void **) &pSource);  
-  
-    if (FAILED(hr))  
-    {  
-        Fatal("Could not CoCreate CLSID_DiaSource. Register msdia80.dll." );  
-    }  
-    ```  
-  
-2.  Call [IDiaDataSource::loadDataFromPdb](../../debugger/debug-interface-access/idiadatasource-loaddatafrompdb.md) or [IDiaDataSource::loadDataForExe](../../debugger/debug-interface-access/idiadatasource-loaddataforexe.md) to load the debugging information.  
-  
-    ```C++  
-    wchar_t wszFilename[ _MAX_PATH ];  
-    mbstowcs( wszFilename, szFilename, sizeof( wszFilename )/sizeof( wszFilename[0] ) );  
-    if ( FAILED( pSource->loadDataFromPdb( wszFilename ) ) )  
-    {  
-        if ( FAILED( pSource->loadDataForExe( wszFilename, NULL, NULL ) ) )  
-        {  
-            Fatal( "loadDataFromPdb/Exe" );  
-        }  
-    }  
-    ```  
-  
-3.  Call [IDiaDataSource::openSession](../../debugger/debug-interface-access/idiadatasource-opensession.md) to open an [IDiaSession](../../debugger/debug-interface-access/idiasession.md) to gain access to the debugging information.  
-  
-    ```C++  
-    CComPtr<IDiaSession> psession;  
-    if ( FAILED( pSource->openSession( &psession ) ) )   
-    {  
-        Fatal( "openSession" );  
-    }  
-    ```  
-  
-4.  Use the methods in `IDiaSession` to query for the symbols in the data source.  
-  
-    ```C++  
-    CComPtr<IDiaSymbol> pglobal;  
-    if ( FAILED( psession->get_globalScope( &pglobal) ) )  
-    {  
-        Fatal( "get_globalScope" );  
-    }  
-    ```  
-  
-5.  Use the `IDiaEnum*` interfaces to enumerate and scan through the symbols or other elements of debug information.  
-  
-    ```C++  
-    CComPtr<IDiaEnumTables> pTables;  
-    if ( FAILED( psession->getEnumTables( &pTables ) ) )  
-    {  
-        Fatal( "getEnumTables" );  
-    }  
-    CComPtr< IDiaTable > pTable;  
-    while ( SUCCEEDED( hr = pTables->Next( 1, &pTable, &celt ) ) && celt == 1 )  
-    {  
-         // Do something with each IDiaTable.  
-    }  
-    ```  
-  
-## See Also  
- [IDiaDataSource](../../debugger/debug-interface-access/idiadatasource.md)
+A program database file (extension .pdb) is a binary file that contains type and symbolic debugging information gathered over the course of compiling and linking the project. A PDB file is created when you compile a C/C++ program with **/ZI** or **/Zi** or a [!INCLUDE[vbprvb](../../code-quality/includes/vbprvb_md.md)], [!INCLUDE[csprcs](../../data-tools/includes/csprcs_md.md)], or [!INCLUDE[jsprjscript](../../debugger/debug-interface-access/includes/jsprjscript_md.md)] program with the **/debug** option. Object files contain references into the .pdb file for debugging information. For more information on pdb files, see [PDB Files](https://docs.microsoft.com/previous-versions/visualstudio/visual-studio-2010/yd4f8bd1(v=vs.100)). A DIA application can use the following general steps to obtain details about the various symbols, objects, and data elements within an executable image.
+
+### To query the .pdb file
+
+1. Acquire a data source by creating an [IDiaDataSource](../../debugger/debug-interface-access/idiadatasource.md) interface.
+
+    ```C++
+    CComPtr<IDiaDataSource> pSource;
+    hr = CoCreateInstance( CLSID_DiaSource,
+                           NULL,
+                           CLSCTX_INPROC_SERVER,
+                           __uuidof( IDiaDataSource ),
+                          (void **) &pSource);
+
+    if (FAILED(hr))
+    {
+        Fatal("Could not CoCreate CLSID_DiaSource. Register msdia80.dll." );
+    }
+    ```
+
+2. Call [IDiaDataSource::loadDataFromPdb](../../debugger/debug-interface-access/idiadatasource-loaddatafrompdb.md) or [IDiaDataSource::loadDataForExe](../../debugger/debug-interface-access/idiadatasource-loaddataforexe.md) to load the debugging information.
+
+    ```C++
+    wchar_t wszFilename[ _MAX_PATH ];
+    mbstowcs( wszFilename, szFilename, sizeof( wszFilename )/sizeof( wszFilename[0] ) );
+    if ( FAILED( pSource->loadDataFromPdb( wszFilename ) ) )
+    {
+        if ( FAILED( pSource->loadDataForExe( wszFilename, NULL, NULL ) ) )
+        {
+            Fatal( "loadDataFromPdb/Exe" );
+        }
+    }
+    ```
+
+3. Call [IDiaDataSource::openSession](../../debugger/debug-interface-access/idiadatasource-opensession.md) to open an [IDiaSession](../../debugger/debug-interface-access/idiasession.md) to gain access to the debugging information.
+
+    ```C++
+    CComPtr<IDiaSession> psession;
+    if ( FAILED( pSource->openSession( &psession ) ) )
+    {
+        Fatal( "openSession" );
+    }
+    ```
+
+4. Use the methods in `IDiaSession` to query for the symbols in the data source.
+
+    ```C++
+    CComPtr<IDiaSymbol> pglobal;
+    if ( FAILED( psession->get_globalScope( &pglobal) ) )
+    {
+        Fatal( "get_globalScope" );
+    }
+    ```
+
+5. Use the `IDiaEnum*` interfaces to enumerate and scan through the symbols or other elements of debug information.
+
+    ```C++
+    CComPtr<IDiaEnumTables> pTables;
+    if ( FAILED( psession->getEnumTables( &pTables ) ) )
+    {
+        Fatal( "getEnumTables" );
+    }
+    CComPtr< IDiaTable > pTable;
+    while ( SUCCEEDED( hr = pTables->Next( 1, &pTable, &celt ) ) && celt == 1 )
+    {
+         // Do something with each IDiaTable.
+    }
+    ```
+
+## See Also
+[IDiaDataSource](../../debugger/debug-interface-access/idiadatasource.md)


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.