### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/idebugbeforesymbolsearchevent2-getmodulename.md
+++ b/docs/extensibility/debugger/reference/idebugbeforesymbolsearchevent2-getmodulename.md
@@ -19,18 +19,18 @@ Retrieves the name of the module currently being debugged.
 
 ```cpp
 HRESULT GetModuleName(
-   BSTR *pbstrModuleName
+    BSTR *pbstrModuleName
 );
 ```
 
 ```csharp
 public int GetModuleName (
-   string pbstrModuleName
+    string pbstrModuleName
 );
 ```
 
 #### Parameters
-`pbstrModuleName` 
+`pbstrModuleName`  
 [out] Name of the module.
 
 ## Return Value

--- a/docs/extensibility/debugger/reference/idebugbeforesymbolsearchevent2-getmodulename.md
+++ b/docs/extensibility/debugger/reference/idebugbeforesymbolsearchevent2-getmodulename.md
@@ -2,62 +2,62 @@
 title: "IDebugBeforeSymbolSearchEvent2::GetModuleName | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "GetModuleName"
   - "IDebugBeforeSymbolSearchEvent2::GetModuleName"
 ms.assetid: 0b4abeac-2eaf-4b2e-a2d5-c9ec303bc869
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # IDebugBeforeSymbolSearchEvent2::GetModuleName
-Retrieves the name of the module currently being debugged.  
-  
-## Syntax  
-  
-```cpp  
-HRESULT GetModuleName(   
-   BSTR *pbstrModuleName  
-);  
-```  
-  
-```csharp  
-public int GetModuleName (  
-   string pbstrModuleName  
-);  
-```  
-  
-#### Parameters  
- `pbstrModuleName`  
- [out] Name of the module.  
-  
-## Return Value  
- If successful, returns `S_OK`; otherwise, returns an error code.  
-  
-## Example  
- The following example shows how to implement this method for a **CDebugBeforeSymbolSearchEventBase** object that exposes the [IDebugBeforeSymbolSearchEvent2](../../../extensibility/debugger/reference/idebugbeforesymbolsearchevent2.md) interface.  
-  
-```cpp  
-STDMETHODIMP CDebugBeforeSymbolSearchEventBase::GetModuleName(BSTR *pbstrModuleName)  
-{  
-    HRESULT hRes = E_FAIL;  
-  
-    if (m_bstrModuleName)  
-    {  
-  
-        *pbstrModuleName = SysAllocString( m_bstrModuleName);  
-  
-        if (*pbstrModuleName)  
-        {  
-            hRes = S_OK;  
-        }  
-    }  
-  
-    return ( hRes );  
-}  
-```  
-  
-## See Also  
- [IDebugBeforeSymbolSearchEvent2](../../../extensibility/debugger/reference/idebugbeforesymbolsearchevent2.md)
+Retrieves the name of the module currently being debugged.
+
+## Syntax
+
+```cpp
+HRESULT GetModuleName(
+   BSTR *pbstrModuleName
+);
+```
+
+```csharp
+public int GetModuleName (
+   string pbstrModuleName
+);
+```
+
+#### Parameters
+`pbstrModuleName` 
+[out] Name of the module.
+
+## Return Value
+If successful, returns `S_OK`; otherwise, returns an error code.
+
+## Example
+The following example shows how to implement this method for a **CDebugBeforeSymbolSearchEventBase** object that exposes the [IDebugBeforeSymbolSearchEvent2](../../../extensibility/debugger/reference/idebugbeforesymbolsearchevent2.md) interface.
+
+```cpp
+STDMETHODIMP CDebugBeforeSymbolSearchEventBase::GetModuleName(BSTR *pbstrModuleName)
+{
+    HRESULT hRes = E_FAIL;
+
+    if (m_bstrModuleName)
+    {
+
+        *pbstrModuleName = SysAllocString( m_bstrModuleName);
+
+        if (*pbstrModuleName)
+        {
+            hRes = S_OK;
+        }
+    }
+
+    return ( hRes );
+}
+```
+
+## See Also
+[IDebugBeforeSymbolSearchEvent2](../../../extensibility/debugger/reference/idebugbeforesymbolsearchevent2.md)


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.