### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/enumerating-locals.md
+++ b/docs/extensibility/debugger/enumerating-locals.md
@@ -77,7 +77,7 @@ namespace EEMC
                 // Enumerate "this", if any, and all parameters and local variables.
                 else if (guidFilter == FilterGuids.guidFilterLocalsPlusArgs)
                 {
-                    IDebugClassField fieldThis   = null;
+                    IDebugClassField fieldThis  = null;
                     IEnumDebugFields parameters = null;
                     IEnumDebugFields locals     = null;
 
@@ -92,7 +92,7 @@ namespace EEMC
                 // Enumerate only "this".
                 else if (guidFilter == FilterGuids.guidFilterThis)
                 {
-                    IDebugClassField fieldThis   = null;
+                    IDebugClassField fieldThis = null;
                     methodField.GetThis(out fieldThis);
 
                     CEnumMethodField enumMethodField =
@@ -104,7 +104,7 @@ namespace EEMC
             // Wrap a property enumerator around the field enumerator.
             CEnumPropertyInfo propertiesInfo =
                 new CEnumPropertyInfo(provider, address, binder, radix, fields,
-                 (DEBUGPROP_INFO_FLAGS) dwFields);
+                (DEBUGPROP_INFO_FLAGS) dwFields);
 
             properties = (IEnumDebugPropertyInfo2) propertiesInfo;
             return COM.S_OK;
@@ -192,7 +192,7 @@ STDMETHODIMP CFieldProperty::EnumChildren(
         }
         else if (guidFilter == guidFilterThis )
         {
-            IDebugClassField* pfieldThis  = NULL;
+            IDebugClassField* pfieldThis = NULL;
 
             hr = pmethod->GetThis( &pfieldThis );
             if (SUCCEEDED(hr))

--- a/docs/extensibility/debugger/enumerating-locals.md
+++ b/docs/extensibility/debugger/enumerating-locals.md
@@ -2,244 +2,244 @@
 title: "Enumerating Locals | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "debugging [Debugging SDK], enumerating locals"
   - "expression evaluation, enumerating locals"
 ms.assetid: 254a88e7-d3a7-447a-bd0c-8985e73d85cf
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # Enumerate locals
 > [!IMPORTANT]
->  In Visual Studio 2015, this way of implementing expression evaluators is deprecated. For information about implementing CLR expression evaluators, see [CLR expression evaluators](https://github.com/Microsoft/ConcordExtensibilitySamples/wiki/CLR-Expression-Evaluators) and [Managed expression evaluator sample](https://github.com/Microsoft/ConcordExtensibilitySamples/wiki/Managed-Expression-Evaluator-Sample).  
-  
- When Visual Studio is ready to populate the **Locals** window, it calls [EnumChildren](../../extensibility/debugger/reference/idebugproperty2-enumchildren.md) on the [IDebugProperty2](../../extensibility/debugger/reference/idebugproperty2.md) object returned from [GetMethodProperty](../../extensibility/debugger/reference/idebugexpressionevaluator-getmethodproperty.md) (see [Implementing GetMethodProperty](../../extensibility/debugger/implementing-getmethodproperty.md)). `IDebugProperty2::EnumChildren` returns an [IEnumDebugPropertyInfo2](../../extensibility/debugger/reference/ienumdebugpropertyinfo2.md) object.  
-  
- Implementing `IDebugProperty2::EnumChildren` performs the following tasks:  
-  
-1.  Ensures this is representing a method.  
-  
-2.  Uses the `guidFilter` argument to determine which method to call on the [IDebugMethodField](../../extensibility/debugger/reference/idebugmethodfield.md) object. If `guidFilter` equals:  
-  
-    1.  `guidFilterLocals`, call [EnumLocals](../../extensibility/debugger/reference/idebugmethodfield-enumlocals.md) to obtain an [IEnumDebugFields](../../extensibility/debugger/reference/ienumdebugfields.md) object.  
-  
-    2.  `guidFilterArgs`, call [EnumArguments](../../extensibility/debugger/reference/idebugmethodfield-enumarguments.md) to obtain an `IEnumDebugFields` object.  
-  
-    3.  `guidFilterLocalsPlusArgs`, synthesize an enumeration that combines the results from `IDebugMethodField::EnumLocals` and `IDebugMethodField::EnumArguments`. This synthesis is represented by the class `CEnumMethodField`.  
-  
-3.  Instantiates a class (called `CEnumPropertyInfo` in this example) that implements the `IEnumDebugPropertyInfo2` interface and contains the `IEnumDebugFields` object.  
-  
-4.  Returns the `IEnumDebugProperty2Info2` interface from the `CEnumPropertyInfo` object.  
-  
-## Managed code  
- This example shows an implementation of `IDebugProperty2::EnumChildren` in managed code.  
-  
-```csharp  
-namespace EEMC  
-{  
-    public class CFieldProperty : IDebugProperty2  
-    {  
-        public HRESULT EnumChildren (  
-                uint                    dwFields,  
-                uint                    radix,  
-            ref Guid                    guidFilter,   
-                ulong                   attribFilter,   
-                string                  nameFilter,   
-                uint                    timeout,  
-            out IEnumDebugPropertyInfo2 properties)   
-        {  
-            properties = null;  
-            IEnumDebugFields fields = null;  
-  
-            // If this field is a method...  
-            if (0 != ((uint) fieldKind & (uint) FIELD_KIND.FIELD_TYPE_METHOD))  
-            {  
-                IDebugMethodField methodField = (IDebugMethodField) field;  
-  
-                // Enumerate parameters.  
-                if (guidFilter == FilterGuids.guidFilterArgs)  
-                {  
-                    methodField.EnumParameters(out fields);    
-                }  
-                // Enumerate local variables.  
-                else if (guidFilter == FilterGuids.guidFilterLocals)  
-                {  
-                    methodField.EnumLocals(address, out fields);    
-                }  
-                // Enumerate all local variables, including invisible compiler temps.  
-                else if (guidFilter == FilterGuids.guidFilterAllLocals)  
-                {  
-                    methodField.EnumAllLocals(address, out fields);    
-                }  
-                // Enumerate "this", if any, and all parameters and local variables.  
-                else if (guidFilter == FilterGuids.guidFilterLocalsPlusArgs)  
-                {  
-                    IDebugClassField fieldThis   = null;  
-                    IEnumDebugFields parameters = null;  
-                    IEnumDebugFields locals     = null;  
-  
-                    methodField.GetThis(out fieldThis);  
-                    methodField.EnumParameters(out parameters);  
-                    methodField.EnumLocals(address, out locals);  
-  
-                    CEnumMethodField enumMethodField =   
-                        new CEnumMethodField(fieldThis, parameters, locals);  
-                    fields = (IEnumDebugFields) enumMethodField;  
-                }  
-                // Enumerate only "this".  
-                else if (guidFilter == FilterGuids.guidFilterThis)  
-                {  
-                    IDebugClassField fieldThis   = null;  
-                    methodField.GetThis(out fieldThis);  
-  
-                    CEnumMethodField enumMethodField =   
-                        new CEnumMethodField(fieldThis, null, null);  
-                    fields = (IEnumDebugFields) enumMethodField;  
-                }  
-                else throw new COMException();// E_FAIL  
-            }  
-            // Wrap a property enumerator around the field enumerator.  
-            CEnumPropertyInfo propertiesInfo =   
-                new CEnumPropertyInfo(provider, address, binder, radix, fields,   
-                 (DEBUGPROP_INFO_FLAGS) dwFields);  
-  
-            properties = (IEnumDebugPropertyInfo2) propertiesInfo;  
-            return COM.S_OK;  
-        }  
-    }  
-}  
-```  
-  
-## Unmanaged code  
- This example shows an implementation of `IDebugProperty2::EnumChildren` in unmanaged code.  
-  
-```cpp  
-STDMETHODIMP CFieldProperty::EnumChildren(   
-        in DEBUGPROP_INFO_FLAGS        infoFlags,  
-        in DWORD                       radix,  
-        in REFGUID                     guidFilter,  
-        in DBG_ATTRIB_FLAGS            attribFilter,  
-        in LPCOLESTR                   pszNameFilter,  
-        in DWORD                       timeout,  
-        out IEnumDebugPropertyInfo2 ** ppchildren )  
-{  
-    if (ppchildren == NULL)  
-        return E_INVALIDARG;  
-    else  
-        *ppchildren = 0;  
-  
-    //get enumeration  
-    HRESULT hr;  
-    IEnumDebugFields*     pfields    = NULL;  
-  
-    if (m_fieldKind & FIELD_TYPE_METHOD)  
-    {  
-        //-----------------------------------------------------  
-        // A Method  
-  
-        IDebugMethodField*  pmethod    = NULL;  
-  
-        //enumerate the requested properties  
-        hr = m_field->QueryInterface( IID_IDebugMethodField,  
-            reinterpret_cast<void**>(&pmethod) );  
-        if (FAILED(hr))  
-            return hr;  
-  
-        if (guidFilter == guidFilterArgs)  
-        {  
-            hr = pmethod->EnumParameters( &pfields );    
-        }  
-        else if (guidFilter == guidFilterLocals)  
-        {  
-            hr = pmethod->EnumLocals( m_address, &pfields );  
-        }  
-        else if (guidFilter == guidFilterAllLocals)  
-        {  
-            hr = pmethod->EnumAllLocals( m_address, &pfields );  
-        }  
-        else if (guidFilter == guidFilterLocalsPlusArgs)  
-        {  
-            //we create a special enumerator for this  
-            IDebugClassField* pfieldThis  = NULL;  
-            IEnumDebugFields* pparameters = NULL;  
-            IEnumDebugFields* plocals     = NULL;  
-  
-            pmethod->GetThis( &pfieldThis );  
-            pmethod->EnumParameters( &pparameters );  
-            pmethod->EnumLocals( m_address, &plocals );  
-  
-            CEnumMethodField* penumMethodField =  
-                new CEnumMethodField( pfieldThis, pparameters, plocals );  
-            if (pfieldThis != NULL)  
-                pfieldThis->Release();  
-            if (pparameters != NULL)  
-                pparameters->Release();  
-            if (plocals != NULL)  
-                plocals->Release();  
-            if (!penumMethodField)   
-            {   
-                hr = E_OUTOFMEMORY;  
-            }  
-            else  
-            {  
-                hr = penumMethodField->QueryInterface( IID_IEnumDebugFields,  
-                        reinterpret_cast<void**>(&pfields) );  
-                penumMethodField->Release();  
-            }  
-        }  
-        else if (guidFilter == guidFilterThis )  
-        {  
-            IDebugClassField* pfieldThis  = NULL;  
-  
-            hr = pmethod->GetThis( &pfieldThis );  
-            if (SUCCEEDED(hr))  
-            {  
-                CEnumMethodField* penumMethodField =  
-                    new CEnumMethodField( pfieldThis, NULL, NULL );  
-                pfieldThis->Release();  
-                if (!penumMethodField)   
-                {  
-                    hr = E_OUTOFMEMORY;  
-                }  
-                else  
-                {  
-                    hr = penumMethodField->QueryInterface( IID_IEnumDebugFields,  
-                        reinterpret_cast<void**>(&pfields) );  
-                    penumMethodField->Release();  
-                }  
-            }  
-        }  
-        else  
-        {  
-            hr = E_FAIL;  
-        }  
-  
-        pmethod->Release();  
-        if (hr != S_OK)  
-            return hr;  
-    }  
-  
-    //create a property info enumeration around the field enumerator  
-    CEnumPropertyInfo* pproperties =  
-        new CEnumPropertyInfo( m_provider, m_address, m_binder,   
-                               radix, pfields, infoFlags );  
-    if (pfields != NULL)  
-        pfields->Release();  
-    if (pproperties == NULL)  
-        return E_OUTOFMEMORY;  
-  
-    hr = pproperties->QueryInterface( IID_IEnumDebugPropertyInfo2,  
-        reinterpret_cast<void**>(ppchildren) );  
-    pproperties->Release();  
-  
-    return hr;  
-}  
-```  
-  
-## See also  
- [Sample implementation of locals](../../extensibility/debugger/sample-implementation-of-locals.md)   
- [Implement GetMethodProperty](../../extensibility/debugger/implementing-getmethodproperty.md)   
- [Evaluation context](../../extensibility/debugger/evaluation-context.md)
+> In Visual Studio 2015, this way of implementing expression evaluators is deprecated. For information about implementing CLR expression evaluators, see [CLR expression evaluators](https://github.com/Microsoft/ConcordExtensibilitySamples/wiki/CLR-Expression-Evaluators) and [Managed expression evaluator sample](https://github.com/Microsoft/ConcordExtensibilitySamples/wiki/Managed-Expression-Evaluator-Sample).
+
+When Visual Studio is ready to populate the **Locals** window, it calls [EnumChildren](../../extensibility/debugger/reference/idebugproperty2-enumchildren.md) on the [IDebugProperty2](../../extensibility/debugger/reference/idebugproperty2.md) object returned from [GetMethodProperty](../../extensibility/debugger/reference/idebugexpressionevaluator-getmethodproperty.md) (see [Implementing GetMethodProperty](../../extensibility/debugger/implementing-getmethodproperty.md)). `IDebugProperty2::EnumChildren` returns an [IEnumDebugPropertyInfo2](../../extensibility/debugger/reference/ienumdebugpropertyinfo2.md) object.
+
+Implementing `IDebugProperty2::EnumChildren` performs the following tasks:
+
+1. Ensures this is representing a method.
+
+2. Uses the `guidFilter` argument to determine which method to call on the [IDebugMethodField](../../extensibility/debugger/reference/idebugmethodfield.md) object. If `guidFilter` equals:
+
+    1. `guidFilterLocals`, call [EnumLocals](../../extensibility/debugger/reference/idebugmethodfield-enumlocals.md) to obtain an [IEnumDebugFields](../../extensibility/debugger/reference/ienumdebugfields.md) object.
+
+    2. `guidFilterArgs`, call [EnumArguments](../../extensibility/debugger/reference/idebugmethodfield-enumarguments.md) to obtain an `IEnumDebugFields` object.
+
+    3. `guidFilterLocalsPlusArgs`, synthesize an enumeration that combines the results from `IDebugMethodField::EnumLocals` and `IDebugMethodField::EnumArguments`. This synthesis is represented by the class `CEnumMethodField`.
+
+3. Instantiates a class (called `CEnumPropertyInfo` in this example) that implements the `IEnumDebugPropertyInfo2` interface and contains the `IEnumDebugFields` object.
+
+4. Returns the `IEnumDebugProperty2Info2` interface from the `CEnumPropertyInfo` object.
+
+## Managed code
+This example shows an implementation of `IDebugProperty2::EnumChildren` in managed code.
+
+```csharp
+namespace EEMC
+{
+    public class CFieldProperty : IDebugProperty2
+    {
+        public HRESULT EnumChildren (
+                uint                    dwFields,
+                uint                    radix,
+            ref Guid                    guidFilter,
+                ulong                   attribFilter,
+                string                  nameFilter,
+                uint                    timeout,
+            out IEnumDebugPropertyInfo2 properties)
+        {
+            properties = null;
+            IEnumDebugFields fields = null;
+
+            // If this field is a method...
+            if (0 != ((uint) fieldKind & (uint) FIELD_KIND.FIELD_TYPE_METHOD))
+            {
+                IDebugMethodField methodField = (IDebugMethodField) field;
+
+                // Enumerate parameters.
+                if (guidFilter == FilterGuids.guidFilterArgs)
+                {
+                    methodField.EnumParameters(out fields);
+                }
+                // Enumerate local variables.
+                else if (guidFilter == FilterGuids.guidFilterLocals)
+                {
+                    methodField.EnumLocals(address, out fields);
+                }
+                // Enumerate all local variables, including invisible compiler temps.
+                else if (guidFilter == FilterGuids.guidFilterAllLocals)
+                {
+                    methodField.EnumAllLocals(address, out fields);
+                }
+                // Enumerate "this", if any, and all parameters and local variables.
+                else if (guidFilter == FilterGuids.guidFilterLocalsPlusArgs)
+                {
+                    IDebugClassField fieldThis   = null;
+                    IEnumDebugFields parameters = null;
+                    IEnumDebugFields locals     = null;
+
+                    methodField.GetThis(out fieldThis);
+                    methodField.EnumParameters(out parameters);
+                    methodField.EnumLocals(address, out locals);
+
+                    CEnumMethodField enumMethodField =
+                        new CEnumMethodField(fieldThis, parameters, locals);
+                    fields = (IEnumDebugFields) enumMethodField;
+                }
+                // Enumerate only "this".
+                else if (guidFilter == FilterGuids.guidFilterThis)
+                {
+                    IDebugClassField fieldThis   = null;
+                    methodField.GetThis(out fieldThis);
+
+                    CEnumMethodField enumMethodField =
+                        new CEnumMethodField(fieldThis, null, null);
+                    fields = (IEnumDebugFields) enumMethodField;
+                }
+                else throw new COMException();// E_FAIL
+            }
+            // Wrap a property enumerator around the field enumerator.
+            CEnumPropertyInfo propertiesInfo =
+                new CEnumPropertyInfo(provider, address, binder, radix, fields,
+                 (DEBUGPROP_INFO_FLAGS) dwFields);
+
+            properties = (IEnumDebugPropertyInfo2) propertiesInfo;
+            return COM.S_OK;
+        }
+    }
+}
+```
+
+## Unmanaged code
+ This example shows an implementation of `IDebugProperty2::EnumChildren` in unmanaged code.
+
+```cpp
+STDMETHODIMP CFieldProperty::EnumChildren(
+        in DEBUGPROP_INFO_FLAGS        infoFlags,
+        in DWORD                       radix,
+        in REFGUID                     guidFilter,
+        in DBG_ATTRIB_FLAGS            attribFilter,
+        in LPCOLESTR                   pszNameFilter,
+        in DWORD                       timeout,
+        out IEnumDebugPropertyInfo2 ** ppchildren )
+{
+    if (ppchildren == NULL)
+        return E_INVALIDARG;
+    else
+        *ppchildren = 0;
+
+    //get enumeration
+    HRESULT hr;
+    IEnumDebugFields*     pfields    = NULL;
+
+    if (m_fieldKind & FIELD_TYPE_METHOD)
+    {
+        //-----------------------------------------------------
+        // A Method
+
+        IDebugMethodField*  pmethod    = NULL;
+
+        //enumerate the requested properties
+        hr = m_field->QueryInterface( IID_IDebugMethodField,
+            reinterpret_cast<void**>(&pmethod) );
+        if (FAILED(hr))
+            return hr;
+
+        if (guidFilter == guidFilterArgs)
+        {
+            hr = pmethod->EnumParameters( &pfields );
+        }
+        else if (guidFilter == guidFilterLocals)
+        {
+            hr = pmethod->EnumLocals( m_address, &pfields );
+        }
+        else if (guidFilter == guidFilterAllLocals)
+        {
+            hr = pmethod->EnumAllLocals( m_address, &pfields );
+        }
+        else if (guidFilter == guidFilterLocalsPlusArgs)
+        {
+            //we create a special enumerator for this
+            IDebugClassField* pfieldThis  = NULL;
+            IEnumDebugFields* pparameters = NULL;
+            IEnumDebugFields* plocals     = NULL;
+
+            pmethod->GetThis( &pfieldThis );
+            pmethod->EnumParameters( &pparameters );
+            pmethod->EnumLocals( m_address, &plocals );
+
+            CEnumMethodField* penumMethodField =
+                new CEnumMethodField( pfieldThis, pparameters, plocals );
+            if (pfieldThis != NULL)
+                pfieldThis->Release();
+            if (pparameters != NULL)
+                pparameters->Release();
+            if (plocals != NULL)
+                plocals->Release();
+            if (!penumMethodField)
+            {
+                hr = E_OUTOFMEMORY;
+            }
+            else
+            {
+                hr = penumMethodField->QueryInterface( IID_IEnumDebugFields,
+                        reinterpret_cast<void**>(&pfields) );
+                penumMethodField->Release();
+            }
+        }
+        else if (guidFilter == guidFilterThis )
+        {
+            IDebugClassField* pfieldThis  = NULL;
+
+            hr = pmethod->GetThis( &pfieldThis );
+            if (SUCCEEDED(hr))
+            {
+                CEnumMethodField* penumMethodField =
+                    new CEnumMethodField( pfieldThis, NULL, NULL );
+                pfieldThis->Release();
+                if (!penumMethodField)
+                {
+                    hr = E_OUTOFMEMORY;
+                }
+                else
+                {
+                    hr = penumMethodField->QueryInterface( IID_IEnumDebugFields,
+                        reinterpret_cast<void**>(&pfields) );
+                    penumMethodField->Release();
+                }
+            }
+        }
+        else
+        {
+            hr = E_FAIL;
+        }
+
+        pmethod->Release();
+        if (hr != S_OK)
+            return hr;
+    }
+
+    //create a property info enumeration around the field enumerator
+    CEnumPropertyInfo* pproperties =
+        new CEnumPropertyInfo( m_provider, m_address, m_binder,
+                               radix, pfields, infoFlags );
+    if (pfields != NULL)
+        pfields->Release();
+    if (pproperties == NULL)
+        return E_OUTOFMEMORY;
+
+    hr = pproperties->QueryInterface( IID_IEnumDebugPropertyInfo2,
+        reinterpret_cast<void**>(ppchildren) );
+    pproperties->Release();
+
+    return hr;
+}
+```
+
+## See also
+[Sample implementation of locals](../../extensibility/debugger/sample-implementation-of-locals.md)  
+[Implement GetMethodProperty](../../extensibility/debugger/implementing-getmethodproperty.md)  
+[Evaluation context](../../extensibility/debugger/evaluation-context.md)


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.