### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/displaykind.md
+++ b/docs/extensibility/debugger/reference/displaykind.md
@@ -19,9 +19,9 @@ Enumerates the valid values that represent the kinds of information to take from
 ```cpp
 enum enum_DisplayKind
 {
-   DisplayKind_Value = 0x1,
-   DisplayKind_Name = 0x2,
-   DisplayKind_Type = 0x3,
+    DisplayKind_Value = 0x1,
+    DisplayKind_Name = 0x2,
+    DisplayKind_Type = 0x3,
 };
 typedef DWORD DisplayKind;
 ```
@@ -29,9 +29,9 @@ typedef DWORD DisplayKind;
 ```csharp
 public enum enum_DisplayKind
 {
-   DisplayKind_Value = 0x1,
-   DisplayKind_Name = 0x2,
-   DisplayKind_Type = 0x3,
+    DisplayKind_Value = 0x1,
+    DisplayKind_Name = 0x2,
+    DisplayKind_Type = 0x3,
 };
 ```
 

--- a/docs/extensibility/debugger/reference/displaykind.md
+++ b/docs/extensibility/debugger/reference/displaykind.md
@@ -2,56 +2,56 @@
 title: "DisplayKind | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "DisplayKind enumeration"
 ms.assetid: 940968c5-6065-4bda-8ee6-c31597db4d71
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # DisplayKind
-Enumerates the valid values that represent the kinds of information to take from an [IDebugField](../../../extensibility/debugger/reference/idebugfield.md) object and display to the user.  
-  
-## Syntax  
-  
-```cpp  
-enum enum_DisplayKind  
-{  
-   DisplayKind_Value = 0x1,  
-   DisplayKind_Name = 0x2,  
-   DisplayKind_Type = 0x3,  
-};  
-typedef DWORD DisplayKind;  
-```  
-  
-```csharp  
-public enum enum_DisplayKind  
-{  
-   DisplayKind_Value = 0x1,  
-   DisplayKind_Name = 0x2,  
-   DisplayKind_Type = 0x3,  
-};  
-```  
-  
-#### Parameters  
- DisplayKind_Value  
- Value of the field.  
-  
- DisplayKind_Name  
- Name of the field.  
-  
- DisplayKind_Type  
- Type of field.  
-  
-## Requirements  
- Header: Ee.h  
-  
- Namespace: Microsoft.VisualStudio.Debugger.Interop  
-  
- Assembly: Microsoft.VisualStudio.Debugger.Interop.dll  
-  
-## See Also  
- [Enumerations](../../../extensibility/debugger/reference/enumerations-visual-studio-debugging.md)   
- [GetValueDisplayStringCount](../../../extensibility/debugger/reference/ieevisualizerservice-getvaluedisplaystringcount.md)
+Enumerates the valid values that represent the kinds of information to take from an [IDebugField](../../../extensibility/debugger/reference/idebugfield.md) object and display to the user.
+
+## Syntax
+
+```cpp
+enum enum_DisplayKind
+{
+   DisplayKind_Value = 0x1,
+   DisplayKind_Name = 0x2,
+   DisplayKind_Type = 0x3,
+};
+typedef DWORD DisplayKind;
+```
+
+```csharp
+public enum enum_DisplayKind
+{
+   DisplayKind_Value = 0x1,
+   DisplayKind_Name = 0x2,
+   DisplayKind_Type = 0x3,
+};
+```
+
+#### Parameters
+DisplayKind_Value  
+Value of the field.
+
+DisplayKind_Name  
+Name of the field.
+
+DisplayKind_Type  
+Type of field.
+
+## Requirements
+Header: Ee.h
+
+Namespace: Microsoft.VisualStudio.Debugger.Interop
+
+Assembly: Microsoft.VisualStudio.Debugger.Interop.dll
+
+## See Also
+[Enumerations](../../../extensibility/debugger/reference/enumerations-visual-studio-debugging.md)  
+[GetValueDisplayStringCount](../../../extensibility/debugger/reference/ieevisualizerservice-getvaluedisplaystringcount.md)


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.