### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/evaluating-locals.md
+++ b/docs/extensibility/debugger/evaluating-locals.md
@@ -2,188 +2,188 @@
 title: "Evaluating Locals | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "debugging [Debugging SDK], evaluating locals"
   - "expression evaluation, evaluating locals"
 ms.assetid: 7d1ed528-4e7a-4d8f-87b4-162440644a75
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # Evaluate locals
 > [!IMPORTANT]
->  In Visual Studio 2015, this way of implementing expression evaluators is deprecated. For information about implementing CLR expression evaluators, see [CLR expression evaluators](https://github.com/Microsoft/ConcordExtensibilitySamples/wiki/CLR-Expression-Evaluators) and [Managed expression evaluator sample](https://github.com/Microsoft/ConcordExtensibilitySamples/wiki/Managed-Expression-Evaluator-Sample).  
-  
- [GetPropertyInfo](../../extensibility/debugger/reference/idebugproperty2-getpropertyinfo.md) is called to obtain the value of a local, as well as the local's name and type. Since the value of a local is dependent on the current state of the program, the local's value must be obtained from memory. The [IDebugBinder](../../extensibility/debugger/reference/idebugbinder.md) object is used to bind the [IDebugField](../../extensibility/debugger/reference/idebugfield.md) object representing the local to the appropriate location in memory containing the value. This location in memory is represented by an [IDebugObject](../../extensibility/debugger/reference/idebugobject.md) object.  
-  
- This functionality of retrieving the value of a local is encapsulated in a helper function that performs the following tasks:  
-  
-1.  Binds the `IDebugField` object to memory to obtain an `IDebugObject` object.  
-  
-2.  Gets the value from memory. This value is represented as a series of bytes.  
-  
-3.  Formats the value based on the local's type.  
-  
-4.  Returns a generic object that contains the local's value. In C#, this is an `object`, and in C++, this is a `VARIANT`.  
-  
-## Managed code  
- This is an implementation of a function that retrieves the value of a local in managed code.  
-  
-```csharp  
-namespace EEMC  
-{  
-    internal class Field  
-    {  
-        internal static object GetValue(  
-            IDebugBinder binder,  
-            IDebugField field,  
-            Type t,  
-            uint size)  
-        {  
-            if (t == null || size == 0)  return null;  
-  
-            IDebugObject debugObject = null;  
-            binder.Bind(null, field, out debugObject);  
-  
-            byte[] buffer = new byte[size];  
-            for (int i = 0; i < size; i++)  buffer[i] = 0;  
-  
-            debugObject.GetValue(buffer, size);   
-  
-            if (t == typeof(sbyte)) return (sbyte) buffer[0];  
-            if (t == typeof(short)) return BitConverter.ToInt16(buffer, 0);  
-            if (t == typeof(int))   return BitConverter.ToInt32(buffer, 0);  
-            if (t == typeof(long))  return BitConverter.ToInt64(buffer, 0);  
-            if (t == typeof(byte))  return buffer[0];  
-            if (t == typeof(char))  return BitConverter.ToChar(buffer, 0);  
-            if (t == typeof(uint))  return BitConverter.ToUInt32(buffer, 0);  
-            if (t == typeof(ulong)) return BitConverter.ToUInt64(buffer, 0);  
-            if (t == typeof(float)) return BitConverter.ToSingle(buffer, 0);  
-            if (t == typeof(double))  return BitConverter.ToDouble(buffer, 0);  
-            if (t == typeof(bool))  return BitConverter.ToBoolean(buffer, 0);  
-            if (t == typeof(string))  return BitConverter.ToString(buffer, 0);  
-            return null;  
-        }  
-    }  
-}  
-```  
-  
-## Unmanaged code  
- This is an implementation of a function that retrieves the value of a local in unmanaged code. `FieldGetType` is shown in [Getting Local Values](../../extensibility/debugger/getting-local-values.md).  
-  
-```cpp  
-HRESULT FieldGetPrimitiveValue(  
-    in  IDebugBinder* pbinder,  
-    in  IDebugField*  pfield,  
-    out VARIANT*      pvarValue  
-    )  
-{  
-    if (pvarValue == NULL)  
-        return E_INVALIDARG;  
-    else  
-        *pvarValue = 0;  
-  
-    if (pfield == NULL)  
-        return E_INVALIDARG;  
-  
-    if (pbinder == NULL)  
-        return E_INVALIDARG;  
-  
-    HRESULT hr;  
-    UINT          valueSize = 0;  
-    BYTE*         pvalueBits = NULL;  
-    IDebugObject* pobject    = NULL;  
-  
-    //get the value as bits  
-    hr = pbinder->Bind( NULL, pfield, &pobject );  
-    if (FAILED(hr))  
-        return hr;  
-  
-    hr = pobject->GetSize( &valueSize );  
-    if (FAILED(hr))  
-    {  
-        pobject->Release();  
-        return hr;  
-    }  
-  
-    pvalueBits = reinterpret_cast<BYTE *>(malloc(valueSize * sizeof(BYTE)));  
-    if (!pvalueBits)  
-    {  
-        pobject->Release();  
-        return E_OUTOFMEMORY;  
-    }  
-  
-    hr = pobject->GetValue( pvalueBits, valueSize );  
-    pobject->Release();  
-    if (FAILED(hr))  
-    {  
-        free(pvalueBits);  
-        return hr;  
-    }  
-  
-    //get the type  
-    VARIANT     valueType;  
-  
-    hr = FieldGetType( pfield, &valueType );  
-    if (FAILED(hr))  
-    {  
-        free(pvalueBits);  
-        return hr;  
-    }  
-  
-    //copy a primitive value  
-    switch (valueType.vt)  
-    {  
-    case VT_BSTR:  
-        {  
-            pvarValue->vt = VT_BSTR;  
-            if (valueSize == 0)  
-                pvarValue->bstrVal = SysAllocString( OLE("") );  
-            else  
-                pvarValue->bstrVal =  
-                    SysAllocStringByteLen( reinterpret_cast<char*>(pvalueBits),  
-                                           valueSize );  
-        }  
-  
-    case VT_BOOL:  
-    case VT_I1:  
-    case VT_I2:  
-    case VT_I4:  
-    case VT_I8:  
-    case VT_UI1:  
-    case VT_UI2:  
-    case VT_UI4:  
-    case VT_UI8:  
-    case VT_R4:  
-    case VT_R8:  
-        pvarValue->vt = valueType.vt;  
-  
-        if (valueSize > 8)  
-            valueSize = 8;  
-        memcpy( &(pvarValue->iVal), pvalueBits, valueSize );  
-        break;  
-  
-    case VT_VOID:  
-    case VT_EMPTY:  
-        pvarValue->vt = valueType.vt;  
-        break;  
-  
-    default:  
-        //not a primitive type  
-        VariantClear(&valueType);  
-        free(pvalueBits);  
-        return E_FAIL;  
-    }  
-  
-    free(pvalueBits);  
-    VariantClear(&valueType);  
-    return S_OK;  
-}  
-```  
-  
-## See also  
- [Sample implementation of locals](../../extensibility/debugger/sample-implementation-of-locals.md)   
- [Get local values](../../extensibility/debugger/getting-local-values.md)   
- [Evaluation context](../../extensibility/debugger/evaluation-context.md)
+> In Visual Studio 2015, this way of implementing expression evaluators is deprecated. For information about implementing CLR expression evaluators, see [CLR expression evaluators](https://github.com/Microsoft/ConcordExtensibilitySamples/wiki/CLR-Expression-Evaluators) and [Managed expression evaluator sample](https://github.com/Microsoft/ConcordExtensibilitySamples/wiki/Managed-Expression-Evaluator-Sample).
+
+[GetPropertyInfo](../../extensibility/debugger/reference/idebugproperty2-getpropertyinfo.md) is called to obtain the value of a local, as well as the local's name and type. Since the value of a local is dependent on the current state of the program, the local's value must be obtained from memory. The [IDebugBinder](../../extensibility/debugger/reference/idebugbinder.md) object is used to bind the [IDebugField](../../extensibility/debugger/reference/idebugfield.md) object representing the local to the appropriate location in memory containing the value. This location in memory is represented by an [IDebugObject](../../extensibility/debugger/reference/idebugobject.md) object.
+
+This functionality of retrieving the value of a local is encapsulated in a helper function that performs the following tasks:
+
+1. Binds the `IDebugField` object to memory to obtain an `IDebugObject` object.
+
+2. Gets the value from memory. This value is represented as a series of bytes.
+
+3. Formats the value based on the local's type.
+
+4. Returns a generic object that contains the local's value. In C#, this is an `object`, and in C++, this is a `VARIANT`.
+
+## Managed code
+ This is an implementation of a function that retrieves the value of a local in managed code.
+
+```csharp
+namespace EEMC
+{
+    internal class Field
+    {
+        internal static object GetValue(
+            IDebugBinder binder,
+            IDebugField field,
+            Type t,
+            uint size)
+        {
+            if (t == null || size == 0)  return null;
+
+            IDebugObject debugObject = null;
+            binder.Bind(null, field, out debugObject);
+
+            byte[] buffer = new byte[size];
+            for (int i = 0; i < size; i++)  buffer[i] = 0;
+
+            debugObject.GetValue(buffer, size);
+
+            if (t == typeof(sbyte)) return (sbyte) buffer[0];
+            if (t == typeof(short)) return BitConverter.ToInt16(buffer, 0);
+            if (t == typeof(int))   return BitConverter.ToInt32(buffer, 0);
+            if (t == typeof(long))  return BitConverter.ToInt64(buffer, 0);
+            if (t == typeof(byte))  return buffer[0];
+            if (t == typeof(char))  return BitConverter.ToChar(buffer, 0);
+            if (t == typeof(uint))  return BitConverter.ToUInt32(buffer, 0);
+            if (t == typeof(ulong)) return BitConverter.ToUInt64(buffer, 0);
+            if (t == typeof(float)) return BitConverter.ToSingle(buffer, 0);
+            if (t == typeof(double))  return BitConverter.ToDouble(buffer, 0);
+            if (t == typeof(bool))  return BitConverter.ToBoolean(buffer, 0);
+            if (t == typeof(string))  return BitConverter.ToString(buffer, 0);
+            return null;
+        }
+    }
+}
+```
+
+## Unmanaged code
+ This is an implementation of a function that retrieves the value of a local in unmanaged code. `FieldGetType` is shown in [Getting Local Values](../../extensibility/debugger/getting-local-values.md).
+
+```cpp
+HRESULT FieldGetPrimitiveValue(
+    in  IDebugBinder* pbinder,
+    in  IDebugField*  pfield,
+    out VARIANT*      pvarValue
+    )
+{
+    if (pvarValue == NULL)
+        return E_INVALIDARG;
+    else
+        *pvarValue = 0;
+
+    if (pfield == NULL)
+        return E_INVALIDARG;
+
+    if (pbinder == NULL)
+        return E_INVALIDARG;
+
+    HRESULT hr;
+    UINT          valueSize = 0;
+    BYTE*         pvalueBits = NULL;
+    IDebugObject* pobject    = NULL;
+
+    //get the value as bits
+    hr = pbinder->Bind( NULL, pfield, &pobject );
+    if (FAILED(hr))
+        return hr;
+
+    hr = pobject->GetSize( &valueSize );
+    if (FAILED(hr))
+    {
+        pobject->Release();
+        return hr;
+    }
+
+    pvalueBits = reinterpret_cast<BYTE *>(malloc(valueSize * sizeof(BYTE)));
+    if (!pvalueBits)
+    {
+        pobject->Release();
+        return E_OUTOFMEMORY;
+    }
+
+    hr = pobject->GetValue( pvalueBits, valueSize );
+    pobject->Release();
+    if (FAILED(hr))
+    {
+        free(pvalueBits);
+        return hr;
+    }
+
+    //get the type
+    VARIANT     valueType;
+
+    hr = FieldGetType( pfield, &valueType );
+    if (FAILED(hr))
+    {
+        free(pvalueBits);
+        return hr;
+    }
+
+    //copy a primitive value
+    switch (valueType.vt)
+    {
+    case VT_BSTR:
+        {
+            pvarValue->vt = VT_BSTR;
+            if (valueSize == 0)
+                pvarValue->bstrVal = SysAllocString( OLE("") );
+            else
+                pvarValue->bstrVal =
+                    SysAllocStringByteLen( reinterpret_cast<char*>(pvalueBits),
+                                           valueSize );
+        }
+
+    case VT_BOOL:
+    case VT_I1:
+    case VT_I2:
+    case VT_I4:
+    case VT_I8:
+    case VT_UI1:
+    case VT_UI2:
+    case VT_UI4:
+    case VT_UI8:
+    case VT_R4:
+    case VT_R8:
+        pvarValue->vt = valueType.vt;
+
+        if (valueSize > 8)
+            valueSize = 8;
+        memcpy( &(pvarValue->iVal), pvalueBits, valueSize );
+        break;
+
+    case VT_VOID:
+    case VT_EMPTY:
+        pvarValue->vt = valueType.vt;
+        break;
+
+    default:
+        //not a primitive type
+        VariantClear(&valueType);
+        free(pvalueBits);
+        return E_FAIL;
+    }
+
+    free(pvalueBits);
+    VariantClear(&valueType);
+    return S_OK;
+}
+```
+
+## See also
+[Sample implementation of locals](../../extensibility/debugger/sample-implementation-of-locals.md)  
+[Get local values](../../extensibility/debugger/getting-local-values.md)  
+[Evaluation context](../../extensibility/debugger/evaluation-context.md)


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.