### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/assemblylocresolution.md
+++ b/docs/extensibility/debugger/reference/assemblylocresolution.md
@@ -2,67 +2,67 @@
 title: "ASSEMBLYLOCRESOLUTION | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-f1_keywords: 
+f1_keywords:
   - "ASSEMBLYLOCRESOLUTION"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "ASSEMBLYLOCRESOLUTION enumeration"
 ms.assetid: 0bcfe85c-5f37-4a9d-bf2b-141acd96ad67
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # ASSEMBLYLOCRESOLUTION
-Specifies where an assembly is located.  
-  
-## Syntax  
-  
-```cpp  
-enum enum_ASSEMBLYLOCRESOLUTION {  
-   ALR_NAME      = 0x0,  
-   ALR_USERDIR   = 0x1,  
-   ALR_SHAREDDIR = 0x2,  
-   ALR_REMOTEDIR = 0x4,  
-};  
-typedef DWORD ASSEMBLYLOCRESOLUTION;  
-```  
-  
-```csharp  
-public enum enum_ASSEMBLYLOCRESOLUTION {  
-   ALR_NAME      = 0x0,  
-   ALR_USERDIR   = 0x1,  
-   ALR_SHAREDDIR = 0x2,  
-   ALR_REMOTEDIR = 0x4,  
-};  
-```  
-  
-## Members  
- ALR_NAME  
- Assembly is located in the current namespace.  
-  
- ALR_USERDIR  
- Assembly is located in a user directory.  
-  
- ALR_SHAREDDIR  
- Assembly is located in shared directory.  
-  
- ALR_REMOTEDIR  
- Assembly is located in a remote directory.  
-  
-## Remarks  
- These values are returned by the [ResolveAssemblyRef](../../../extensibility/debugger/reference/ipropertyproxyeeside-resolveassemblyref.md) and [GetManagedViewerCreationData](../../../extensibility/debugger/reference/ipropertyproxyeeside-getmanagedviewercreationdata.md) methods.  
-  
- These values can be combined with the `OR` operation.  
-  
-## Requirements  
- Header: msdbg.h  
-  
- Namespace: Microsoft.VisualStudio.Debugger.Interop  
-  
- Assembly: Microsoft.VisualStudio.Debugger.Interop.dll  
-  
-## See Also  
- [Enumerations](../../../extensibility/debugger/reference/enumerations-visual-studio-debugging.md)   
- [ResolveAssemblyRef](../../../extensibility/debugger/reference/ipropertyproxyeeside-resolveassemblyref.md)   
- [GetManagedViewerCreationData](../../../extensibility/debugger/reference/ipropertyproxyeeside-getmanagedviewercreationdata.md)
+Specifies where an assembly is located.
+
+## Syntax
+
+```cpp
+enum enum_ASSEMBLYLOCRESOLUTION {
+   ALR_NAME      = 0x0,
+   ALR_USERDIR   = 0x1,
+   ALR_SHAREDDIR = 0x2,
+   ALR_REMOTEDIR = 0x4,
+};
+typedef DWORD ASSEMBLYLOCRESOLUTION;
+```
+
+```csharp
+public enum enum_ASSEMBLYLOCRESOLUTION {
+   ALR_NAME      = 0x0,
+   ALR_USERDIR   = 0x1,
+   ALR_SHAREDDIR = 0x2,
+   ALR_REMOTEDIR = 0x4,
+};
+```
+
+## Members
+ALR_NAME  
+Assembly is located in the current namespace.
+
+ALR_USERDIR  
+Assembly is located in a user directory.
+
+ALR_SHAREDDIR  
+Assembly is located in shared directory.
+
+ALR_REMOTEDIR  
+Assembly is located in a remote directory.
+
+## Remarks
+These values are returned by the [ResolveAssemblyRef](../../../extensibility/debugger/reference/ipropertyproxyeeside-resolveassemblyref.md) and [GetManagedViewerCreationData](../../../extensibility/debugger/reference/ipropertyproxyeeside-getmanagedviewercreationdata.md) methods.
+
+These values can be combined with the `OR` operation.
+
+## Requirements
+Header: msdbg.h
+
+Namespace: Microsoft.VisualStudio.Debugger.Interop
+
+Assembly: Microsoft.VisualStudio.Debugger.Interop.dll
+
+## See Also
+[Enumerations](../../../extensibility/debugger/reference/enumerations-visual-studio-debugging.md)  
+[ResolveAssemblyRef](../../../extensibility/debugger/reference/ipropertyproxyeeside-resolveassemblyref.md)  
+[GetManagedViewerCreationData](../../../extensibility/debugger/reference/ipropertyproxyeeside-getmanagedviewercreationdata.md)

--- a/docs/extensibility/debugger/reference/assemblylocresolution.md
+++ b/docs/extensibility/debugger/reference/assemblylocresolution.md
@@ -20,20 +20,20 @@ Specifies where an assembly is located.
 
 ```cpp
 enum enum_ASSEMBLYLOCRESOLUTION {
-   ALR_NAME      = 0x0,
-   ALR_USERDIR   = 0x1,
-   ALR_SHAREDDIR = 0x2,
-   ALR_REMOTEDIR = 0x4,
+    ALR_NAME      = 0x0,
+    ALR_USERDIR   = 0x1,
+    ALR_SHAREDDIR = 0x2,
+    ALR_REMOTEDIR = 0x4,
 };
 typedef DWORD ASSEMBLYLOCRESOLUTION;
 ```
 
 ```csharp
 public enum enum_ASSEMBLYLOCRESOLUTION {
-   ALR_NAME      = 0x0,
-   ALR_USERDIR   = 0x1,
-   ALR_SHAREDDIR = 0x2,
-   ALR_REMOTEDIR = 0x4,
+    ALR_NAME      = 0x0,
+    ALR_USERDIR   = 0x1,
+    ALR_SHAREDDIR = 0x2,
+    ALR_REMOTEDIR = 0x4,
 };
 ```
 


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.