### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/event-sources-visual-studio-sdk.md
+++ b/docs/extensibility/debugger/event-sources-visual-studio-sdk.md
@@ -15,13 +15,13 @@ ms.workload:
 There are two sources of events: the debug engine (DE) and the Session Debug Manager (SDM). Events sent from a DE have a non-NULL engine, while events sent from the SDM have a NULL engine.
 
 ## Example
- The following example shows how to send the **IDebugProgramCreateEvent2** from the DE to the SDM.
+The following example shows how to send the **IDebugProgramCreateEvent2** from the DE to the SDM.
 
 ```csharp
 CDebugProgramCreateEvent* pProgramCreateEvent = new CDebugProgramCreateEvent();
 if (FAILED(pCallback->Event(m_pEngine, NULL, m_pProgram, NULL, pProgramCreateEvent, IID_IDebugProgramCreateEvent2, EVENT_ASYNCHRONOUS)))
 {
-   // Handle failure here.
+    // Handle failure here.
 }
 ]
 
@@ -29,39 +29,39 @@ CEvent * pProgCreate = new CEvent(IID_IDebugProgramCreateEvent2, EVENT_ASYNCHRON
 pProgCreate->SendEvent(pCallback, m_pEngine, (IDebugProgram2 *)this, NULL);
 
 HRESULT CEvent::SendEvent(IDebugEventCallback2 *pCallback, IDebugEngine2 *pEngine, IDebugProgram2 *pProgram, IDebugThread2 *pThread) {
-   HRESULT hr;
+    HRESULT hr;
 
-   if (m_dwAttrib & EVENT_STOPPING)
-   {
-      hr = SendStoppingEvent(pCallback, pEngine, pProgram, pThread);
-   }
-   else if (m_dwAttrib & EVENT_SYNCHRONOUS)
-   {
-      hr = SendSynchronousEvent(pCallback, pEngine, pProgram, pThread);
-   }
-   else
-   {
-      assert(m_dwAttrib == 0);
-      hr = SendAsynchronousEvent(pCallback, pEngine, pProgram, pThread);
-   }
+    if (m_dwAttrib & EVENT_STOPPING)
+    {
+        hr = SendStoppingEvent(pCallback, pEngine, pProgram, pThread);
+    }
+    else if (m_dwAttrib & EVENT_SYNCHRONOUS)
+    {
+        hr = SendSynchronousEvent(pCallback, pEngine, pProgram, pThread);
+    }
+    else
+    {
+        assert(m_dwAttrib == 0);
+        hr = SendAsynchronousEvent(pCallback, pEngine, pProgram, pThread);
+    }
 
-   return hr;
+    return hr;
 }
 
 HRESULT CEvent::SendAsynchronousEvent(IDebugEventCallback2 *pCallback, IDebugEngine2 *pEngine, IDebugProgram2 *pProgram, IDebugThread2 *pThread) {
 
     HRESULT hr;
 
-   // Make sure the CEvent object running this code is not deleted until the code completes.
-   AddRef();
+    // Make sure the CEvent object running this code is not deleted until the code completes.
+    AddRef();
 
-   pCallback->Event(pEngine, NULL, pProgram, pThread, (IDebugEvent2 *)this, m_riid, m_dwAttrib);
+    pCallback->Event(pEngine, NULL, pProgram, pThread, (IDebugEvent2 *)this, m_riid, m_dwAttrib);
 
-   // No error recovery here.
-   hr = S_OK;
+    // No error recovery here.
+    hr = S_OK;
 
-   Release();
-   return hr;
+    Release();
+    return hr;
 }
 
 ```

