### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/idebugboundbreakpoint2-getpendingbreakpoint.md
+++ b/docs/extensibility/debugger/reference/idebugboundbreakpoint2-getpendingbreakpoint.md
@@ -21,13 +21,13 @@ Gets the pending breakpoint from which the specified bound breakpoint was create
 
 ```cpp
 HRESULT GetPendingBreakpoint( 
-   IDebugPendingBreakpoint2** ppPendingBreakpoint
+    IDebugPendingBreakpoint2** ppPendingBreakpoint
 );
 ```
 
 ```csharp
 int GetPendingBreakpoint( 
-   out IDebugPendingBreakpoint2 ppPendingBreakpoint
+    out IDebugPendingBreakpoint2 ppPendingBreakpoint
 );
 ```
 
@@ -48,30 +48,30 @@ The following example shows how to implement this method for a simple `CBoundBre
 HRESULT CBoundBreakpoint::GetPendingBreakpoint(
     IDebugPendingBreakpoint2** ppPendingBreakpoint)
 {
-   HRESULT hr;
+    HRESULT hr;
 
-   // Check for valid IDebugPendingBreakpoint2 interface pointer.
-   if (ppPendingBreakpoint)
-   {
-      // Be sure that the bound breakpoint has not been deleted. If
-      // deleted, then return hr = E_BP_DELETED.
-      if (m_state != BPS_DELETED)
-      {
-         // Query for the IDebugPendingBreakpoint2 interface.
-         hr = m_pPendingBP->QueryInterface(IID_IDebugPendingBreakpoint2,
-                                           (void**)ppPendingBreakpoint);
-      }
-      else
-      {
-         hr = E_BP_DELETED;
-      }
-   }
-   else
-   {
-      hr = E_INVALIDARG;
-   }
+    // Check for valid IDebugPendingBreakpoint2 interface pointer.
+    if (ppPendingBreakpoint)
+    {
+        // Be sure that the bound breakpoint has not been deleted. If
+        // deleted, then return hr = E_BP_DELETED.
+        if (m_state != BPS_DELETED)
+        {
+            // Query for the IDebugPendingBreakpoint2 interface.
+            hr = m_pPendingBP->QueryInterface(IID_IDebugPendingBreakpoint2,
+                                              (void**)ppPendingBreakpoint);
+        }
+        else
+        {
+            hr = E_BP_DELETED;
+        }
+    }
+    else
+    {
+        hr = E_INVALIDARG;
+    }
 
-   return hr;
+    return hr;
 }
 ```
 

--- a/docs/extensibility/debugger/reference/idebugboundbreakpoint2-getpendingbreakpoint.md
+++ b/docs/extensibility/debugger/reference/idebugboundbreakpoint2-getpendingbreakpoint.md
@@ -2,79 +2,79 @@
 title: "IDebugBoundBreakpoint2::GetPendingBreakpoint | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-f1_keywords: 
