### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/guid-array.md
+++ b/docs/extensibility/debugger/reference/guid-array.md
@@ -19,16 +19,16 @@ Describes an array of unique identifiers for available debug engines.
 ```cpp
 typedef struct tagGUID_ARRAY
 {
-   DWORD dwCount;
-   GUID *Members;
+    DWORD dwCount;
+    GUID *Members;
 } GUID_ARRAY;
 ```
 
 ```csharp
 public struct GUID_ARRAY
 {
-   public uint dwCount;
-   public Guid Members;
+    public uint dwCount;
+    public Guid Members;
 }
 ```
 

--- a/docs/extensibility/debugger/reference/guid-array.md
+++ b/docs/extensibility/debugger/reference/guid-array.md
@@ -2,53 +2,53 @@
 title: "GUID_ARRAY | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "GUID_ARRAY structure"
 ms.assetid: 9e12500c-2c1c-49b1-a0ba-e08366c97eb8
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # GUID_ARRAY
-Describes an array of unique identifiers for available debug engines.  
-  
-## Syntax  
-  
-```cpp  
-typedef struct tagGUID_ARRAY  
-{  
-   DWORD dwCount;  
-   GUID *Members;  
-} GUID_ARRAY;  
-```  
-  
-```csharp  
-public struct GUID_ARRAY  
-{  
-   public uint dwCount;  
-   public Guid Members;  
-}  
-```  
-  
-## Terms  
- dwCount  
- Number of unique identifiers in the array.  
-  
- Members  
- Array that contains unique identifiers.  
-  
-## Remarks  
- This structure is returned by the [GetEngineFilter](../../../extensibility/debugger/reference/idebugprocess3-getenginefilter.md) method.  
-  
-## Requirements  
- Header: Msdbg.h  
-  
- Namespace: Microsoft.VisualStudio.Debugger.Interop  
-  
- Assembly: Microsoft.VisualStudio.Debugger.Interop.dll  
-  
-## See Also  
- [Structures and Unions](../../../extensibility/debugger/reference/structures-and-unions.md)   
- [GetEngineFilter](../../../extensibility/debugger/reference/idebugprocess3-getenginefilter.md)
+Describes an array of unique identifiers for available debug engines.
+
+## Syntax
+
+```cpp
+typedef struct tagGUID_ARRAY
+{
+   DWORD dwCount;
+   GUID *Members;
+} GUID_ARRAY;
+```
+
+```csharp
+public struct GUID_ARRAY
+{
+   public uint dwCount;
+   public Guid Members;
+}
+```
+
+## Terms
+dwCount  
+Number of unique identifiers in the array.
+
+Members  
+Array that contains unique identifiers.
+
+## Remarks
+This structure is returned by the [GetEngineFilter](../../../extensibility/debugger/reference/idebugprocess3-getenginefilter.md) method.
+
+## Requirements
+Header: Msdbg.h
+
+Namespace: Microsoft.VisualStudio.Debugger.Interop
+
+Assembly: Microsoft.VisualStudio.Debugger.Interop.dll
+
+## See Also
+[Structures and Unions](../../../extensibility/debugger/reference/structures-and-unions.md)  
+[GetEngineFilter](../../../extensibility/debugger/reference/idebugprocess3-getenginefilter.md)


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.