### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/const-guid-array.md
+++ b/docs/extensibility/debugger/reference/const-guid-array.md
@@ -20,15 +20,15 @@ A structure that holds a list of `GUID`s.
 
 ```cpp
 typedef struct tagCONST_GUID_ARRAY {
-   DWORD       dwCount;
-   CONST GUID* Members;
+    DWORD       dwCount;
+    CONST GUID* Members;
 } CONST_GUID_ARRAY;
 ```
 
 ```csharp
 public struct CONST_GUID_ARRAY {
-   public uint   dwCount;
-   public Guid[] Members;
+    public uint   dwCount;
+    public Guid[] Members;
 }
 ```
 

--- a/docs/extensibility/debugger/reference/const-guid-array.md
+++ b/docs/extensibility/debugger/reference/const-guid-array.md
@@ -2,57 +2,57 @@
 title: "CONST_GUID_ARRAY | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-f1_keywords: 
+f1_keywords:
   - "CONST_GUID_ARRAY"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "CONST_GUID_ARRAY structure"
 ms.assetid: bd55e7d8-372c-4c3e-9eed-28f6b415a5db
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # CONST_GUID_ARRAY
-A structure that holds a list of `GUID`s.  
-  
-## Syntax  
-  
-```cpp  
-typedef struct tagCONST_GUID_ARRAY {  
-   DWORD       dwCount;  
-   CONST GUID* Members;  
-} CONST_GUID_ARRAY;  
-```  
-  
-```csharp  
-public struct CONST_GUID_ARRAY {  
-   public uint   dwCount;  
-   public Guid[] Members;  
-}  
-```  
-  
-## Members  
- dwCount  
- Number of `GUID`s in the `Members` array.  
-  
- Members  
- Array of `GUID`s.  
-  
-## Remarks  
- This structure is passed to the [PublishProgram](../../../extensibility/debugger/reference/idebugprogrampublisher2-publishprogram.md) method, and is returned from the [GetProviderProcessData](../../../extensibility/debugger/reference/idebugprogramprovider2-getproviderprocessdata.md) and [WatchForProviderEvents](../../../extensibility/debugger/reference/idebugprogramprovider2-watchforproviderevents.md) methods.  
-  
- The owner of an instance of this structure is responsible for freeing any memory allocated.  
-  
-## Requirements  
- Header: msdbg.h  
-  
- Namespace: Microsoft.VisualStudio.Debugger.Interop  
-  
- Assembly: Microsoft.VisualStudio.Debugger.Interop.dll  
-  
-## See Also  
- [Structures and Unions](../../../extensibility/debugger/reference/structures-and-unions.md)   
- [PublishProgram](../../../extensibility/debugger/reference/idebugprogrampublisher2-publishprogram.md)   
- [GetProviderProcessData](../../../extensibility/debugger/reference/idebugprogramprovider2-getproviderprocessdata.md)   
- [WatchForProviderEvents](../../../extensibility/debugger/reference/idebugprogramprovider2-watchforproviderevents.md)
+A structure that holds a list of `GUID`s.
+
+## Syntax
+
+```cpp
+typedef struct tagCONST_GUID_ARRAY {
+   DWORD       dwCount;
+   CONST GUID* Members;
+} CONST_GUID_ARRAY;
+```
+
+```csharp
+public struct CONST_GUID_ARRAY {
+   public uint   dwCount;
+   public Guid[] Members;
+}
+```
+
+## Members
+dwCount  
+Number of `GUID`s in the `Members` array.
+
+Members  
+Array of `GUID`s.
+
+## Remarks
+This structure is passed to the [PublishProgram](../../../extensibility/debugger/reference/idebugprogrampublisher2-publishprogram.md) method, and is returned from the [GetProviderProcessData](../../../extensibility/debugger/reference/idebugprogramprovider2-getproviderprocessdata.md) and [WatchForProviderEvents](../../../extensibility/debugger/reference/idebugprogramprovider2-watchforproviderevents.md) methods.
+
+The owner of an instance of this structure is responsible for freeing any memory allocated.
+
+## Requirements
+Header: msdbg.h
+
+Namespace: Microsoft.VisualStudio.Debugger.Interop
+
+Assembly: Microsoft.VisualStudio.Debugger.Interop.dll
+
+## See Also
+[Structures and Unions](../../../extensibility/debugger/reference/structures-and-unions.md)  
+[PublishProgram](../../../extensibility/debugger/reference/idebugprogrampublisher2-publishprogram.md)  
+[GetProviderProcessData](../../../extensibility/debugger/reference/idebugprogramprovider2-getproviderprocessdata.md)  
+[WatchForProviderEvents](../../../extensibility/debugger/reference/idebugprogramprovider2-watchforproviderevents.md)


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.