### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/idebugboundbreakpoint2-getbreakpointresolution.md
+++ b/docs/extensibility/debugger/reference/idebugboundbreakpoint2-getbreakpointresolution.md
@@ -21,13 +21,13 @@ Gets the breakpoint resolution that describes this breakpoint.
 
 ```cpp
 HRESULT GetBreakpointResolution( 
-   IDebugBreakpointResolution2** ppBPResolution
+    IDebugBreakpointResolution2** ppBPResolution
 );
 ```
 
 ```csharp
 int GetBreakpointResolution( 
-   out IDebugBreakpointResolution2 ppBPResolution
+    out IDebugBreakpointResolution2 ppBPResolution
 );
 ```
 
@@ -52,30 +52,30 @@ The following example shows how to implement this method for a simple `CBoundBre
 HRESULT CBoundBreakpoint::GetBreakpointResolution(
     IDebugBreakpointResolution2** ppBPResolution)
 {
-   HRESULT hr;
+    HRESULT hr;
 
-   if (ppBPResolution)
-   {
-      // Verify that the bound breakpoint has not been deleted. If
-      // deleted, then return hr = E_BP_DELETED.
-      if (m_state != BPS_DELETED)
-      {
-         // Query for the IDebugBreakpointResolution2 interface.
-         hr = m_pBPRes->QueryInterface(IID_IDebugBreakpointResolution2,
-                                       (void **)ppBPResolution);
-         assert(hr == S_OK);
-      }
-      else
-      {
-         hr = E_BP_DELETED;
-      }
-   }
-   else
-   {
-      hr = E_INVALIDARG;
-   }
+    if (ppBPResolution)
+    {
+        // Verify that the bound breakpoint has not been deleted. If
+        // deleted, then return hr = E_BP_DELETED.
+        if (m_state != BPS_DELETED)
+        {
+            // Query for the IDebugBreakpointResolution2 interface.
+            hr = m_pBPRes->QueryInterface(IID_IDebugBreakpointResolution2,
+                                          (void **)ppBPResolution);
+            assert(hr == S_OK);
+        }
+        else
+        {
+            hr = E_BP_DELETED;
+        }
+    }
+    else
+    {
+        hr = E_INVALIDARG;
+    }
 
-   return hr;
+    return hr;
 }
 ```
 

--- a/docs/extensibility/debugger/reference/idebugboundbreakpoint2-getbreakpointresolution.md
+++ b/docs/extensibility/debugger/reference/idebugboundbreakpoint2-getbreakpointresolution.md
@@ -2,84 +2,84 @@
 title: "IDebugBoundBreakpoint2::GetBreakpointResolution | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-f1_keywords: 