--- a/docs/extensibility/debugger/event-sources-visual-studio-sdk.md
+++ b/docs/extensibility/debugger/event-sources-visual-studio-sdk.md
@@ -2,69 +2,69 @@
 title: "Event Sources (Visual Studio SDK) | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "debugging [Debugging SDK], event sources"
 ms.assetid: b9ba0908-ae4c-4a64-aab1-bee453dd7a22
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # Event sources (Visual Studio SDK)
-There are two sources of events: the debug engine (DE) and the Session Debug Manager (SDM). Events sent from a DE have a non-NULL engine, while events sent from the SDM have a NULL engine.  
-  
-## Example  
- The following example shows how to send the **IDebugProgramCreateEvent2** from the DE to the SDM.  
-  
-```csharp  
-CDebugProgramCreateEvent* pProgramCreateEvent = new CDebugProgramCreateEvent();  
-if (FAILED(pCallback->Event(m_pEngine, NULL, m_pProgram, NULL, pProgramCreateEvent, IID_IDebugProgramCreateEvent2, EVENT_ASYNCHRONOUS)))  
-{  
-   // Handle failure here.  
-}  
-]  
-  
-CEvent * pProgCreate = new CEvent(IID_IDebugProgramCreateEvent2, EVENT_ASYNCHRONOUS);    
-pProgCreate->SendEvent(pCallback, m_pEngine, (IDebugProgram2 *)this, NULL);  
-  
-HRESULT CEvent::SendEvent(IDebugEventCallback2 *pCallback, IDebugEngine2 *pEngine, IDebugProgram2 *pProgram, IDebugThread2 *pThread) {    
-   HRESULT hr;    
-  
-   if (m_dwAttrib & EVENT_STOPPING)    
-   {    
-      hr = SendStoppingEvent(pCallback, pEngine, pProgram, pThread);    
-   }    
-   else if (m_dwAttrib & EVENT_SYNCHRONOUS)    
-   {    
-      hr = SendSynchronousEvent(pCallback, pEngine, pProgram, pThread);    
-   }    
-   else    
-   {    
-      assert(m_dwAttrib == 0);    
-      hr = SendAsynchronousEvent(pCallback, pEngine, pProgram, pThread);    
-   }    
-  
-   return hr;    
-}    
-  
-HRESULT CEvent::SendAsynchronousEvent(IDebugEventCallback2 *pCallback, IDebugEngine2 *pEngine, IDebugProgram2 *pProgram, IDebugThread2 *pThread) {    
-  
-    HRESULT hr;    
-  
-   // Make sure the CEvent object running this code is not deleted until the code completes.    
-   AddRef();    
-  
-   pCallback->Event(pEngine, NULL, pProgram, pThread, (IDebugEvent2 *)this, m_riid, m_dwAttrib);    
-  
-   // No error recovery here.    
-   hr = S_OK;     
-  
-   Release();    
-   return hr;    
-}  
-  
-```  
-  
-## See also  
- [Sending events](../../extensibility/debugger/sending-events.md)
+There are two sources of events: the debug engine (DE) and the Session Debug Manager (SDM). Events sent from a DE have a non-NULL engine, while events sent from the SDM have a NULL engine.
+
+## Example
+ The following example shows how to send the **IDebugProgramCreateEvent2** from the DE to the SDM.
+
+```csharp
+CDebugProgramCreateEvent* pProgramCreateEvent = new CDebugProgramCreateEvent();
+if (FAILED(pCallback->Event(m_pEngine, NULL, m_pProgram, NULL, pProgramCreateEvent, IID_IDebugProgramCreateEvent2, EVENT_ASYNCHRONOUS)))
+{
+   // Handle failure here.
+}
+]
+
+CEvent * pProgCreate = new CEvent(IID_IDebugProgramCreateEvent2, EVENT_ASYNCHRONOUS);
+pProgCreate->SendEvent(pCallback, m_pEngine, (IDebugProgram2 *)this, NULL);
+
+HRESULT CEvent::SendEvent(IDebugEventCallback2 *pCallback, IDebugEngine2 *pEngine, IDebugProgram2 *pProgram, IDebugThread2 *pThread) {
+   HRESULT hr;
+
+   if (m_dwAttrib & EVENT_STOPPING)
+   {
+      hr = SendStoppingEvent(pCallback, pEngine, pProgram, pThread);
+   }
+   else if (m_dwAttrib & EVENT_SYNCHRONOUS)
+   {
+      hr = SendSynchronousEvent(pCallback, pEngine, pProgram, pThread);
+   }
+   else
+   {
+      assert(m_dwAttrib == 0);
+      hr = SendAsynchronousEvent(pCallback, pEngine, pProgram, pThread);
+   }
+
+   return hr;
+}
+
+HRESULT CEvent::SendAsynchronousEvent(IDebugEventCallback2 *pCallback, IDebugEngine2 *pEngine, IDebugProgram2 *pProgram, IDebugThread2 *pThread) {
+
+    HRESULT hr;
+
+   // Make sure the CEvent object running this code is not deleted until the code completes.
+   AddRef();
+
+   pCallback->Event(pEngine, NULL, pProgram, pThread, (IDebugEvent2 *)this, m_riid, m_dwAttrib);
+
+   // No error recovery here.
+   hr = S_OK;
+
+   Release();
+   return hr;
+}
+
+```
+
+## See also
+[Sending events](../../extensibility/debugger/sending-events.md)


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.