### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/field-kind-ex.md
+++ b/docs/extensibility/debugger/reference/field-kind-ex.md
@@ -19,19 +19,19 @@ Enumerates additional kinds of fields that an [IDebugField](../../../extensibili
 ```cpp
 enum enum_FIELD_KIND_EX
 {
-   FIELD_KIND_EX_NONE = 0,
-   FIELD_TYPE_EX_METHODVAR = 0x1,
-   FIELD_TYPE_EX_CLASSVAR = 0x2
-} ;
+    FIELD_KIND_EX_NONE = 0,
+    FIELD_TYPE_EX_METHODVAR = 0x1,
+    FIELD_TYPE_EX_CLASSVAR = 0x2
+};
 typedef DWORD FIELD_KIND_EX;
 ```
 
 ```csharp
 public enum enum_FIELD_KIND_EX
 {
-   FIELD_KIND_EX_NONE = 0,
-   FIELD_TYPE_EX_METHODVAR = 0x1,
-   FIELD_TYPE_EX_CLASSVAR = 0x2
+    FIELD_KIND_EX_NONE = 0,
+    FIELD_TYPE_EX_METHODVAR = 0x1,
+    FIELD_TYPE_EX_CLASSVAR = 0x2
 };
 ```
 

--- a/docs/extensibility/debugger/reference/field-kind-ex.md
+++ b/docs/extensibility/debugger/reference/field-kind-ex.md
@@ -2,56 +2,56 @@
 title: "FIELD_KIND_EX | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "FIELD_KIND_EX enumeration"
 ms.assetid: 922c3208-1e94-485f-b70a-3bc96affeff8
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # FIELD_KIND_EX
-Enumerates additional kinds of fields that an [IDebugField](../../../extensibility/debugger/reference/idebugfield.md) object can contain. This enumeration extends the [FIELD_KIND](../../../extensibility/debugger/reference/field-kind.md) enumeration.  
-  
-## Syntax  
-  
-```cpp  
-enum enum_FIELD_KIND_EX  
-{  
-   FIELD_KIND_EX_NONE = 0,  
-   FIELD_TYPE_EX_METHODVAR = 0x1,  
-   FIELD_TYPE_EX_CLASSVAR = 0x2  
-} ;  
-typedef DWORD FIELD_KIND_EX;  
-```  
-  
-```csharp  
-public enum enum_FIELD_KIND_EX  
-{  
-   FIELD_KIND_EX_NONE = 0,  
-   FIELD_TYPE_EX_METHODVAR = 0x1,  
-   FIELD_TYPE_EX_CLASSVAR = 0x2  
-};  
-```  
-  
-## Members  
- FIELD_KIND_EX_NONE  
- Field does not contain an extended type.  
-  
- FIELD_TYPE_EX_METHODVAR  
- Field contains a method variable.  
-  
- FIELD_TYPE_EX_CLASSVAR  
- Field contains a class variable.  
-  
-## Requirements  
- Header: Sh.h  
-  
- Namespace: Microsoft.VisualStudio.Debugger.Interop  
-  
- Assembly: Microsoft.VisualStudio.Debugger.Interop.dll  
-  
-## See Also  
- [Enumerations](../../../extensibility/debugger/reference/enumerations-visual-studio-debugging.md)   
- [GetExtendedKind](../../../extensibility/debugger/reference/idebugextendedfield-getextendedkind.md)
+Enumerates additional kinds of fields that an [IDebugField](../../../extensibility/debugger/reference/idebugfield.md) object can contain. This enumeration extends the [FIELD_KIND](../../../extensibility/debugger/reference/field-kind.md) enumeration.
+
+## Syntax
+
+```cpp
+enum enum_FIELD_KIND_EX
+{
+   FIELD_KIND_EX_NONE = 0,
+   FIELD_TYPE_EX_METHODVAR = 0x1,
+   FIELD_TYPE_EX_CLASSVAR = 0x2
+} ;
+typedef DWORD FIELD_KIND_EX;
+```
+
+```csharp
+public enum enum_FIELD_KIND_EX
+{
+   FIELD_KIND_EX_NONE = 0,
+   FIELD_TYPE_EX_METHODVAR = 0x1,
+   FIELD_TYPE_EX_CLASSVAR = 0x2
+};
+```
+
+## Members
+FIELD_KIND_EX_NONE  
+Field does not contain an extended type.
+
+FIELD_TYPE_EX_METHODVAR  
+Field contains a method variable.
+
+FIELD_TYPE_EX_CLASSVAR  
+Field contains a class variable.
+
+## Requirements
+Header: Sh.h
+
+Namespace: Microsoft.VisualStudio.Debugger.Interop
+
+Assembly: Microsoft.VisualStudio.Debugger.Interop.dll
+
+## See Also
+[Enumerations](../../../extensibility/debugger/reference/enumerations-visual-studio-debugging.md)  
+[GetExtendedKind](../../../extensibility/debugger/reference/idebugextendedfield-getextendedkind.md)


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.