### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/code-path.md
+++ b/docs/extensibility/debugger/reference/code-path.md
@@ -20,15 +20,15 @@ Describes a method or function call.
 
 ```cpp
 typedef struct tagCODE_PATH { 
-   BSTR                bstrName;
-   IDebugCodeContext2* pCode;
+    BSTR                bstrName;
+    IDebugCodeContext2* pCode;
 } CODE_PATH;
 ```
 
 ```csharp
 public struct CODE_PATH {
-   public string            bstrName;
-   public IDebugCodeContext pCode;
+    public string            bstrName;
+    public IDebugCodeContext pCode;
 }
 ```
 

--- a/docs/extensibility/debugger/reference/code-path.md
+++ b/docs/extensibility/debugger/reference/code-path.md
@@ -2,54 +2,54 @@
 title: "CODE_PATH | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-f1_keywords: 
+f1_keywords:
   - "CODE_PATH"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "CODE_PATH structure"
 ms.assetid: 2d4b2890-4c9d-47e1-83c0-df9c6436427f
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # CODE_PATH
-Describes a method or function call.  
-  
-## Syntax  
-  
-```cpp  
-typedef struct tagCODE_PATH {   
-   BSTR                bstrName;  
-   IDebugCodeContext2* pCode;  
-} CODE_PATH;  
-```  
-  
-```csharp  
-public struct CODE_PATH {  
-   public string            bstrName;  
-   public IDebugCodeContext pCode;  
-}  
-```  
-  
-## Members  
- bstrName  
- The name of the code path.  
-  
- pCode  
- The [IDebugCodeContext2](../../../extensibility/debugger/reference/idebugcodecontext2.md) object that identifies where in the code to step into a function.  
-  
-## Remarks  
- This structure is used to implement stepping into a function. [EnumCodePaths](../../../extensibility/debugger/reference/idebugprogram2-enumcodepaths.md) returns all the calls from the current location in the program being debugged. This structure represents one such call.  
-  
-## Requirements  
- Header: msdbg.h  
-  
- Namespace: Microsoft.VisualStudio.Debugger.Interop  
-  
- Assembly: Microsoft.VisualStudio.Debugger.Interop.dll  
-  
-## See Also  
- [Structures and Unions](../../../extensibility/debugger/reference/structures-and-unions.md)   
- [IDebugCodeContext2](../../../extensibility/debugger/reference/idebugcodecontext2.md)   
- [EnumCodePaths](../../../extensibility/debugger/reference/idebugprogram2-enumcodepaths.md)
+Describes a method or function call.
+
+## Syntax
+
+```cpp
+typedef struct tagCODE_PATH { 
+   BSTR                bstrName;
+   IDebugCodeContext2* pCode;
+} CODE_PATH;
+```
+
+```csharp
+public struct CODE_PATH {
+   public string            bstrName;
+   public IDebugCodeContext pCode;
+}
+```
+
+## Members
+bstrName  
+The name of the code path.
+
+pCode  
+The [IDebugCodeContext2](../../../extensibility/debugger/reference/idebugcodecontext2.md) object that identifies where in the code to step into a function.
+
+## Remarks
+This structure is used to implement stepping into a function. [EnumCodePaths](../../../extensibility/debugger/reference/idebugprogram2-enumcodepaths.md) returns all the calls from the current location in the program being debugged. This structure represents one such call.
+
+## Requirements
+Header: msdbg.h
+
+Namespace: Microsoft.VisualStudio.Debugger.Interop
+
+Assembly: Microsoft.VisualStudio.Debugger.Interop.dll
+
+## See Also
+[Structures and Unions](../../../extensibility/debugger/reference/structures-and-unions.md)  
+[IDebugCodeContext2](../../../extensibility/debugger/reference/idebugcodecontext2.md)  
+[EnumCodePaths](../../../extensibility/debugger/reference/idebugprogram2-enumcodepaths.md)


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.