### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/debugger/how-to-set-a-thread-name-in-native-code.md
+++ b/docs/debugger/how-to-set-a-thread-name-in-native-code.md
@@ -83,7 +83,7 @@ typedef struct tagTHREADNAME_INFO
     LPCSTR szName; // Pointer to name (in user addr space).
     DWORD dwThreadID; // Thread ID (-1=caller thread).
     DWORD dwFlags; // Reserved for future use, must be zero.
- } THREADNAME_INFO;
+} THREADNAME_INFO;
 #pragma pack(pop)
 void SetThreadName(DWORD dwThreadID, const char* threadName) {
     THREADNAME_INFO info;

--- a/docs/debugger/how-to-set-a-thread-name-in-native-code.md
+++ b/docs/debugger/how-to-set-a-thread-name-in-native-code.md
@@ -2,9 +2,9 @@
 title: "How to: Set a Thread Name in Native Code | Microsoft Docs"
 ms.date: "12/17/2018"
 ms.topic: "conceptual"
-dev_langs: 
+dev_langs:
   - "C++"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "debugging [C++], threads"
   - "SetThreadName function"
   - "threading [Visual Studio], names"
@@ -14,7 +14,7 @@ ms.assetid: c85d0968-9f22-4d69-87f4-acca2ae777b8
 author: "mikejo5000"
 ms.author: "mikejo"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "cplusplus"
 ---
 # How to: Set a Thread Name in Native Code
@@ -29,14 +29,14 @@ It is worth noting that _both_ approaches can be used together, if desired, sinc
 ### Set a thread name by using `SetThreadDescription`
 
 Benefits:
- * Thread names are visible when debugging in Visual Studio, regardless of whether or not the debugger was attached to the process at the time that SetThreadDescription is invoked.
- * Thread names are visible when performing post-mortem debugging by loading a crash dump in Visual Studio.
- * Thread names are also visible when using other tools, such as the [WinDbg](https://docs.microsoft.com/windows-hardware/drivers/debugger/debugger-download-tools) debugger and the [Windows Performance Analyzer](https://docs.microsoft.com/windows-hardware/test/wpt/windows-performance-analyzer) performance analyzer.
+* Thread names are visible when debugging in Visual Studio, regardless of whether or not the debugger was attached to the process at the time that SetThreadDescription is invoked.
+* Thread names are visible when performing post-mortem debugging by loading a crash dump in Visual Studio.
+* Thread names are also visible when using other tools, such as the [WinDbg](https://docs.microsoft.com/windows-hardware/drivers/debugger/debugger-download-tools) debugger and the [Windows Performance Analyzer](https://docs.microsoft.com/windows-hardware/test/wpt/windows-performance-analyzer) performance analyzer.
 
 Caveats:
- * Thread names are only visible in Visual Studio 2017 version 15.6 and later.
- * When post-mortem debugging a crash dump file, thread names are only visible if the crash was created on Windows 10 version 1607, Windows Server 2016 or later versions of Windows.
- 
+* Thread names are only visible in Visual Studio 2017 version 15.6 and later.
+* When post-mortem debugging a crash dump file, thread names are only visible if the crash was created on Windows 10 version 1607, Windows Server 2016 or later versions of Windows.
+
 *Example:*
 
 ```C++
@@ -57,52 +57,52 @@ int main()
 
 ### Set a thread name by throwing an exception
 
-Another way to set a thread name in your program is to communicate the desired thread name to the Visual Studio debugger by throwing a specially-configured exception. 
+Another way to set a thread name in your program is to communicate the desired thread name to the Visual Studio debugger by throwing a specially-configured exception.
 
 Benefits:
- * Works in all versions of Visual Studio.
+* Works in all versions of Visual Studio.
 
 Caveats:
- * Only works if the debugger is attached at the time the exception-based method is used. 
- * Thread names set by using this method will not be available in dumps or performance analysis tools.
- 
+* Only works if the debugger is attached at the time the exception-based method is used.
+* Thread names set by using this method will not be available in dumps or performance analysis tools.
+
 *Example:*
 
-The `SetThreadName` function shown below demonstrates this exception-based approach. Note that the thread name will be automatically copied to the thread, so that the memory for the `threadName` parameter can be released after the `SetThreadName` call is completed. 
+The `SetThreadName` function shown below demonstrates this exception-based approach. Note that the thread name will be automatically copied to the thread, so that the memory for the `threadName` parameter can be released after the `SetThreadName` call is completed.
 
 ```C++
-//  
-// Usage: SetThreadName ((DWORD)-1, "MainThread");  
-//  
-#include <windows.h>  
-const DWORD MS_VC_EXCEPTION = 0x406D1388;  
-#pragma pack(push,8)  
-typedef struct tagTHREADNAME_INFO  
-{  
-    DWORD dwType; // Must be 0x1000.  
-    LPCSTR szName; // Pointer to name (in user addr space).  
-    DWORD dwThreadID; // Thread ID (-1=caller thread).  
-    DWORD dwFlags; // Reserved for future use, must be zero.  
- } THREADNAME_INFO;  
-#pragma pack(pop)  
-void SetThreadName(DWORD dwThreadID, const char* threadName) {  
-    THREADNAME_INFO info;  
-    info.dwType = 0x1000;  
-    info.szName = threadName;  
-    info.dwThreadID = dwThreadID;  
-    info.dwFlags = 0;  
-#pragma warning(push)  
-#pragma warning(disable: 6320 6322)  
-    __try{  
-        RaiseException(MS_VC_EXCEPTION, 0, sizeof(info) / sizeof(ULONG_PTR), (ULONG_PTR*)&info);  
-    }  
-    __except (EXCEPTION_EXECUTE_HANDLER){  
-    }  
-#pragma warning(pop)  
-}  
-```  
+//
+// Usage: SetThreadName ((DWORD)-1, "MainThread");
+//
+#include <windows.h>
+const DWORD MS_VC_EXCEPTION = 0x406D1388;
+#pragma pack(push,8)
+typedef struct tagTHREADNAME_INFO
+{
+    DWORD dwType; // Must be 0x1000.
+    LPCSTR szName; // Pointer to name (in user addr space).
+    DWORD dwThreadID; // Thread ID (-1=caller thread).
+    DWORD dwFlags; // Reserved for future use, must be zero.
+ } THREADNAME_INFO;
+#pragma pack(pop)
+void SetThreadName(DWORD dwThreadID, const char* threadName) {
+    THREADNAME_INFO info;
+    info.dwType = 0x1000;
+    info.szName = threadName;
+    info.dwThreadID = dwThreadID;
+    info.dwFlags = 0;
+#pragma warning(push)
+#pragma warning(disable: 6320 6322)
+    __try{
+        RaiseException(MS_VC_EXCEPTION, 0, sizeof(info) / sizeof(ULONG_PTR), (ULONG_PTR*)&info);
+    }
+    __except (EXCEPTION_EXECUTE_HANDLER){
+    }
+#pragma warning(pop)
+}
+```
 
-## See Also  
- [Debug Multithreaded Applications](../debugger/debug-multithreaded-applications-in-visual-studio.md)   
- [Viewing Data in the Debugger](../debugger/viewing-data-in-the-debugger.md)   
- [How to: Set a Thread Name in Managed Code](../debugger/how-to-set-a-thread-name-in-managed-code.md)
+## See Also
+[Debug Multithreaded Applications](../debugger/debug-multithreaded-applications-in-visual-studio.md)  
+[Viewing Data in the Debugger](../debugger/viewing-data-in-the-debugger.md)  
+[How to: Set a Thread Name in Managed Code](../debugger/how-to-set-a-thread-name-in-managed-code.md)


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.