+f1_keywords:
   - "IDebugBoundBreakpoint2::GetBreakpointResolution"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "GetBreakpointResolution method"
   - "IDebugBoundBreakpoint2::GetBreakpointResolution method"
 ms.assetid: 4479ac61-18a9-4a30-b213-9921c5af9a26
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # IDebugBoundBreakpoint2::GetBreakpointResolution
-Gets the breakpoint resolution that describes this breakpoint.  
-  
-## Syntax  
-  
-```cpp  
-HRESULT GetBreakpointResolution(   
-   IDebugBreakpointResolution2** ppBPResolution  
-);  
-```  
-  
-```csharp  
-int GetBreakpointResolution(   
-   out IDebugBreakpointResolution2 ppBPResolution  
-);  
-```  
-  
-#### Parameters  
- `ppBPResolution`  
- [out] Returns the [IDebugBreakpointResolution2](../../../extensibility/debugger/reference/idebugbreakpointresolution2.md) interface that represents one of the following:  
-  
--   The breakpoint resolution object that describes the location in code where a code breakpoint has been bound.  
-  
--   The data location where a data breakpoint has bound.  
-  
-## Return Value  
- If successful, returns `S_OK`; otherwise, returns an error code. Returns `E_BP_DELETED` if the state of the bound breakpoint object is set to `BPS_DELETED` (part of the [BP_STATE](../../../extensibility/debugger/reference/bp-state.md) enumeration).  
-  
-## Remarks  
- Call the [GetBreakpointType](../../../extensibility/debugger/reference/idebugbreakpointresolution2-getbreakpointtype.md) method to determine if the breakpoint resolution is for code or data.  
-  
-## Example  
- The following example shows how to implement this method for a simple `CBoundBreakpoint` object that exposes the [IDebugBoundBreakpoint2](../../../extensibility/debugger/reference/idebugboundbreakpoint2.md) interface.  
-  
-```  
-HRESULT CBoundBreakpoint::GetBreakpointResolution(  
-    IDebugBreakpointResolution2** ppBPResolution)  
-{    
-   HRESULT hr;    
-  
-   if (ppBPResolution)    
-   {    
-      // Verify that the bound breakpoint has not been deleted. If   
-      // deleted, then return hr = E_BP_DELETED.    
-      if (m_state != BPS_DELETED)    
-      {    
-         // Query for the IDebugBreakpointResolution2 interface.    
-         hr = m_pBPRes->QueryInterface(IID_IDebugBreakpointResolution2,  
-                                       (void **)ppBPResolution);  
-         assert(hr == S_OK);    
-      }    
-      else    
-      {    
-         hr = E_BP_DELETED;    
-      }    
-   }    
-   else    
-   {    
-      hr = E_INVALIDARG;    
-   }    
-  
-   return hr;    
-}    
-```  
-  
-## See Also  
- [IDebugBoundBreakpoint2](../../../extensibility/debugger/reference/idebugboundbreakpoint2.md)   
- [IDebugBreakpointResolution2](../../../extensibility/debugger/reference/idebugbreakpointresolution2.md)   
- [GetBreakpointType](../../../extensibility/debugger/reference/idebugbreakpointresolution2-getbreakpointtype.md)
+Gets the breakpoint resolution that describes this breakpoint.
+
+## Syntax
+
+```cpp
+HRESULT GetBreakpointResolution( 
+   IDebugBreakpointResolution2** ppBPResolution
+);
+```
+
+```csharp
+int GetBreakpointResolution( 
+   out IDebugBreakpointResolution2 ppBPResolution
+);
+```
+
+#### Parameters
+`ppBPResolution`  
+[out] Returns the [IDebugBreakpointResolution2](../../../extensibility/debugger/reference/idebugbreakpointresolution2.md) interface that represents one of the following:
+
+- The breakpoint resolution object that describes the location in code where a code breakpoint has been bound.
+
+- The data location where a data breakpoint has bound.
+
+## Return Value
+If successful, returns `S_OK`; otherwise, returns an error code. Returns `E_BP_DELETED` if the state of the bound breakpoint object is set to `BPS_DELETED` (part of the [BP_STATE](../../../extensibility/debugger/reference/bp-state.md) enumeration).
+
+## Remarks
+Call the [GetBreakpointType](../../../extensibility/debugger/reference/idebugbreakpointresolution2-getbreakpointtype.md) method to determine if the breakpoint resolution is for code or data.
+
+## Example
+The following example shows how to implement this method for a simple `CBoundBreakpoint` object that exposes the [IDebugBoundBreakpoint2](../../../extensibility/debugger/reference/idebugboundbreakpoint2.md) interface.
+
+```
+HRESULT CBoundBreakpoint::GetBreakpointResolution(
+    IDebugBreakpointResolution2** ppBPResolution)
+{
+   HRESULT hr;
+
+   if (ppBPResolution)
+   {
+      // Verify that the bound breakpoint has not been deleted. If
+      // deleted, then return hr = E_BP_DELETED.
+      if (m_state != BPS_DELETED)
+      {
+         // Query for the IDebugBreakpointResolution2 interface.
+         hr = m_pBPRes->QueryInterface(IID_IDebugBreakpointResolution2,
+                                       (void **)ppBPResolution);
+         assert(hr == S_OK);
+      }
+      else
+      {
+         hr = E_BP_DELETED;
+      }
+   }
+   else
+   {
+      hr = E_INVALIDARG;
+   }
+
+   return hr;
+}
+```
+
+## See Also
+[IDebugBoundBreakpoint2](../../../extensibility/debugger/reference/idebugboundbreakpoint2.md)  
+[IDebugBreakpointResolution2](../../../extensibility/debugger/reference/idebugbreakpointresolution2.md)  
+[GetBreakpointType](../../../extensibility/debugger/reference/idebugbreakpointresolution2-getbreakpointtype.md)


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.