### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/debug-custom-viewer.md
+++ b/docs/extensibility/debugger/reference/debug-custom-viewer.md
@@ -20,23 +20,23 @@ A structure that identifies a custom viewer or type visualizer.
 
 ```cpp
 typedef struct tagDEBUG_CUSTOM_VIEWER {
-   DWORD dwID;
-   BSTR  bstrMenuName;
-   BSTR  bstrDescription;
-   GUID  guidLang;
-   GUID  guidVendor;
-   BSTR  bstrMetric;
+    DWORD dwID;
+    BSTR  bstrMenuName;
+    BSTR  bstrDescription;
+    GUID  guidLang;
+    GUID  guidVendor;
+    BSTR  bstrMetric;
 } DEBUG_CUSTOM_VIEWER;
 ```
 
 ```csharp
 public struct DEBUG_CUSTOM_VIEWER {
-   public uint   dwID;
-   public string bstrMenuName;
-   public string bstrDescription;
-   public Guid   guidLang;
-   public Guid   guidVendor;
-   public string bstrMetric;
+    public uint   dwID;
+    public string bstrMenuName;
+    public string bstrDescription;
+    public Guid   guidLang;
+    public Guid   guidVendor;
+    public string bstrMetric;
 };
 ```
 

--- a/docs/extensibility/debugger/reference/debug-custom-viewer.md
+++ b/docs/extensibility/debugger/reference/debug-custom-viewer.md
@@ -2,74 +2,74 @@
 title: "DEBUG_CUSTOM_VIEWER | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-f1_keywords: 
+f1_keywords:
   - "DEBUG_CUSTOM_VIEWER"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "DEBUG_CUSTOM_VIEWER structure"
 ms.assetid: 8e0ef3f0-0107-48e8-a037-6e52b4c4ed9d
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # DEBUG_CUSTOM_VIEWER
-A structure that identifies a custom viewer or type visualizer.  
-  
-## Syntax  
-  
-```cpp  
-typedef struct tagDEBUG_CUSTOM_VIEWER {  
-   DWORD dwID;  
-   BSTR  bstrMenuName;  
-   BSTR  bstrDescription;  
-   GUID  guidLang;  
-   GUID  guidVendor;  
-   BSTR  bstrMetric;  
-} DEBUG_CUSTOM_VIEWER;  
-```  
-  
-```csharp  
-public struct DEBUG_CUSTOM_VIEWER {  
-   public uint   dwID;  
-   public string bstrMenuName;  
-   public string bstrDescription;  
-   public Guid   guidLang;  
-   public Guid   guidVendor;  
-   public string bstrMetric;  
-};  
-```  
-  
-## Members  
- dwID  
- An ID to differentiate multiple viewers or visualizers implemented by one `GUID`.  
-  
- bstrMenuName  
- The text that will appear in the drop-down menu.  
-  
- bstrDescription  
- A description of the custom viewer or type visualizer (must be a null value if not used).  
-  
- guidLang  
- Language of the providing expression evaluator.  
-  
- guidVendor  
- Vendor of the providing expression evaluator.  
-  
- bstrMetric  
- Metric under which the custom viewer or type visualizer `CLSID` is stored.  
-  
-## Remarks  
- A list of this structure is returned by a call to the [GetCustomViewerList](../../../extensibility/debugger/reference/idebugproperty3-getcustomviewerlist.md) method (and, by extension, the [GetCustomViewerList](../../../extensibility/debugger/reference/ieevisualizerservice-getcustomviewerlist.md) method).  
-  
-## Requirements  
- Header: msdbg.h  
-  
- Namespace: Microsoft.VisualStudio.Debugger.Interop  
-  
- Assembly: Microsoft.VisualStudio.Debugger.Interop.dll  
-  
-## See Also  
- [Structures and Unions](../../../extensibility/debugger/reference/structures-and-unions.md)   
- [GetCustomViewerList](../../../extensibility/debugger/reference/idebugproperty3-getcustomviewerlist.md)   
- [GetCustomViewerList](../../../extensibility/debugger/reference/ieevisualizerservice-getcustomviewerlist.md)
+A structure that identifies a custom viewer or type visualizer.
+
+## Syntax
+
+```cpp
+typedef struct tagDEBUG_CUSTOM_VIEWER {
+   DWORD dwID;
+   BSTR  bstrMenuName;
+   BSTR  bstrDescription;
+   GUID  guidLang;
+   GUID  guidVendor;
+   BSTR  bstrMetric;
+} DEBUG_CUSTOM_VIEWER;
+```
+
+```csharp
+public struct DEBUG_CUSTOM_VIEWER {
+   public uint   dwID;
+   public string bstrMenuName;
+   public string bstrDescription;
+   public Guid   guidLang;
+   public Guid   guidVendor;
+   public string bstrMetric;
+};
+```
+
+## Members
+dwID  
+An ID to differentiate multiple viewers or visualizers implemented by one `GUID`.
+
+bstrMenuName  
+The text that will appear in the drop-down menu.
+
+bstrDescription  
+A description of the custom viewer or type visualizer (must be a null value if not used).
+
+guidLang  
+Language of the providing expression evaluator.
+
+guidVendor  
+Vendor of the providing expression evaluator.
+
+bstrMetric  
+Metric under which the custom viewer or type visualizer `CLSID` is stored.
+
+## Remarks
+A list of this structure is returned by a call to the [GetCustomViewerList](../../../extensibility/debugger/reference/idebugproperty3-getcustomviewerlist.md) method (and, by extension, the [GetCustomViewerList](../../../extensibility/debugger/reference/ieevisualizerservice-getcustomviewerlist.md) method).
+
+## Requirements
+Header: msdbg.h
+
+Namespace: Microsoft.VisualStudio.Debugger.Interop
+
+Assembly: Microsoft.VisualStudio.Debugger.Interop.dll
+
+## See Also
+[Structures and Unions](../../../extensibility/debugger/reference/structures-and-unions.md)  
+[GetCustomViewerList](../../../extensibility/debugger/reference/idebugproperty3-getcustomviewerlist.md)  
+[GetCustomViewerList](../../../extensibility/debugger/reference/ieevisualizerservice-getcustomviewerlist.md)


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.