### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/idebugboundbreakpoint2-enable.md
+++ b/docs/extensibility/debugger/reference/idebugboundbreakpoint2-enable.md
@@ -20,14 +20,14 @@ Enables or disables the breakpoint.
 ## Syntax
 
 ```cpp
-HRESULT Enable( 
-   BOOL fEnable
+HRESULT Enable(
+    BOOL fEnable
 );
 ```
 
 ```csharp
 int Enable( 
-   int fEnable
+    int fEnable
 );
 ```
 
@@ -44,47 +44,47 @@ The following example shows how to implement this method for a simple `CBoundBre
 ```
 HRESULT CBoundBreakpoint::Enable(BOOL fEnable)
 {
-   HRESULT hr;
+    HRESULT hr;
 
-   // Verify that the bound breakpoint has not been deleted. If deleted,
-   // then return hr = E_BP_DELETED.
-   if (m_state != BPS_DELETED)
-   {
-      // Check the state of the bound breakpoint. If the breakpoint is
-      // supposed to be, but has not already been, enabled, then have the
-      // interpreter set the breakpoint.
-      if (fEnable && m_state != BPS_ENABLED)
-      {
-         hr = m_pInterp->SetBreakpoint(m_sbstrDoc, this);
-         if (hr == S_OK)
-         {
-            // Change the state of the breakpoint to BPS_ENABLED.
-            m_state = BPS_ENABLED;
-         }
-      }
-      // Check the state of the bound breakpoint. If the breakpoint is
-      // supposed to be, but has not already been, disabled, then have the
-      // interpreter remove the breakpoint.
-      else if (!fEnable && m_state != BPS_DISABLED)
-      {
-         hr = m_pInterp->RemoveBreakpoint(m_sbstrDoc, this);
-         if (hr == S_OK)
-         {
-            // Change the state of the breakpoint to BPS_DISABLED.
-            m_state = BPS_DISABLED;
-         }
-      }
-      else
-      {
-         hr = S_FALSE;
-      }
-   }
-   else
-   {
-      hr = E_BP_DELETED;
-   }
+    // Verify that the bound breakpoint has not been deleted. If deleted,
+    // then return hr = E_BP_DELETED.
+    if (m_state != BPS_DELETED)
+    {
+        // Check the state of the bound breakpoint. If the breakpoint is
+        // supposed to be, but has not already been, enabled, then have the
+        // interpreter set the breakpoint.
+        if (fEnable && m_state != BPS_ENABLED)
+        {
+            hr = m_pInterp->SetBreakpoint(m_sbstrDoc, this);
+            if (hr == S_OK)
+            {
+                // Change the state of the breakpoint to BPS_ENABLED.
+                m_state = BPS_ENABLED;
+            }
+        }
+        // Check the state of the bound breakpoint. If the breakpoint is
+        // supposed to be, but has not already been, disabled, then have the
+        // interpreter remove the breakpoint.
+        else if (!fEnable && m_state != BPS_DISABLED)
+        {
+            hr = m_pInterp->RemoveBreakpoint(m_sbstrDoc, this);
+            if (hr == S_OK)
+            {
+                // Change the state of the breakpoint to BPS_DISABLED.
+                m_state = BPS_DISABLED;
+            }
+        }
+        else
+        {
+            hr = S_FALSE;
+        }
+    }
+    else
+    {
+        hr = E_BP_DELETED;
+    }
 
-   return hr;
+    return hr;
 }
 ```
 

--- a/docs/extensibility/debugger/reference/idebugboundbreakpoint2-enable.md
+++ b/docs/extensibility/debugger/reference/idebugboundbreakpoint2-enable.md
@@ -2,92 +2,92 @@
 title: "IDebugBoundBreakpoint2::Enable | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-f1_keywords: 
+f1_keywords:
   - "IDebugBoundBreakpoint2::Enable"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "Enable method"
   - "IDebugBoundBreakpoint2::Enable method"
 ms.assetid: 1b4e3f73-c94d-4aa3-9aa8-0d8cb8a6c5ca
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # IDebugBoundBreakpoint2::Enable
-Enables or disables the breakpoint.  
-  
-## Syntax  
-  
-```cpp  
-HRESULT Enable(   
-   BOOL fEnable  
-);  
-```  
-  
-```csharp  
-int Enable(   
-   int fEnable  
-);  
-```  
-  
-#### Parameters  
- `fEnable`  
- [in] Set to non-zero (`TRUE`) to enable or to zero (`FALSE`) to disable the breakpoint.  
-  
-## Return Value  
- If successful, returns `S_OK`; otherwise, returns an error code. Returns `E_BP_DELETED` if the state of the bound breakpoint object is set to `BPS_DELETED` (part of the [BP_STATE](../../../extensibility/debugger/reference/bp-state.md) enumeration).  
-  
-## Example  
- The following example shows how to implement this method for a simple `CBoundBreakpoint` object that exposes the [IDebugBoundBreakpoint2](../../../extensibility/debugger/reference/idebugboundbreakpoint2.md) interface.  
-  
-```  
-HRESULT CBoundBreakpoint::Enable(BOOL fEnable)    
-{    
-   HRESULT hr;    
-  
-   // Verify that the bound breakpoint has not been deleted. If deleted,   
-   // then return hr = E_BP_DELETED.    
-   if (m_state != BPS_DELETED)    
-   {    
-      // Check the state of the bound breakpoint. If the breakpoint is  
-      // supposed to be, but has not already been, enabled, then have the  
-      // interpreter set the breakpoint.    
-      if (fEnable && m_state != BPS_ENABLED)    
-      {    
-         hr = m_pInterp->SetBreakpoint(m_sbstrDoc, this);    
-         if (hr == S_OK)    
-         {    
-            // Change the state of the breakpoint to BPS_ENABLED.    
-            m_state = BPS_ENABLED;    
-         }    
-      }    
-      // Check the state of the bound breakpoint. If the breakpoint is   
-      // supposed to be, but has not already been, disabled, then have the   
-      // interpreter remove the breakpoint.    
-      else if (!fEnable && m_state != BPS_DISABLED)    
-      {    
-         hr = m_pInterp->RemoveBreakpoint(m_sbstrDoc, this);    
-         if (hr == S_OK)    
-         {    
-            // Change the state of the breakpoint to BPS_DISABLED.    
-            m_state = BPS_DISABLED;    
-         }    
-      }    
-      else    
-      {    
-         hr = S_FALSE;    
-      }    
-   }    
-   else    
-   {    
-      hr = E_BP_DELETED;    
-   }    
-  
-   return hr;    
-}    
-```  
-  
-## See Also  
- [IDebugBoundBreakpoint2](../../../extensibility/debugger/reference/idebugboundbreakpoint2.md)   
- [BP_STATE](../../../extensibility/debugger/reference/bp-state.md)
+Enables or disables the breakpoint.
+
+## Syntax
+
+```cpp
+HRESULT Enable( 
+   BOOL fEnable
+);
+```
+
+```csharp
+int Enable( 
+   int fEnable
+);
+```
+
+#### Parameters
+`fEnable`  
+[in] Set to non-zero (`TRUE`) to enable or to zero (`FALSE`) to disable the breakpoint.
+
+## Return Value
+If successful, returns `S_OK`; otherwise, returns an error code. Returns `E_BP_DELETED` if the state of the bound breakpoint object is set to `BPS_DELETED` (part of the [BP_STATE](../../../extensibility/debugger/reference/bp-state.md) enumeration).
+
+## Example
+The following example shows how to implement this method for a simple `CBoundBreakpoint` object that exposes the [IDebugBoundBreakpoint2](../../../extensibility/debugger/reference/idebugboundbreakpoint2.md) interface.
+
+```
+HRESULT CBoundBreakpoint::Enable(BOOL fEnable)
+{
+   HRESULT hr;
+
+   // Verify that the bound breakpoint has not been deleted. If deleted,
+   // then return hr = E_BP_DELETED.
+   if (m_state != BPS_DELETED)
+   {
+      // Check the state of the bound breakpoint. If the breakpoint is
+      // supposed to be, but has not already been, enabled, then have the
+      // interpreter set the breakpoint.
+      if (fEnable && m_state != BPS_ENABLED)
+      {
+         hr = m_pInterp->SetBreakpoint(m_sbstrDoc, this);
+         if (hr == S_OK)
+         {
+            // Change the state of the breakpoint to BPS_ENABLED.
+            m_state = BPS_ENABLED;
+         }
+      }
+      // Check the state of the bound breakpoint. If the breakpoint is
+      // supposed to be, but has not already been, disabled, then have the
+      // interpreter remove the breakpoint.
+      else if (!fEnable && m_state != BPS_DISABLED)
+      {
+         hr = m_pInterp->RemoveBreakpoint(m_sbstrDoc, this);
+         if (hr == S_OK)
+         {
+            // Change the state of the breakpoint to BPS_DISABLED.
+            m_state = BPS_DISABLED;
+         }
+      }
+      else
+      {
+         hr = S_FALSE;
+      }
+   }
+   else
+   {
+      hr = E_BP_DELETED;
+   }
+
+   return hr;
+}
+```
+
+## See Also
+[IDebugBoundBreakpoint2](../../../extensibility/debugger/reference/idebugboundbreakpoint2.md)  
+[BP_STATE](../../../extensibility/debugger/reference/bp-state.md)


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.