### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/ad-process-id.md
+++ b/docs/extensibility/debugger/reference/ad-process-id.md
@@ -2,86 +2,86 @@
 title: "AD_PROCESS_ID | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-f1_keywords: 
+f1_keywords:
   - "AD_PROCESS_ID"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "AD_PROCESS_ID union"
 ms.assetid: 4cb40d12-2e92-4f09-83f4-689928bd65b3
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # AD_PROCESS_ID
-Specifies the process ID, which may be either a system ID or a GUID.  
-  
-## Syntax  
-  
-```cpp  
-typedef struct _AD_PROCESS_ID {  
-   AD_PROCESS_ID_TYPE ProcessIdType;  
-   union {  
-      DWORD dwProcessId;   
-      GUID  guidProcessId;   
-      DWORD dwUnused;   
-   } ProcessId;  
-} AD_PROCESS_ID;  
-```  
-  
-```csharp  
-public struct AD_PROCESS_ID {  
-   AD_PROCESS_ID_TYPE ProcessIdType;  
-   DWORD              dwProcessId;   
-   GUID               guidProcessId;   
-   DWORD              dwUnused;   
-};  
-```  
-  
-## Members  
- `ProcessIdType`  
- A value from the [AD_PROCESS_ID_TYPE](../../../extensibility/debugger/reference/ad-process-id-type.md) enumeration specifying how to interpret the `ProcessId` union (or, for managed code, which member of the structure to access).  
-  
- dwProcessId  
- The process ID as a value from the system.  
-  
- guidProcessId  
- The process ID as a GUID.  
-  
- dwUnused  
- Padding.  
-  
-## Remarks  
- This structure is passed to the following methods:  
-  
-- [GetProviderProgramNode](../../../extensibility/debugger/reference/idebugprogramprovider2-getproviderprogramnode.md)  
-  
-- [WatchForProviderEvents](../../../extensibility/debugger/reference/idebugprogramprovider2-watchforproviderevents.md)  
-  
-- [GetProviderProcessData](../../../extensibility/debugger/reference/idebugprogramprovider2-getproviderprocessdata.md)  
-  
-- [GetProcess](../../../extensibility/debugger/reference/idebugport2-getprocess.md)  
-  
-  And is returned from the following methods:  
-  
-- [GetPhysicalProcessId](../../../extensibility/debugger/reference/idebugprocess2-getphysicalprocessid.md)  
-  
-- [GetHostId](../../../extensibility/debugger/reference/idebugprogramhost2-gethostid.md)  
-  
-## Requirements  
- Header: msdbg.h  
-  
- Namespace: Microsoft.VisualStudio.Debugger.Interop  
-  
- Assembly: Microsoft.VisualStudio.Debugger.Interop.dll  
-  
-## See Also  
- [Structures and Unions](../../../extensibility/debugger/reference/structures-and-unions.md)   
- [GetProcess](../../../extensibility/debugger/reference/idebugport2-getprocess.md)   
- [PROCESS_INFO](../../../extensibility/debugger/reference/process-info.md)   
- [AD_PROCESS_ID_TYPE](../../../extensibility/debugger/reference/ad-process-id-type.md)   
- [GetPhysicalProcessId](../../../extensibility/debugger/reference/idebugprocess2-getphysicalprocessid.md)   
- [GetHostId](../../../extensibility/debugger/reference/idebugprogramhost2-gethostid.md)   
- [GetProviderProgramNode](../../../extensibility/debugger/reference/idebugprogramprovider2-getproviderprogramnode.md)   
- [WatchForProviderEvents](../../../extensibility/debugger/reference/idebugprogramprovider2-watchforproviderevents.md)   
- [GetProviderProcessData](../../../extensibility/debugger/reference/idebugprogramprovider2-getproviderprocessdata.md)
+Specifies the process ID, which may be either a system ID or a GUID.
+
+## Syntax
+
+```cpp
+typedef struct _AD_PROCESS_ID {
+   AD_PROCESS_ID_TYPE ProcessIdType;
+   union {
+      DWORD dwProcessId; 
+      GUID  guidProcessId; 
+      DWORD dwUnused; 
+   } ProcessId;
+} AD_PROCESS_ID;
+```
+
+```csharp
+public struct AD_PROCESS_ID {
+   AD_PROCESS_ID_TYPE ProcessIdType;
+   DWORD              dwProcessId; 
+   GUID               guidProcessId; 
+   DWORD              dwUnused; 
+};
+```
+
+## Members
+`ProcessIdType`  
+A value from the [AD_PROCESS_ID_TYPE](../../../extensibility/debugger/reference/ad-process-id-type.md) enumeration specifying how to interpret the `ProcessId` union (or, for managed code, which member of the structure to access).
+
+dwProcessId  
+The process ID as a value from the system.
+
+guidProcessId  
+The process ID as a GUID.
+
+dwUnused  
+Padding.
+
+## Remarks
+This structure is passed to the following methods:
+
+- [GetProviderProgramNode](../../../extensibility/debugger/reference/idebugprogramprovider2-getproviderprogramnode.md)
+
+- [WatchForProviderEvents](../../../extensibility/debugger/reference/idebugprogramprovider2-watchforproviderevents.md)
+
+- [GetProviderProcessData](../../../extensibility/debugger/reference/idebugprogramprovider2-getproviderprocessdata.md)
+
+- [GetProcess](../../../extensibility/debugger/reference/idebugport2-getprocess.md)
+
+  And is returned from the following methods:
+
+- [GetPhysicalProcessId](../../../extensibility/debugger/reference/idebugprocess2-getphysicalprocessid.md)
+
+- [GetHostId](../../../extensibility/debugger/reference/idebugprogramhost2-gethostid.md)
+
+## Requirements
+Header: msdbg.h
+
+Namespace: Microsoft.VisualStudio.Debugger.Interop
+
+Assembly: Microsoft.VisualStudio.Debugger.Interop.dll
+
+## See Also
+[Structures and Unions](../../../extensibility/debugger/reference/structures-and-unions.md)  
+[GetProcess](../../../extensibility/debugger/reference/idebugport2-getprocess.md)  
+[PROCESS_INFO](../../../extensibility/debugger/reference/process-info.md)  
+[AD_PROCESS_ID_TYPE](../../../extensibility/debugger/reference/ad-process-id-type.md)  
+[GetPhysicalProcessId](../../../extensibility/debugger/reference/idebugprocess2-getphysicalprocessid.md)  
+[GetHostId](../../../extensibility/debugger/reference/idebugprogramhost2-gethostid.md)  
+[GetProviderProgramNode](../../../extensibility/debugger/reference/idebugprogramprovider2-getproviderprogramnode.md)  
+[WatchForProviderEvents](../../../extensibility/debugger/reference/idebugprogramprovider2-watchforproviderevents.md)  
+[GetProviderProcessData](../../../extensibility/debugger/reference/idebugprogramprovider2-getproviderprocessdata.md)

