### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/getting-local-properties.md
+++ b/docs/extensibility/debugger/getting-local-properties.md
@@ -2,7 +2,7 @@
 title: "Getting Local Properties | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "expression evaluation, getting local properties"
   - "debugging [Debugging SDK], local properties"
   - "expression evaluation, local properties"
@@ -10,146 +10,146 @@ ms.assetid: 6c3a79e8-1ba1-4863-97c3-0216c3d9f092
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # Get local properties
 > [!IMPORTANT]
->  In Visual Studio 2015, this way of implementing expression evaluators is deprecated. For information about implementing CLR expression evaluators, see [CLR expression evaluators](https://github.com/Microsoft/ConcordExtensibilitySamples/wiki/CLR-Expression-Evaluators) and [Managed expression evaluator sample](https://github.com/Microsoft/ConcordExtensibilitySamples/wiki/Managed-Expression-Evaluator-Sample).  
-  
- Visual Studio calls [EnumChildren](../../extensibility/debugger/reference/idebugproperty2-enumchildren.md) to obtain an [IEnumDebugPropertyInfo2](../../extensibility/debugger/reference/ienumdebugpropertyinfo2.md) object that provides access to all the locals to be displayed in the **Locals** window. Visual Studio then calls [Next](../../extensibility/debugger/reference/ienumdebugpropertyinfo2-next.md) to get the information to be displayed for each local. In this example, the class `CEnumPropertyInfo` implements the `IEnumDebugPropertyInfo2` interface.  
-  
- This implementation of `IEnumDebugPropertyInfo2::Next` performs the following tasks:  
-  
-1.  Clears the array where the information is to be stored.  
-  
-2.  Calls [Next](../../extensibility/debugger/reference/ienumdebugfields-next.md) for each local, storing the returned [DEBUG_PROPERTY_INFO](../../extensibility/debugger/reference/debug-property-info.md) in the array to be returned. The [IEnumDebugFields](../../extensibility/debugger/reference/ienumdebugfields.md) object was supplied when this `CEnumPropertyInfo` class was instantiated.  
-  
-## Managed code  
- This example shows an implementation of `IEnumDebugPropertyInfo2::EnumChildren` for a method's locals in managed code.  
-  
-```csharp  
-namespace EEMC  
-{  
-    public class CEnumMethodField : IEnumDebugFields  
-    {  
-        public HRESULT Next(  
-                uint                  count,  
-                DEBUG_PROPERTY_INFO[] properties,  
-            out uint                  fetched)  
-        {  
-            if (count > properties.Length)  
-                throw new COMException();  
-  
-            // Zero out the array.  
-            for (int i= 0; i < count; i++)  
-            {  
-                properties[i].bstrFullName = "";  
-                properties[i].bstrName = "";  
-                properties[i].bstrType = "";  
-                properties[i].bstrValue = "";  
-                properties[i].dwAttrib = 0;  
-                properties[i].dwFields = 0;  
-                properties[i].pProperty = null;  
-            }  
-            fetched = 0;  
-  
-            // COM interop.  
-            HRESULT hr;  
-            uint innerFetched;  
-            IDebugField[] field = new IDebugField[1];  
-  
-            while (fetched < count)  
-            {  
-                field[0] = null;  
-                innerFetched = 0;  
-  
-                // Get next field.  
-                if (fetched < fieldCount)  
-                    hr = fields.Next(1, field, ref innerFetched);  
-                // No more fields.  
-                else return COM.S_FALSE;  
-  
-                if (hr != COM.S_OK || innerFetched != 1 || field[0] == null)  
-                    throw new COMException("CEnumPropertyInfo.Next");  
-  
-                // Get property from field.  
-                CFieldProperty fieldProperty =   
-                    new CFieldProperty(provider, address, binder, field[0]);  
-  
-                DEBUG_PROPERTY_INFO[] property =  
-                                new DEBUG_PROPERTY_INFO[1];  
-                fieldProperty.GetPropertyInfo((uint) infoFlags, radix, 0, null, 0, property);  
-                properties[fetched++] = property[0];  
-            }  
-            return COM.S_OK;  
-        }  
-    }  
-}  
-```  
-  
-## Unmanaged code  
- This example shows an implementation of `IEnumDebugPropertyInfo2::EnumChildren` for a method's locals in unmanaged code.  
-  
-```cpp  
-STDMETHODIMP CEnumPropertyInfo::Next(  
-    in  ULONG                count,  
-    out DEBUG_PROPERTY_INFO* pelements,   
-    out ULONG*               pfetched )  
-{  
-    if (pfetched)  
-        *pfetched = 0;  
-    if (!pelements)  
-        return E_INVALIDARG;  
-    else  
-        memset( pelements, 0, count * sizeof(DEBUG_PROPERTY_INFO));  
-  
-    HRESULT hr  = S_OK;  
-    ULONG   idx = 0;  
-    while (idx < count)  
-    {  
-        ULONG        fetchedFields;  
-        IDebugField* pfield;  
-  
-        //get the next field  
-        hr = m_fields->Next( 1, &pfield, &fetchedFields );  
-        if (FAILED(hr))  
-            return hr;  
-        if (fetchedFields != 1)  
-            return E_FAIL;  
-        idx++;  
-  
-        //create a CFieldProperty to retrieve the DEBUG_PROPERTY_INFO  
-        CFieldProperty* pproperty =  
-            new CFieldProperty( m_provider, m_address, m_binder, pfield );  
-        pfield->Release();  
-        if (!pproperty)  
-            return E_OUTOFMEMORY;  
-  
-        hr = pproperty->Init();  
-        if (FAILED(hr))  
-        {  
-            pproperty->Release();  
-            return hr;  
-        }  
-  
-        hr = pproperty->GetPropertyInfo( m_infoFlags,  
-                                         m_radix,  
-                                         0,  
-                                         NULL,  
-                                         0,  
-                                         pelements + idx - 1);  
-        pproperty->Release();  
-        if (FAILED(hr))  
-            return hr;  
-    }  
-  
-    if (pfetched)  
-        *pfetched = idx;  
-    return hr;  
-}  
-```  
-  
-## See also  
- [Sample implementation of locals](../../extensibility/debugger/sample-implementation-of-locals.md)   
- [Enumerating locals](../../extensibility/debugger/enumerating-locals.md)
+> In Visual Studio 2015, this way of implementing expression evaluators is deprecated. For information about implementing CLR expression evaluators, see [CLR expression evaluators](https://github.com/Microsoft/ConcordExtensibilitySamples/wiki/CLR-Expression-Evaluators) and [Managed expression evaluator sample](https://github.com/Microsoft/ConcordExtensibilitySamples/wiki/Managed-Expression-Evaluator-Sample).
+
+Visual Studio calls [EnumChildren](../../extensibility/debugger/reference/idebugproperty2-enumchildren.md) to obtain an [IEnumDebugPropertyInfo2](../../extensibility/debugger/reference/ienumdebugpropertyinfo2.md) object that provides access to all the locals to be displayed in the **Locals** window. Visual Studio then calls [Next](../../extensibility/debugger/reference/ienumdebugpropertyinfo2-next.md) to get the information to be displayed for each local. In this example, the class `CEnumPropertyInfo` implements the `IEnumDebugPropertyInfo2` interface.
+
+This implementation of `IEnumDebugPropertyInfo2::Next` performs the following tasks:
+
+1. Clears the array where the information is to be stored.
+
+2. Calls [Next](../../extensibility/debugger/reference/ienumdebugfields-next.md) for each local, storing the returned [DEBUG_PROPERTY_INFO](../../extensibility/debugger/reference/debug-property-info.md) in the array to be returned. The [IEnumDebugFields](../../extensibility/debugger/reference/ienumdebugfields.md) object was supplied when this `CEnumPropertyInfo` class was instantiated.
+
+## Managed code
+This example shows an implementation of `IEnumDebugPropertyInfo2::EnumChildren` for a method's locals in managed code.
+
+```csharp
+namespace EEMC
+{
+    public class CEnumMethodField : IEnumDebugFields
+    {
+        public HRESULT Next(
+                uint                  count,
+                DEBUG_PROPERTY_INFO[] properties,
+            out uint                  fetched)
+        {
+            if (count > properties.Length)
+                throw new COMException();
+
+            // Zero out the array.
+            for (int i= 0; i < count; i++)
+            {
+                properties[i].bstrFullName = "";
+                properties[i].bstrName = "";
+                properties[i].bstrType = "";
+                properties[i].bstrValue = "";
+                properties[i].dwAttrib = 0;
+                properties[i].dwFields = 0;
+                properties[i].pProperty = null;
+            }
+            fetched = 0;
+
+            // COM interop.
+            HRESULT hr;
+            uint innerFetched;
+            IDebugField[] field = new IDebugField[1];
+
+            while (fetched < count)
+            {
+                field[0] = null;
+                innerFetched = 0;
+
+                // Get next field.
+                if (fetched < fieldCount)
+                    hr = fields.Next(1, field, ref innerFetched);
+                // No more fields.
+                else return COM.S_FALSE;
+
+                if (hr != COM.S_OK || innerFetched != 1 || field[0] == null)
+                    throw new COMException("CEnumPropertyInfo.Next");
+
+                // Get property from field.
+                CFieldProperty fieldProperty =
+                    new CFieldProperty(provider, address, binder, field[0]);
+
+                DEBUG_PROPERTY_INFO[] property =
+                                new DEBUG_PROPERTY_INFO[1];
+                fieldProperty.GetPropertyInfo((uint) infoFlags, radix, 0, null, 0, property);
+                properties[fetched++] = property[0];
+            }
+            return COM.S_OK;
+        }
+    }
+}
+```
+
+## Unmanaged code
+ This example shows an implementation of `IEnumDebugPropertyInfo2::EnumChildren` for a method's locals in unmanaged code.
+
+```cpp
+STDMETHODIMP CEnumPropertyInfo::Next(
+    in  ULONG                count,
+    out DEBUG_PROPERTY_INFO* pelements,
+    out ULONG*               pfetched )
+{
+    if (pfetched)
+        *pfetched = 0;
+    if (!pelements)
+        return E_INVALIDARG;
+    else
+        memset( pelements, 0, count * sizeof(DEBUG_PROPERTY_INFO));
+
+    HRESULT hr  = S_OK;
+    ULONG   idx = 0;
+    while (idx < count)
+    {
+        ULONG        fetchedFields;
+        IDebugField* pfield;
+
+        //get the next field
+        hr = m_fields->Next( 1, &pfield, &fetchedFields );
+        if (FAILED(hr))
+            return hr;
+        if (fetchedFields != 1)
+            return E_FAIL;
+        idx++;
+
+        //create a CFieldProperty to retrieve the DEBUG_PROPERTY_INFO
+        CFieldProperty* pproperty =
+            new CFieldProperty( m_provider, m_address, m_binder, pfield );
+        pfield->Release();
+        if (!pproperty)
+            return E_OUTOFMEMORY;
+
+        hr = pproperty->Init();
+        if (FAILED(hr))
+        {
+            pproperty->Release();
+            return hr;
+        }
+
+        hr = pproperty->GetPropertyInfo( m_infoFlags,
+                                         m_radix,
+                                         0,
+                                         NULL,
+                                         0,
+                                         pelements + idx - 1);
+        pproperty->Release();
+        if (FAILED(hr))
+            return hr;
+    }
+
+    if (pfetched)
+        *pfetched = idx;
+    return hr;
+}
+```
+
+## See also
+[Sample implementation of locals](../../extensibility/debugger/sample-implementation-of-locals.md)  
+[Enumerating locals](../../extensibility/debugger/enumerating-locals.md)

--- a/docs/extensibility/debugger/getting-local-properties.md
+++ b/docs/extensibility/debugger/getting-local-properties.md
@@ -75,10 +75,10 @@ namespace EEMC
 
                 // Get property from field.
                 CFieldProperty fieldProperty =
-                    new CFieldProperty(provider, address, binder, field[0]);
+                        new CFieldProperty(provider, address, binder, field[0]);
 
                 DEBUG_PROPERTY_INFO[] property =
-                                new DEBUG_PROPERTY_INFO[1];
+                        new DEBUG_PROPERTY_INFO[1];
                 fieldProperty.GetPropertyInfo((uint) infoFlags, radix, 0, null, 0, property);
                 properties[fetched++] = property[0];
             }


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.