### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/built-type.md
+++ b/docs/extensibility/debugger/reference/built-type.md
@@ -2,60 +2,60 @@
 title: "BUILT_TYPE | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-f1_keywords: 
+f1_keywords:
   - "BUILT_TYPE"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "BUILT_TYPE structure"
 ms.assetid: cc02c32c-0f65-4210-ad25-a9b1899066e8
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # BUILT_TYPE
-This structure specifies information about a field type taken from metadata.  
-  
-## Syntax  
-  
-```cpp  
-typedef struct _tagTYPE_BUILT {  
-   ULONG32      ulAppDomainID;  
-   GUID         guidModule;  
-   IDebugField* pUnderlyingField;  
-} BUILT_TYPE;  
-```  
-  
-```csharp  
-public struct BUILT_TYPE {  
-   public uint        ulAppDomainID;  
-   public Guid        guidModule;  
-   public IDebugField pUnderlyingField;  
-};  
-```  
-  
-#### Parameters  
- ulAppDomainID  
- ID of the application from which the symbol came. This is used to uniquely identify an instance of the application.  
-  
- guidModule  
- The GUID of the module that contains this field.  
-  
- pUnderlyingField  
- An [IDebugField](../../../extensibility/debugger/reference/idebugfield.md) object identifying the underlying field associated with this built field.  
-  
-## Remarks  
- This structure appears as part of the union in the [TYPE_INFO](../../../extensibility/debugger/reference/type-info.md) structure when the `dwKind` field of the `TYPE_INFO` structure is set to `TYPE_KIND_BUILT` (a value from the [dwTYPE_KIND](../../../extensibility/debugger/reference/dwtype-kind.md) enumeration).  
-  
-## Requirements  
- Header: sh.h  
-  
- Namespace: Microsoft.VisualStudio.Debugger.Interop  
-  
- Assembly: Microsoft.VisualStudio.Debugger.Interop.dll  
-  
-## See Also  
- [Structures and Unions](../../../extensibility/debugger/reference/structures-and-unions.md)   
- [TYPE_INFO](../../../extensibility/debugger/reference/type-info.md)   
- [dwTYPE_KIND](../../../extensibility/debugger/reference/dwtype-kind.md)   
- [IDebugField](../../../extensibility/debugger/reference/idebugfield.md)
+This structure specifies information about a field type taken from metadata.
+
+## Syntax
+
+```cpp
+typedef struct _tagTYPE_BUILT {
+   ULONG32      ulAppDomainID;
+   GUID         guidModule;
+   IDebugField* pUnderlyingField;
+} BUILT_TYPE;
+```
+
+```csharp
+public struct BUILT_TYPE {
+   public uint        ulAppDomainID;
+   public Guid        guidModule;
+   public IDebugField pUnderlyingField;
+};
+```
+
+#### Parameters
+ulAppDomainID  
+ID of the application from which the symbol came. This is used to uniquely identify an instance of the application.
+
+guidModule  
+The GUID of the module that contains this field.
+
+pUnderlyingField  
+An [IDebugField](../../../extensibility/debugger/reference/idebugfield.md) object identifying the underlying field associated with this built field.
+
+## Remarks
+This structure appears as part of the union in the [TYPE_INFO](../../../extensibility/debugger/reference/type-info.md) structure when the `dwKind` field of the `TYPE_INFO` structure is set to `TYPE_KIND_BUILT` (a value from the [dwTYPE_KIND](../../../extensibility/debugger/reference/dwtype-kind.md) enumeration).
+
+## Requirements
+Header: sh.h
+
+Namespace: Microsoft.VisualStudio.Debugger.Interop
+
+Assembly: Microsoft.VisualStudio.Debugger.Interop.dll
+
+## See Also
+[Structures and Unions](../../../extensibility/debugger/reference/structures-and-unions.md)  
+[TYPE_INFO](../../../extensibility/debugger/reference/type-info.md)  
+[dwTYPE_KIND](../../../extensibility/debugger/reference/dwtype-kind.md)  
+[IDebugField](../../../extensibility/debugger/reference/idebugfield.md)

--- a/docs/extensibility/debugger/reference/built-type.md
+++ b/docs/extensibility/debugger/reference/built-type.md
@@ -20,17 +20,17 @@ This structure specifies information about a field type taken from metadata.
 
 ```cpp
 typedef struct _tagTYPE_BUILT {
-   ULONG32      ulAppDomainID;
-   GUID         guidModule;
-   IDebugField* pUnderlyingField;
+    ULONG32      ulAppDomainID;
+    GUID         guidModule;
+    IDebugField* pUnderlyingField;
 } BUILT_TYPE;
 ```
 
 ```csharp
 public struct BUILT_TYPE {
-   public uint        ulAppDomainID;
-   public Guid        guidModule;
-   public IDebugField pUnderlyingField;
+    public uint        ulAppDomainID;
+    public Guid        guidModule;
+    public IDebugField pUnderlyingField;
 };
 ```
 


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.