### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/bstr-array.md
+++ b/docs/extensibility/debugger/reference/bstr-array.md
@@ -2,55 +2,55 @@
 title: "BSTR_ARRAY | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-f1_keywords: 
+f1_keywords:
   - "BSTR_ARRAY"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "BSTR_ARRAY structure"
 ms.assetid: 48da37f7-a237-48a9-9ff9-389c1a00862c
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # BSTR_ARRAY
-A structure that describes an array of strings.  
-  
-## Syntax  
-  
-```cpp  
-typedef struct tagBSTR_ARRAY {  
-   DWORD dwCount;  
-   BSTR* Members;  
-} BSTR_ARRAY;  
-```  
-  
-```csharp  
-struct BSTR_ARRAY {  
-   DWORD    dwCount;  
-   string[] Members;  
-}  
-```  
-  
-## Terms  
- dwCount  
- Number of strings in `Members` array.  
-  
- Members  
- Array of strings.  
-  
-## Remarks  
- This structure is returned from the [EnumPersistedPorts](../../../extensibility/debugger/reference/idebugportsupplier3-enumpersistedports.md) method.  
-  
- [C++ only] Each individual string must be freed using `SysFreeString`, and the `Members` array must be freed with `CoTaskMemFree`.  
-  
-## Requirements  
- Header: msdbg.h  
-  
- Namespace: Microsoft.VisualStudio.Debugger.Interop  
-  
- Assembly: Microsoft.VisualStudio.Debugger.Interop.dll  
-  
-## See Also  
- [Structures and Unions](../../../extensibility/debugger/reference/structures-and-unions.md)   
- [EnumPersistedPorts](../../../extensibility/debugger/reference/idebugportsupplier3-enumpersistedports.md)
+A structure that describes an array of strings.
+
+## Syntax
+
+```cpp
+typedef struct tagBSTR_ARRAY {
+   DWORD dwCount;
+   BSTR* Members;
+} BSTR_ARRAY;
+```
+
+```csharp
+struct BSTR_ARRAY {
+   DWORD    dwCount;
+   string[] Members;
+}
+```
+
+## Terms
+dwCount  
+Number of strings in `Members` array.
+
+Members  
+Array of strings.
+
+## Remarks
+This structure is returned from the [EnumPersistedPorts](../../../extensibility/debugger/reference/idebugportsupplier3-enumpersistedports.md) method.
+
+[C++ only] Each individual string must be freed using `SysFreeString`, and the `Members` array must be freed with `CoTaskMemFree`.
+
+## Requirements
+Header: msdbg.h
+
+Namespace: Microsoft.VisualStudio.Debugger.Interop
+
+Assembly: Microsoft.VisualStudio.Debugger.Interop.dll
+
+## See Also
+[Structures and Unions](../../../extensibility/debugger/reference/structures-and-unions.md)  
+[EnumPersistedPorts](../../../extensibility/debugger/reference/idebugportsupplier3-enumpersistedports.md)

--- a/docs/extensibility/debugger/reference/bstr-array.md
+++ b/docs/extensibility/debugger/reference/bstr-array.md
@@ -20,15 +20,15 @@ A structure that describes an array of strings.
 
 ```cpp
 typedef struct tagBSTR_ARRAY {
-   DWORD dwCount;
-   BSTR* Members;
+    DWORD dwCount;
+    BSTR* Members;
 } BSTR_ARRAY;
 ```
 
 ```csharp
 struct BSTR_ARRAY {
-   DWORD    dwCount;
-   string[] Members;
+    DWORD    dwCount;
+    string[] Members;
 }
 ```
 


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.