### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/encunavailablereason.md
+++ b/docs/extensibility/debugger/reference/encunavailablereason.md
@@ -2,80 +2,79 @@
 title: "EncUnavailableReason | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-f1_keywords: 
+f1_keywords:
   - "EncUnavailableReason"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "EncUnavailableReason enumeration"
 ms.assetid: c10aa4c0-d7e0-4de1-b8ff-7e050985eb12
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # EncUnavailableReason
-`This is for internal use only!` Represents the reasons that **Edit and Continue** is not available.  
-  
-## Syntax  
-  
-```cpp  
-enum tagEncUnavailableReason {  
-   ENCUN_NONE,  
-   ENCUN_INTEROP,  
-   ENCUN_SQLCLR,  
-   ENCUN_MINIDUMP,  
-   ENCUN_EMBEDDED,  
-   ENCUN_ATTACH,  
-   ENCUN_WIN64  
-};  
-typedef enum tagEncUnavailableReason EncUnavailableReason;  
-```  
-  
-```csharp  
-public enum EncUnavailableReason {  
-   ENCUN_NONE,  
-   ENCUN_INTEROP,  
-   ENCUN_SQLCLR,  
-   ENCUN_MINIDUMP,  
-   ENCUN_EMBEDDED,  
-   ENCUN_ATTACH,  
-   ENCUN_WIN64  
-};  
-```  
-  
-#### Parameters  
- ENCUN_NONE  
- No specific reason why Edit and Continue is not available.  
-  
- ENCUN_INTEROP  
- Edit and Continue is not available during an InterOp call.  
-  
- ENCUN_SQLCLR  
- Edit and Continue is not available during an SQL procedure call that uses the Common Language Runtime (CLR).  
-  
- ENCUN_MINIDUMP  
- Edit and Continue is not available while processing a mini-dump.  
-  
- ENCUN_EMBEDDED  
- Edit and Continue is not available when processing embedded code.  
-  
- ENCUN_ATTACH  
- Edit and Continue is not available because the session was attached to, not launched by, the debugger.  
-  
- ENCUN_WIN64  
- Edit and Continue is not available while processing 64-bit Windows code.  
-  
-## Remarks  
- This enumeration is for internal use only by [!INCLUDE[vsprvs](../../../code-quality/includes/vsprvs_md.md)]. The [GetENCAvailableState](../../../extensibility/debugger/reference/idebugprocess3-getencavailablestate.md) and [DisableENC](../../../extensibility/debugger/reference/idebugprocess3-disableenc.md) methods as implemented by a custom port supplier should always return `E_NOTIMPL`.  
-  
-## Requirements  
- Header: msdbg.idl  
-  
- Namespace: Microsoft.VisualStudio.Debugger.Interop  
-  
- Assembly: Microsoft.VisualStudio.Debugger.Interop.dll  
-  
-## See Also  
- [Enumerations](../../../extensibility/debugger/reference/enumerations-visual-studio-debugging.md)   
- [DisableENC](../../../extensibility/debugger/reference/idebugprocess3-disableenc.md)   
- [GetENCAvailableState](../../../extensibility/debugger/reference/idebugprocess3-getencavailablestate.md)
+`This is for internal use only!` Represents the reasons that **Edit and Continue** is not available.
+
+## Syntax
+
+```cpp
+enum tagEncUnavailableReason {
+   ENCUN_NONE,
+   ENCUN_INTEROP,
+   ENCUN_SQLCLR,
+   ENCUN_MINIDUMP,
+   ENCUN_EMBEDDED,
+   ENCUN_ATTACH,
+   ENCUN_WIN64
+};
+typedef enum tagEncUnavailableReason EncUnavailableReason;
+```
+
+```csharp
+public enum EncUnavailableReason {
+   ENCUN_NONE,
+   ENCUN_INTEROP,
+   ENCUN_SQLCLR,
+   ENCUN_MINIDUMP,
+   ENCUN_EMBEDDED,
+   ENCUN_ATTACH,
+   ENCUN_WIN64
+};
+```
+
+#### Parameters
+ENCUN_NONE  
+No specific reason why Edit and Continue is not available.
+
+ENCUN_INTEROP  
+Edit and Continue is not available during an InterOp call.
+
+ENCUN_SQLCLR  
+Edit and Continue is not available during an SQL procedure call that uses the Common Language Runtime (CLR).
+
+ENCUN_MINIDUMP  
+Edit and Continue is not available while processing a mini-dump.
+
+ENCUN_EMBEDDED  
+Edit and Continue is not available when processing embedded code.
+
+ENCUN_ATTACH  
+Edit and Continue is not available because the session was attached to, not launched by, the debugger.
+
+ENCUN_WIN64  
+Edit and Continue is not available while processing 64-bit Windows code.
+
+## Remarks
+This enumeration is for internal use only by [!INCLUDE[vsprvs](../../../code-quality/includes/vsprvs_md.md)]. The [GetENCAvailableState](../../../extensibility/debugger/reference/idebugprocess3-getencavailablestate.md) and [DisableENC](../../../extensibility/debugger/reference/idebugprocess3-disableenc.md) methods as implemented by a custom port supplier should always return `E_NOTIMPL`.
+
+## Requirements
+Header: msdbg.idl
+
+Namespace: Microsoft.VisualStudio.Debugger.Interop
+
+Assembly: Microsoft.VisualStudio.Debugger.Interop.dll
+
+## See Also
+[Enumerations](../../../extensibility/debugger/reference/enumerations-visual-studio-debugging.md)  
+[GetENCAvailableState](../../../extensibility/debugger/reference/idebugprocess3-getencavailablestate.md)