--- a/docs/extensibility/debugger/reference/ad-process-id.md
+++ b/docs/extensibility/debugger/reference/ad-process-id.md
@@ -20,21 +20,21 @@ Specifies the process ID, which may be either a system ID or a GUID.
 
 ```cpp
 typedef struct _AD_PROCESS_ID {
-   AD_PROCESS_ID_TYPE ProcessIdType;
-   union {
-      DWORD dwProcessId; 
-      GUID  guidProcessId; 
-      DWORD dwUnused; 
-   } ProcessId;
+    AD_PROCESS_ID_TYPE ProcessIdType;
+    union {
+        DWORD dwProcessId; 
+        GUID  guidProcessId; 
+        DWORD dwUnused; 
+    } ProcessId;
 } AD_PROCESS_ID;
 ```
 
 ```csharp
 public struct AD_PROCESS_ID {
-   AD_PROCESS_ID_TYPE ProcessIdType;
-   DWORD              dwProcessId; 
-   GUID               guidProcessId; 
-   DWORD              dwUnused; 
+    AD_PROCESS_ID_TYPE ProcessIdType;
+    DWORD              dwProcessId; 
+    GUID               guidProcessId; 
+    DWORD              dwUnused; 
 };
 ```
 

--- a/docs/extensibility/debugger/reference/ad-process-id.md
+++ b/docs/extensibility/debugger/reference/ad-process-id.md
@@ -62,7 +62,7 @@ This structure is passed to the following methods:
 
 - [GetProcess](../../../extensibility/debugger/reference/idebugport2-getprocess.md)
 
-  And is returned from the following methods:
+And is returned from the following methods:
 
 - [GetPhysicalProcessId](../../../extensibility/debugger/reference/idebugprocess2-getphysicalprocessid.md)
 


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.