### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/idebugboundbreakpoint2-delete.md
+++ b/docs/extensibility/debugger/reference/idebugboundbreakpoint2-delete.md
@@ -21,7 +21,7 @@ Deletes the breakpoint.
 
 ```cpp
 HRESULT Delete( 
-   void 
+    void 
 );
 ```
 
@@ -38,27 +38,27 @@ The following example shows how to implement this method for a simple `CBoundBre
 ```
 HRESULT CBoundBreakpoint::Delete(void)
 {
-   HRESULT hr;
+    HRESULT hr;
 
-   // Verify that the bound breakpoint has not been
-   // deleted. If deleted, then return hr = E_BP_DELETED.
-   if (m_state != BPS_DELETED)
-   {
-      m_pInterp->RemoveBreakpoint(m_sbstrDoc, this);
+    // Verify that the bound breakpoint has not been
+    // deleted. If deleted, then return hr = E_BP_DELETED.
+    if (m_state != BPS_DELETED)
+    {
+        m_pInterp->RemoveBreakpoint(m_sbstrDoc, this);
 
-      // Change the state of the breakpoint to BPS_DELETED.
-      m_state = BPS_DELETED;
-      hr = S_OK;
-   }
-   else
-   {
-      hr = E_BP_DELETED;
-   }
+        // Change the state of the breakpoint to BPS_DELETED.
+        m_state = BPS_DELETED;
+        hr = S_OK;
+    }
+    else
+    {
+        hr = E_BP_DELETED;
+    }
 
-   return hr;
+    return hr;
 }
 ```
 
 ## See Also
-[IDebugBoundBreakpoint2](../../../extensibility/debugger/reference/idebugboundbreakpoint2.md)
+[IDebugBoundBreakpoint2](../../../extensibility/debugger/reference/idebugboundbreakpoint2.md)  
 [BP_STATE](../../../extensibility/debugger/reference/bp-state.md)

--- a/docs/extensibility/debugger/reference/idebugboundbreakpoint2-delete.md
+++ b/docs/extensibility/debugger/reference/idebugboundbreakpoint2-delete.md
@@ -2,63 +2,63 @@
 title: "IDebugBoundBreakpoint2::Delete | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-f1_keywords: 
+f1_keywords:
   - "IDebugBoundBreakpoint2::Delete"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "Delete method"
   - "IDebugBoundBreakpoint2::Delete method"
 ms.assetid: 7088dc66-f24a-446f-a52a-397d02457a41
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # IDebugBoundBreakpoint2::Delete
-Deletes the breakpoint.  
-  
-## Syntax  
-  
-```cpp  
-HRESULT Delete(   
-   void   
-);  
-```  
-  
-```csharp  
-int Delete();  
-```  
-  
-## Return Value  
- If successful, returns `S_OK`; otherwise, returns an error code. Returns `E_BP_DELETED` if the state of the bound breakpoint object is set to `BPS_DELETED` (part of the [BP_STATE](../../../extensibility/debugger/reference/bp-state.md) enumeration).  
-  
-## Example  
- The following example shows how to implement this method for a simple `CBoundBreakpoint` object that exposes the [IDebugBoundBreakpoint2](../../../extensibility/debugger/reference/idebugboundbreakpoint2.md) interface.  
-  
-```  
-HRESULT CBoundBreakpoint::Delete(void)    
-{    
-   HRESULT hr;    
-  
-   // Verify that the bound breakpoint has not been   
-   // deleted. If deleted, then return hr = E_BP_DELETED.    
-   if (m_state != BPS_DELETED)    
-   {    
-      m_pInterp->RemoveBreakpoint(m_sbstrDoc, this);    
-  
-      // Change the state of the breakpoint to BPS_DELETED.    
-      m_state = BPS_DELETED;    
-      hr = S_OK;    
-   }    
-   else    
-   {    
-      hr = E_BP_DELETED;    
-   }    
-  
-   return hr;    
-}     
-```  
-  
-## See Also  
- [IDebugBoundBreakpoint2](../../../extensibility/debugger/reference/idebugboundbreakpoint2.md)   
- [BP_STATE](../../../extensibility/debugger/reference/bp-state.md)
+Deletes the breakpoint.
+
+## Syntax
+
+```cpp
+HRESULT Delete( 
+   void 
+);
+```
+
+```csharp
+int Delete();
+```
+
+## Return Value
+If successful, returns `S_OK`; otherwise, returns an error code. Returns `E_BP_DELETED` if the state of the bound breakpoint object is set to `BPS_DELETED` (part of the [BP_STATE](../../../extensibility/debugger/reference/bp-state.md) enumeration).
+
+## Example
+The following example shows how to implement this method for a simple `CBoundBreakpoint` object that exposes the [IDebugBoundBreakpoint2](../../../extensibility/debugger/reference/idebugboundbreakpoint2.md) interface.
+
+```
+HRESULT CBoundBreakpoint::Delete(void)
+{
+   HRESULT hr;
+
+   // Verify that the bound breakpoint has not been
+   // deleted. If deleted, then return hr = E_BP_DELETED.
+   if (m_state != BPS_DELETED)
+   {
+      m_pInterp->RemoveBreakpoint(m_sbstrDoc, this);
+
+      // Change the state of the breakpoint to BPS_DELETED.
+      m_state = BPS_DELETED;
+      hr = S_OK;
+   }
+   else
+   {
+      hr = E_BP_DELETED;
+   }
+
+   return hr;
+}
+```
+
+## See Also
+[IDebugBoundBreakpoint2](../../../extensibility/debugger/reference/idebugboundbreakpoint2.md)
+[BP_STATE](../../../extensibility/debugger/reference/bp-state.md)


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.