### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/idebugbreakpointchecksumrequest2-getchecksum.md
+++ b/docs/extensibility/debugger/reference/idebugbreakpointchecksumrequest2-getchecksum.md
@@ -18,15 +18,15 @@ Retrieves the document checksum for a breakpoint request given the unique identi
 
 ```cpp
 HRESULT GetChecksum(
-   REFGUID        guidAlgorithm,
-   CHECKSUM_DATA *pChecksumData
+    REFGUID        guidAlgorithm,
+    CHECKSUM_DATA *pChecksumData
 );
 ```
 
 ```csharp
 public int GetChecksum(
-   ref Guid               guidAlgorithm,
-   out enum_CHECKSUM_DATA pChecksumData
+    ref Guid               guidAlgorithm,
+    out enum_CHECKSUM_DATA pChecksumData
 );
 ```
 

--- a/docs/extensibility/debugger/reference/idebugbreakpointchecksumrequest2-getchecksum.md
+++ b/docs/extensibility/debugger/reference/idebugbreakpointchecksumrequest2-getchecksum.md
@@ -2,98 +2,98 @@
 title: "IDebugBreakpointChecksumRequest2::GetChecksum | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "IDebugBreakpointChecksumRequest2::GetChecksum"
 ms.assetid: ec434882-e5c0-4d76-a58b-22c260d8626e
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # IDebugBreakpointChecksumRequest2::GetChecksum
-Retrieves the document checksum for a breakpoint request given the unique identifier of the checksum algorithm to use.  
-  
-## Syntax  
-  
-```cpp  
-HRESULT GetChecksum(   
-   REFGUID        guidAlgorithm,  
-   CHECKSUM_DATA *pChecksumData  
-);  
-```  
-  
-```csharp  
-public int GetChecksum(   
-   ref Guid               guidAlgorithm,  
-   out enum_CHECKSUM_DATA pChecksumData  
-);  
-```  
-  
-#### Parameters  
- `guidAlgorithm`  
- [in] Unique identifier of the checksum algorithm.  
-  
- `pChecksumData`  
- [out] Document checksum for the breakpoint request.  
-  
-## Return Value  
- If successful, returns `S_OK`; otherwise, returns an error code.  
-  
-## Example  
- The following example shows a function that checks whether the checksum of a document, which is about to be bound, matches one from the UI.  
-  
-```cpp  
-bool CDebugProgram::DoChecksumsMatch(CDebugPendingBreakpoint *pPending, CDebugCodeContext *pContext)  
-{  
-    bool fRet = false;  
-    HRESULT hRes;  
-  
-    // Get the checksum for the document we are about to bind to from the pdb side  
-    GUID guidAlgorithmId;  
-    BYTE *pChecksum = NULL;  
-    ULONG cNumBytes = 0;  
-  
-    hRes = pContext->GetDocumentChecksumAndAlgorithmId(&guidAlgorithmId, &pChecksum, &cNumBytes);  
-  
-    if ( S_OK == hRes )  
-    {  
-        // Get checksum data for the document from the UI (request) side  
-        CComPtr<IDebugBreakpointChecksumRequest2> pChecksumRequest;  
-  
-        hRes = pPending->GetChecksumRequest(&pChecksumRequest);  
-  
-        if ( S_OK == hRes )  
-        {  
-            CHECKSUM_DATA data;  
-  
-            hRes = pChecksumRequest->GetChecksum(guidAlgorithmId, &data);  
-  
-            if ( S_OK == hRes )  
-            {  
-                if ( data.ByteCount == cNumBytes && memcmp(data.pBytes, pChecksum, cNumBytes) == 0 )  
-                    fRet = true;  
-                else  
-                    fRet = false;  
-  
-                // Free up data allocated for checksum data  
-                CoTaskMemFree(data.pBytes);  
-            }  
-            else  
-                fRet = true; // checksums not available - user disabed checksums  
-        }  
-        else  
-            fRet = true; // we couldn't get checksum from UI - default to past behavior  
-  
-        // free up space allocated for checksum from pdb  
-        CoTaskMemFree(pChecksum);  
-    }  
-    else  
-        fRet = true; // we don't have a checksum to compare with.  
-  
-    return ( fRet );  
-}  
-```  
-  
-## See Also  
- [IDebugBreakpointChecksumRequest2](../../../extensibility/debugger/reference/idebugbreakpointchecksumrequest2.md)
+Retrieves the document checksum for a breakpoint request given the unique identifier of the checksum algorithm to use.
+
+## Syntax
+
+```cpp
+HRESULT GetChecksum(
+   REFGUID        guidAlgorithm,
+   CHECKSUM_DATA *pChecksumData
+);
+```
+
+```csharp
+public int GetChecksum(
+   ref Guid               guidAlgorithm,
+   out enum_CHECKSUM_DATA pChecksumData
+);
+```
+
+#### Parameters
+`guidAlgorithm`  
+[in] Unique identifier of the checksum algorithm.
+
+`pChecksumData`  
+[out] Document checksum for the breakpoint request.
+
+## Return Value
+If successful, returns `S_OK`; otherwise, returns an error code.
+
+## Example
+The following example shows a function that checks whether the checksum of a document, which is about to be bound, matches one from the UI.
+
+```cpp
+bool CDebugProgram::DoChecksumsMatch(CDebugPendingBreakpoint *pPending, CDebugCodeContext *pContext)
+{
+    bool fRet = false;
+    HRESULT hRes;
+
+    // Get the checksum for the document we are about to bind to from the pdb side
+    GUID guidAlgorithmId;
+    BYTE *pChecksum = NULL;
+    ULONG cNumBytes = 0;
+
+    hRes = pContext->GetDocumentChecksumAndAlgorithmId(&guidAlgorithmId, &pChecksum, &cNumBytes);
+
+    if ( S_OK == hRes )
+    {
+        // Get checksum data for the document from the UI (request) side
+        CComPtr<IDebugBreakpointChecksumRequest2> pChecksumRequest;
+
+        hRes = pPending->GetChecksumRequest(&pChecksumRequest);
+
+        if ( S_OK == hRes )
+        {
+            CHECKSUM_DATA data;
+
+            hRes = pChecksumRequest->GetChecksum(guidAlgorithmId, &data);
+
+            if ( S_OK == hRes )
+            {
+                if ( data.ByteCount == cNumBytes && memcmp(data.pBytes, pChecksum, cNumBytes) == 0 )
+                    fRet = true;
+                else
+                    fRet = false;
+
+                // Free up data allocated for checksum data
+                CoTaskMemFree(data.pBytes);
+            }
+            else
+                fRet = true; // checksums not available - user disabed checksums
+        }
+        else
+            fRet = true; // we couldn't get checksum from UI - default to past behavior
+
+        // free up space allocated for checksum from pdb
+        CoTaskMemFree(pChecksum);
+    }
+    else
+        fRet = true; // we don't have a checksum to compare with.
+
+    return ( fRet );
+}
+```
+
+## See Also
+[IDebugBreakpointChecksumRequest2](../../../extensibility/debugger/reference/idebugbreakpointchecksumrequest2.md)


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.