+f1_keywords:
   - "IDebugBoundBreakpoint2::GetPendingBreakpoint"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "IDebugBoundBreakpoint2::GetPendingBreakpoint method"
   - "GetPendingBreakpoint method"
 ms.assetid: 22f94f81-f8d9-46de-96e9-fae6f3c24903
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # IDebugBoundBreakpoint2::GetPendingBreakpoint
-Gets the pending breakpoint from which the specified bound breakpoint was created.  
-  
-## Syntax  
-  
-```cpp  
-HRESULT GetPendingBreakpoint(   
-   IDebugPendingBreakpoint2** ppPendingBreakpoint  
-);  
-```  
-  
-```csharp  
-int GetPendingBreakpoint(   
-   out IDebugPendingBreakpoint2 ppPendingBreakpoint  
-);  
-```  
-  
-#### Parameters  
- `ppPendingBreakpoint`  
- [out] Returns the [IDebugPendingBreakpoint2](../../../extensibility/debugger/reference/idebugpendingbreakpoint2.md) object that represents the pending breakpoint that was used to create this bound breakpoint.  
-  
-## Return Value  
- If successful, returns `S_OK`; otherwise, returns an error code.  
-  
-## Remarks  
- A pending breakpoint can be thought of as a collection of all the necessary information needed to bind a breakpoint to code that can be applied to one or many programs.  
-  
-## Example  
- The following example shows how to implement this method for a simple `CBoundBreakpoint` object that exposes the [IDebugBoundBreakpoint2](../../../extensibility/debugger/reference/idebugboundbreakpoint2.md) interface.  
-  
-```  
-HRESULT CBoundBreakpoint::GetPendingBreakpoint(  
-    IDebugPendingBreakpoint2** ppPendingBreakpoint)  
-{    
-   HRESULT hr;    
-  
-   // Check for valid IDebugPendingBreakpoint2 interface pointer.    
-   if (ppPendingBreakpoint)    
-   {    
-      // Be sure that the bound breakpoint has not been deleted. If  
-      // deleted, then return hr = E_BP_DELETED.    
-      if (m_state != BPS_DELETED)    
-      {    
-         // Query for the IDebugPendingBreakpoint2 interface.    
-         hr = m_pPendingBP->QueryInterface(IID_IDebugPendingBreakpoint2,  
-                                           (void**)ppPendingBreakpoint);    
-      }    
-      else    
-      {    
-         hr = E_BP_DELETED;    
-      }    
-   }    
-   else    
-   {    
-      hr = E_INVALIDARG;    
-   }    
-  
-   return hr;    
-}    
-```  
-  
-## See Also  
- [IDebugBoundBreakpoint2](../../../extensibility/debugger/reference/idebugboundbreakpoint2.md)   
- [IDebugPendingBreakpoint2](../../../extensibility/debugger/reference/idebugpendingbreakpoint2.md)
+Gets the pending breakpoint from which the specified bound breakpoint was created.
+
+## Syntax
+
+```cpp
+HRESULT GetPendingBreakpoint( 
+   IDebugPendingBreakpoint2** ppPendingBreakpoint
+);
+```
+
+```csharp
+int GetPendingBreakpoint( 
+   out IDebugPendingBreakpoint2 ppPendingBreakpoint
+);
+```
+
+#### Parameters
+`ppPendingBreakpoint`  
+[out] Returns the [IDebugPendingBreakpoint2](../../../extensibility/debugger/reference/idebugpendingbreakpoint2.md) object that represents the pending breakpoint that was used to create this bound breakpoint.
+
+## Return Value
+If successful, returns `S_OK`; otherwise, returns an error code.
+
+## Remarks
+A pending breakpoint can be thought of as a collection of all the necessary information needed to bind a breakpoint to code that can be applied to one or many programs.
+
+## Example
+The following example shows how to implement this method for a simple `CBoundBreakpoint` object that exposes the [IDebugBoundBreakpoint2](../../../extensibility/debugger/reference/idebugboundbreakpoint2.md) interface.
+
+```
+HRESULT CBoundBreakpoint::GetPendingBreakpoint(
+    IDebugPendingBreakpoint2** ppPendingBreakpoint)
+{
+   HRESULT hr;
+
+   // Check for valid IDebugPendingBreakpoint2 interface pointer.
+   if (ppPendingBreakpoint)
+   {
+      // Be sure that the bound breakpoint has not been deleted. If
+      // deleted, then return hr = E_BP_DELETED.
+      if (m_state != BPS_DELETED)
+      {
+         // Query for the IDebugPendingBreakpoint2 interface.
+         hr = m_pPendingBP->QueryInterface(IID_IDebugPendingBreakpoint2,
+                                           (void**)ppPendingBreakpoint);
+      }
+      else
+      {
+         hr = E_BP_DELETED;
+      }
+   }
+   else
+   {
+      hr = E_INVALIDARG;
+   }
+
+   return hr;
+}
+```
+
+## See Also
+[IDebugBoundBreakpoint2](../../../extensibility/debugger/reference/idebugboundbreakpoint2.md)  
+[IDebugPendingBreakpoint2](../../../extensibility/debugger/reference/idebugpendingbreakpoint2.md)


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.