### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/debugger/debug-interface-access/cv-access-e.md
+++ b/docs/debugger/debug-interface-access/cv-access-e.md
@@ -2,47 +2,47 @@
 title: "CV_access_e | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-dev_langs: 
+dev_langs:
   - "C++"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "CV_access_e enumeration"
 ms.assetid: 33c05d65-abb4-4800-a382-54a3805ea7b0
 author: "mikejo5000"
 ms.author: "mikejo"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "multiple"
 ---
 # CV_access_e
-Specifies the scope of visibility (access level) of member functions and variables.  
-  
-## Syntax  
-  
-```C++  
-typedef enum CV_access_e {   
-   CV_private   = 1,  
-   CV_protected = 2,  
-   CV_public    = 3  
-} CV_access_e;  
-```  
-  
-## Elements  
- CV_private  
- Member has private access.  
-  
- CV_protected  
- Member has protected access.  
-  
- CV_public  
- Member has public access.  
-  
-## Remarks  
- The `friend` access specifier is not included here because it is typically used by non-member functions that have access to both private and protected elements of the class. Use the [IDiaSymbol::get_symTag](../../debugger/debug-interface-access/idiasymbol-get-symtag.md) method to find symbols with `SymTagFriend` access.  
-  
-## Requirements  
- Header: cvconst.h  
-  
-## See Also  
- [Enumerations and Structures](../../debugger/debug-interface-access/enumerations-and-structures.md)   
- [IDiaSymbol::get_access](../../debugger/debug-interface-access/idiasymbol-get-access.md)   
- [IDiaSymbol::get_symTag](../../debugger/debug-interface-access/idiasymbol-get-symtag.md)
+Specifies the scope of visibility (access level) of member functions and variables.
+
+## Syntax
+
+```C++
+typedef enum CV_access_e {
+   CV_private   = 1,
+   CV_protected = 2,
+   CV_public    = 3
+} CV_access_e;
+```
+
+## Elements
+CV_private  
+Member has private access.
+
+CV_protected  
+Member has protected access.
+
+CV_public  
+Member has public access.
+
+## Remarks
+The `friend` access specifier is not included here because it is typically used by non-member functions that have access to both private and protected elements of the class. Use the [IDiaSymbol::get_symTag](../../debugger/debug-interface-access/idiasymbol-get-symtag.md) method to find symbols with `SymTagFriend` access.
+
+## Requirements
+Header: cvconst.h
+
+## See Also
+[Enumerations and Structures](../../debugger/debug-interface-access/enumerations-and-structures.md)  
+[IDiaSymbol::get_access](../../debugger/debug-interface-access/idiasymbol-get-access.md)  
+[IDiaSymbol::get_symTag](../../debugger/debug-interface-access/idiasymbol-get-symtag.md)

--- a/docs/debugger/debug-interface-access/cv-access-e.md
+++ b/docs/debugger/debug-interface-access/cv-access-e.md
@@ -20,9 +20,9 @@ Specifies the scope of visibility (access level) of member functions and variabl
 
 ```C++
 typedef enum CV_access_e {
-   CV_private   = 1,
-   CV_protected = 2,
-   CV_public    = 3
+    CV_private   = 1,
+    CV_protected = 2,
+    CV_public    = 3
 } CV_access_e;
 ```
 


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.