### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/idebugbreakpointboundevent2-getpendingbreakpoint.md
+++ b/docs/extensibility/debugger/reference/idebugbreakpointboundevent2-getpendingbreakpoint.md
@@ -2,70 +2,70 @@
 title: "IDebugBreakpointBoundEvent2::GetPendingBreakpoint | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-f1_keywords: 
+f1_keywords:
   - "IDebugBreakpointBoundEvent2::GetPendingBreakpoint"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "IDebugBreakpointBoundEvent2::GetPendingBreakpoint"
 ms.assetid: 6da7ed86-b412-4964-b6a3-0687a66f63fe
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # IDebugBreakpointBoundEvent2::GetPendingBreakpoint
-Gets the pending breakpoint that is being bound.  
-  
-## Syntax  
-  
-```cpp  
-HRESULT GetPendingBreakpoint(   
-   IDebugPendingBreakpoint2** ppPendingBP  
-);  
-```  
-  
-```cpp  
-int GetPendingBreakpoint(   
-   out IDebugPendingBreakpoint2 ppPendingBP  
-);  
-```  
-  
-#### Parameters  
- `ppPendingBP`  
- [out] Returns the [IDebugPendingBreakpoint2](../../../extensibility/debugger/reference/idebugpendingbreakpoint2.md) object that represents the pending breakpoint being bound.  
-  
-## Return Value  
- If successful, returns `S_OK`; otherwise, returns an error code.  
-  
-## Example  
- The following example shows how to implement this method for a **CBreakpointSetDebugEventBase** object that exposes the [IDebugBreakpointBoundEvent2](../../../extensibility/debugger/reference/idebugbreakpointboundevent2.md) interface.  
-  
-```cpp  
-STDMETHODIMP CBreakpointSetDebugEventBase::GetPendingBreakpoint(  
-    IDebugPendingBreakpoint2 **ppPendingBP)  
-{  
-    HRESULT hRes = E_FAIL;  
-  
-    if ( ppPendingBP )  
-    {  
-        if ( m_pPendingBP )  
-        {  
-            *ppPendingBP = m_pPendingBP;  
-  
-            m_pPendingBP->AddRef();  
-  
-            hRes = S_OK;  
-        }  
-        else  
-            hRes = E_FAIL;  
-    }  
-    else  
-        hRes = E_INVALIDARG;  
-  
-    return ( hRes );  
-}  
-```  
-  
-## See Also  
- [IDebugBreakpointBoundEvent2](../../../extensibility/debugger/reference/idebugbreakpointboundevent2.md)   
- [IDebugPendingBreakpoint2](../../../extensibility/debugger/reference/idebugpendingbreakpoint2.md)
+Gets the pending breakpoint that is being bound.
+
+## Syntax
+
+```cpp
+HRESULT GetPendingBreakpoint( 
+   IDebugPendingBreakpoint2** ppPendingBP
+);
+```
+
+```cpp
+int GetPendingBreakpoint( 
+   out IDebugPendingBreakpoint2 ppPendingBP
+);
+```
+
+#### Parameters
+`ppPendingBP`  
+[out] Returns the [IDebugPendingBreakpoint2](../../../extensibility/debugger/reference/idebugpendingbreakpoint2.md) object that represents the pending breakpoint being bound.
+
+## Return Value
+If successful, returns `S_OK`; otherwise, returns an error code.
+
+## Example
+The following example shows how to implement this method for a **CBreakpointSetDebugEventBase** object that exposes the [IDebugBreakpointBoundEvent2](../../../extensibility/debugger/reference/idebugbreakpointboundevent2.md) interface.
+
+```cpp
+STDMETHODIMP CBreakpointSetDebugEventBase::GetPendingBreakpoint(
+    IDebugPendingBreakpoint2 **ppPendingBP)
+{
+    HRESULT hRes = E_FAIL;
+
+    if ( ppPendingBP )
+    {
+        if ( m_pPendingBP )
+        {
+            *ppPendingBP = m_pPendingBP;
+
+            m_pPendingBP->AddRef();
+
+            hRes = S_OK;
+        }
+        else
+            hRes = E_FAIL;
+    }
+    else
+        hRes = E_INVALIDARG;
+
+    return ( hRes );
+}
+```
+
+## See Also
+[IDebugBreakpointBoundEvent2](../../../extensibility/debugger/reference/idebugbreakpointboundevent2.md)  
+[IDebugPendingBreakpoint2](../../../extensibility/debugger/reference/idebugpendingbreakpoint2.md)

--- a/docs/extensibility/debugger/reference/idebugbreakpointboundevent2-getpendingbreakpoint.md
+++ b/docs/extensibility/debugger/reference/idebugbreakpointboundevent2-getpendingbreakpoint.md
@@ -19,14 +19,14 @@ Gets the pending breakpoint that is being bound.
 ## Syntax
 
 ```cpp
-HRESULT GetPendingBreakpoint( 
-   IDebugPendingBreakpoint2** ppPendingBP
+HRESULT GetPendingBreakpoint(
+    IDebugPendingBreakpoint2** ppPendingBP
 );
 ```
 
 ```cpp
-int GetPendingBreakpoint( 
-   out IDebugPendingBreakpoint2 ppPendingBP
+int GetPendingBreakpoint(
+    out IDebugPendingBreakpoint2 ppPendingBP
 );
 ```
 


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.