--- a/docs/extensibility/debugger/reference/encunavailablereason.md
+++ b/docs/extensibility/debugger/reference/encunavailablereason.md
@@ -77,5 +77,8 @@ Assembly: Microsoft.VisualStudio.Debugger.Interop.dll
 
 ## See Also
 [Enumerations](../../../extensibility/debugger/reference/enumerations-visual-studio-debugging.md)
+
 [DisableENC](../../../extensibility/debugger/reference/idebugprocess3-disableenc.md)
+
 [GetENCAvailableState](../../../extensibility/debugger/reference/idebugprocess3-getencavailablestate.md)
+

--- a/docs/extensibility/debugger/reference/encunavailablereason.md
+++ b/docs/extensibility/debugger/reference/encunavailablereason.md
@@ -20,26 +20,26 @@ ms.workload:
 
 ```cpp
 enum tagEncUnavailableReason {
-   ENCUN_NONE,
-   ENCUN_INTEROP,
-   ENCUN_SQLCLR,
-   ENCUN_MINIDUMP,
-   ENCUN_EMBEDDED,
-   ENCUN_ATTACH,
-   ENCUN_WIN64
+    ENCUN_NONE,
+    ENCUN_INTEROP,
+    ENCUN_SQLCLR,
+    ENCUN_MINIDUMP,
+    ENCUN_EMBEDDED,
+    ENCUN_ATTACH,
+    ENCUN_WIN64
 };
 typedef enum tagEncUnavailableReason EncUnavailableReason;
 ```
 
 ```csharp
 public enum EncUnavailableReason {
-   ENCUN_NONE,
-   ENCUN_INTEROP,
-   ENCUN_SQLCLR,
-   ENCUN_MINIDUMP,
-   ENCUN_EMBEDDED,
-   ENCUN_ATTACH,
-   ENCUN_WIN64
+    ENCUN_NONE,
+    ENCUN_INTEROP,
+    ENCUN_SQLCLR,
+    ENCUN_MINIDUMP,
+    ENCUN_EMBEDDED,
+    ENCUN_ATTACH,
+    ENCUN_WIN64
 };
 ```
 

--- a/docs/extensibility/debugger/reference/encunavailablereason.md
+++ b/docs/extensibility/debugger/reference/encunavailablereason.md
@@ -76,5 +76,6 @@ Namespace: Microsoft.VisualStudio.Debugger.Interop
 Assembly: Microsoft.VisualStudio.Debugger.Interop.dll
 
 ## See Also
-[Enumerations](../../../extensibility/debugger/reference/enumerations-visual-studio-debugging.md)  
+[Enumerations](../../../extensibility/debugger/reference/enumerations-visual-studio-debugging.md)
+[DisableENC](../../../extensibility/debugger/reference/idebugprocess3-disableenc.md)
 [GetENCAvailableState](../../../extensibility/debugger/reference/idebugprocess3-getencavailablestate.md)


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.