### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/context-info.md
+++ b/docs/extensibility/debugger/reference/context-info.md
@@ -2,82 +2,82 @@
 title: "CONTEXT_INFO | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-f1_keywords: 
+f1_keywords:
   - "CONTEXT_INFO"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "CONTEXT_INFO structure"
 ms.assetid: 6b513f4e-e7b0-4969-adf0-2205ccc1e09b
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # CONTEXT_INFO
-This structure describes a memory context or code context.  
-  
-## Syntax  
-  
-```cpp  
-typedef struct _tagCONTEXT_INFO {   
-   CONTEXT_INFO_FIELDS dwFields;  
-   BSTR                bstrModuleUrl;  
-   BSTR                bstrFunction;  
-   TEXT_POSITION       posFunctionOffset;  
-   BSTR                bstrAddress;  
-   BSTR                bstrAddressOffset;  
-   BSTR                bstrAddressAbsolute;  
-} CONTEXT_INFO;  
-```  
-  
-```csharp  
-public struct CONTEXT_INFO {  
-   public uint          dwFields;  
-   public string        bstrModuleUrl;  
-   public string        bstrFunction;  
-   public TEXT_POSITION posFunctionOffset;  
-   public string        bstrAddress;  
-   public string        bstrAddressOffset;  
-   public string        bstrAddressAbsolute;  
-};  
-```  
-  
-## Members  
- dwFields  
- A combination of flags from he [CONTEXT_INFO_FIELDS](../../../extensibility/debugger/reference/context-info-fields.md) enumeration that specifies which fields are filled out<strong>.</strong>  
-  
- bstrModuleUrl  
- The name of the module where the context is located.  
-  
- bstrFunction  
- The function name where the context is located.  
-  
- posFunctionOffset  
- A [TEXT_POSITION](../../../extensibility/debugger/reference/text-position.md) structure that identifies the line and column offset of the function associated with the code context.  
-  
- bstrAddress  
- The address in code where the given context is located.  
-  
- bstrAddressOffset  
- The offset of the address in code where the given context is located.  
-  
- bstrAddressAbsolute  
- The absolute address in memory where the given context is located.  
-  
-## Remarks  
- This structure is returned from a call to the [GetInfo](../../../extensibility/debugger/reference/idebugmemorycontext2-getinfo.md) method.  
-  
- A typical use for this structure is in support of a **Memory** debug window.  
-  
-## Requirements  
- Header: msdbg.h  
-  
- Namespace: Microsoft.VisualStudio.Debugger.Interop  
-  
- Assembly: Microsoft.VisualStudio.Debugger.Interop.dll  
-  
-## See Also  
- [Structures and Unions](../../../extensibility/debugger/reference/structures-and-unions.md)   
- [GetInfo](../../../extensibility/debugger/reference/idebugmemorycontext2-getinfo.md)   
- [CONTEXT_INFO_FIELDS](../../../extensibility/debugger/reference/context-info-fields.md)   
- [TEXT_POSITION](../../../extensibility/debugger/reference/text-position.md)
+This structure describes a memory context or code context.
+
+## Syntax
+
+```cpp
+typedef struct _tagCONTEXT_INFO { 
+   CONTEXT_INFO_FIELDS dwFields;
+   BSTR                bstrModuleUrl;
+   BSTR                bstrFunction;
+   TEXT_POSITION       posFunctionOffset;
+   BSTR                bstrAddress;
+   BSTR                bstrAddressOffset;
+   BSTR                bstrAddressAbsolute;
+} CONTEXT_INFO;
+```
+
+```csharp
+public struct CONTEXT_INFO {
+   public uint          dwFields;
+   public string        bstrModuleUrl;
+   public string        bstrFunction;
+   public TEXT_POSITION posFunctionOffset;
+   public string        bstrAddress;
+   public string        bstrAddressOffset;
+   public string        bstrAddressAbsolute;
+};
+```
+
+## Members
+dwFields  
+A combination of flags from he [CONTEXT_INFO_FIELDS](../../../extensibility/debugger/reference/context-info-fields.md) enumeration that specifies which fields are filled out<strong>.</strong>
+
+bstrModuleUrl  
+The name of the module where the context is located.
+
+bstrFunction  
+The function name where the context is located.
+
+posFunctionOffset  
+A [TEXT_POSITION](../../../extensibility/debugger/reference/text-position.md) structure that identifies the line and column offset of the function associated with the code context.
+
+bstrAddress  
+The address in code where the given context is located.
+
+bstrAddressOffset  
+The offset of the address in code where the given context is located.
+
+bstrAddressAbsolute  
+The absolute address in memory where the given context is located.
+
+## Remarks
+This structure is returned from a call to the [GetInfo](../../../extensibility/debugger/reference/idebugmemorycontext2-getinfo.md) method.
+
+A typical use for this structure is in support of a **Memory** debug window.
+
+## Requirements
+Header: msdbg.h
+
+Namespace: Microsoft.VisualStudio.Debugger.Interop
+
+Assembly: Microsoft.VisualStudio.Debugger.Interop.dll
+
+## See Also
+[Structures and Unions](../../../extensibility/debugger/reference/structures-and-unions.md)  
+[GetInfo](../../../extensibility/debugger/reference/idebugmemorycontext2-getinfo.md)  
+[CONTEXT_INFO_FIELDS](../../../extensibility/debugger/reference/context-info-fields.md)  
+[TEXT_POSITION](../../../extensibility/debugger/reference/text-position.md)

--- a/docs/extensibility/debugger/reference/context-info.md
+++ b/docs/extensibility/debugger/reference/context-info.md
@@ -19,26 +19,26 @@ This structure describes a memory context or code context.
 ## Syntax
 
 ```cpp
-typedef struct _tagCONTEXT_INFO { 
-   CONTEXT_INFO_FIELDS dwFields;
-   BSTR                bstrModuleUrl;
-   BSTR                bstrFunction;
-   TEXT_POSITION       posFunctionOffset;
-   BSTR                bstrAddress;
-   BSTR                bstrAddressOffset;
-   BSTR                bstrAddressAbsolute;
+typedef struct _tagCONTEXT_INFO {
+    CONTEXT_INFO_FIELDS dwFields;
+    BSTR                bstrModuleUrl;
+    BSTR                bstrFunction;
+    TEXT_POSITION       posFunctionOffset;
+    BSTR                bstrAddress;
+    BSTR                bstrAddressOffset;
+    BSTR                bstrAddressAbsolute;
 } CONTEXT_INFO;
 ```
 
 ```csharp
 public struct CONTEXT_INFO {
-   public uint          dwFields;
-   public string        bstrModuleUrl;
-   public string        bstrFunction;
-   public TEXT_POSITION posFunctionOffset;
-   public string        bstrAddress;
-   public string        bstrAddressOffset;
-   public string        bstrAddressAbsolute;
+    public uint          dwFields;
+    public string        bstrModuleUrl;
+    public string        bstrFunction;
+    public TEXT_POSITION posFunctionOffset;
+    public string        bstrAddress;
+    public string        bstrAddressOffset;
+    public string        bstrAddressAbsolute;
 };
 ```
 


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.