### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/ad-process-id-type.md
+++ b/docs/extensibility/debugger/reference/ad-process-id-type.md
@@ -2,54 +2,54 @@
 title: "AD_PROCESS_ID_TYPE | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-f1_keywords: 
+f1_keywords:
   - "AD_PROCESS_ID_TYPE"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "AD_PROCESS_ID_TYPE enumeration"
 ms.assetid: 0aab80e9-285a-4697-94ac-c864d42a6aaa
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # AD_PROCESS_ID_TYPE
-Specifies how to interpret a process ID in the [AD_PROCESS_ID](../../../extensibility/debugger/reference/ad-process-id.md) structure.  
-  
-## Syntax  
-  
-```cpp  
-enum enum_AD_PROCESS_ID {  
-   AD_PROCESS_ID_SYSTEM = 0,  
-   AD_PROCESS_ID_GUID   = 1  
-};  
-typedef DWORD AD_PROCESS_ID_TYPE;  
-```  
-  
-```csharp  
-public enum enum_AD_PROCESS_ID {  
-   AD_PROCESS_ID_SYSTEM = 0,  
-   AD_PROCESS_ID_GUID   = 1  
-};  
-```  
-  
-## Members  
- AD_PROCESS_ID_SYSTEM  
- Process ID is a system identifier. Use the `ProcessId.dwProcessId` field of the [AD_PROCESS_ID](../../../extensibility/debugger/reference/ad-process-id.md) structure.  
-  
- AD_PROCESS_ID_GUID  
- Process ID is a GUID. Use the `ProcessId.guidProcessId` field of the `AD_PROCESS_ID` structure.  
-  
-## Remarks  
- Used for the `ProcessIdType` member of the [AD_PROCESS_ID](../../../extensibility/debugger/reference/ad-process-id.md) structure to identify the type of process ID that is contained in the structure. Determines how to interpret the `ProcessId` union in the structure.  
-  
-## Requirements  
- Header: msdbg.h  
-  
- Namespace: Microsoft.VisualStudio.Debugger.Interop  
-  
- Assembly: Microsoft.VisualStudio.Debugger.Interop.dll  
-  
-## See Also  
- [Enumerations](../../../extensibility/debugger/reference/enumerations-visual-studio-debugging.md)   
- [AD_PROCESS_ID](../../../extensibility/debugger/reference/ad-process-id.md)
+Specifies how to interpret a process ID in the [AD_PROCESS_ID](../../../extensibility/debugger/reference/ad-process-id.md) structure.
+
+## Syntax
+
+```cpp
+enum enum_AD_PROCESS_ID {
+   AD_PROCESS_ID_SYSTEM = 0,
+   AD_PROCESS_ID_GUID   = 1
+};
+typedef DWORD AD_PROCESS_ID_TYPE;
+```
+
+```csharp
+public enum enum_AD_PROCESS_ID {
+   AD_PROCESS_ID_SYSTEM = 0,
+   AD_PROCESS_ID_GUID   = 1
+};
+```
+
+## Members
+AD_PROCESS_ID_SYSTEM
+Process ID is a system identifier. Use the `ProcessId.dwProcessId` field of the [AD_PROCESS_ID](../../../extensibility/debugger/reference/ad-process-id.md) structure.
+
+AD_PROCESS_ID_GUID
+Process ID is a GUID. Use the `ProcessId.guidProcessId` field of the `AD_PROCESS_ID` structure.
+
+## Remarks
+Used for the `ProcessIdType` member of the [AD_PROCESS_ID](../../../extensibility/debugger/reference/ad-process-id.md) structure to identify the type of process ID that is contained in the structure. Determines how to interpret the `ProcessId` union in the structure.
+
+## Requirements
+Header: msdbg.h
+
+Namespace: Microsoft.VisualStudio.Debugger.Interop
+
+Assembly: Microsoft.VisualStudio.Debugger.Interop.dll
+
+## See Also
+[Enumerations](../../../extensibility/debugger/reference/enumerations-visual-studio-debugging.md)  
+[AD_PROCESS_ID](../../../extensibility/debugger/reference/ad-process-id.md)

--- a/docs/extensibility/debugger/reference/ad-process-id-type.md
+++ b/docs/extensibility/debugger/reference/ad-process-id-type.md
@@ -20,16 +20,16 @@ Specifies how to interpret a process ID in the [AD_PROCESS_ID](../../../extensib
 
 ```cpp
 enum enum_AD_PROCESS_ID {
-   AD_PROCESS_ID_SYSTEM = 0,
-   AD_PROCESS_ID_GUID   = 1
+    AD_PROCESS_ID_SYSTEM = 0,
+    AD_PROCESS_ID_GUID   = 1
 };
 typedef DWORD AD_PROCESS_ID_TYPE;
 ```
 
 ```csharp
 public enum enum_AD_PROCESS_ID {
-   AD_PROCESS_ID_SYSTEM = 0,
-   AD_PROCESS_ID_GUID   = 1
+    AD_PROCESS_ID_SYSTEM = 0,
+    AD_PROCESS_ID_GUID   = 1
 };
 ```
 


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.