### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/idebugbreakpointrequest2-getlocationtype.md
+++ b/docs/extensibility/debugger/reference/idebugbreakpointrequest2-getlocationtype.md
@@ -19,14 +19,14 @@ Gets the breakpoint location type of this breakpoint request.
 ## Syntax
 
 ```cpp
-HRESULT GetLocationType( 
-   BP_LOCATION_TYPE* pBPLocationType
+HRESULT GetLocationType(
+    BP_LOCATION_TYPE* pBPLocationType
 );
 ```
 
 ```csharp
-int GetLocationType( 
-   out enum_BP_LOCATION_TYPE pBPLocationType
+int GetLocationType(
+    out enum_BP_LOCATION_TYPE pBPLocationType
 );
 ```
 
@@ -43,31 +43,31 @@ The following example shows how to implement this method for a simple `CDebugBre
 ```
 HRESULT CDebugBreakpointRequest::GetLocationType(BP_LOCATION_TYPE* pBPLocationType)
 {
-   HRESULT hr;
+    HRESULT hr;
 
-   if (pBPLocationType)
-   {
-      // Set default BP_LOCATION_TYPE.
-      *pBPLocationType = BPLT_NONE;
+    if (pBPLocationType)
+    {
+        // Set default BP_LOCATION_TYPE.
+        *pBPLocationType = BPLT_NONE;
 
-      // Check if the BPREQI_BPLOCATION flag is set in BPREQI_FIELDS.
-      if (IsFlagSet(m_bpRequestInfo.dwFields, BPREQI_BPLOCATION))
-      {
-         // Get the new BP_LOCATION_TYPE.
-         *pBPLocationType = m_bpRequestInfo.bpLocation.bpLocationType;
-         hr = S_OK;
-      }
-      else
-      {
-         hr = E_FAIL;
-      }
-   }
-   else
-   {
-      hr = E_INVALIDARG;
-   }
+        // Check if the BPREQI_BPLOCATION flag is set in BPREQI_FIELDS.
+        if (IsFlagSet(m_bpRequestInfo.dwFields, BPREQI_BPLOCATION))
+        {
+            // Get the new BP_LOCATION_TYPE.
+            *pBPLocationType = m_bpRequestInfo.bpLocation.bpLocationType;
+            hr = S_OK;
+        }
+        else
+        {
+            hr = E_FAIL;
+        }
+    }
+    else
+    {
+        hr = E_INVALIDARG;
+    }
 
-   return hr;
+    return hr;
 }
 ```
 

--- a/docs/extensibility/debugger/reference/idebugbreakpointrequest2-getlocationtype.md
+++ b/docs/extensibility/debugger/reference/idebugbreakpointrequest2-getlocationtype.md
@@ -2,77 +2,77 @@
 title: "IDebugBreakpointRequest2::GetLocationType | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-f1_keywords: 
+f1_keywords:
   - "IDebugBreakpointRequest2::GetLocationType"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "IDebugBreakpointRequest2::GetLocationType"
 ms.assetid: b6d14c59-d3aa-48ff-8278-f6b5bba9c2f3
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # IDebugBreakpointRequest2::GetLocationType
-Gets the breakpoint location type of this breakpoint request.  
-  
-## Syntax  
-  
-```cpp  
-HRESULT GetLocationType(   
-   BP_LOCATION_TYPE* pBPLocationType  
-);  
-```  
-  
-```csharp  
-int GetLocationType(   
-   out enum_BP_LOCATION_TYPE pBPLocationType  
-);  
-```  
-  
-#### Parameters  
- `pBPLocationType`  
- [out] Returns a value from the [BP_LOCATION_TYPE](../../../extensibility/debugger/reference/bp-location-type.md) enumeration that describes the location of this breakpoint request.  
-  
-## Return Value  
- If successful, returns `S_OK`; otherwise, returns an error code. Returns `E_FAIL` if the `bpLocation` field in the associated [BP_REQUEST_INFO](../../../extensibility/debugger/reference/bp-request-info.md) structure is not valid.  
-  
-## Example  
- The following example shows how to implement this method for a simple `CDebugBreakpointRequest` object that exposes the[IDebugBreakpointRequest2](../../../extensibility/debugger/reference/idebugbreakpointrequest2.md) interface.  
-  
-```  
-HRESULT CDebugBreakpointRequest::GetLocationType(BP_LOCATION_TYPE* pBPLocationType)    
-{    
-   HRESULT hr;    
-  
-   if (pBPLocationType)    
-   {    
-      // Set default BP_LOCATION_TYPE.    
-      *pBPLocationType = BPLT_NONE;    
-  
-      // Check if the BPREQI_BPLOCATION flag is set in BPREQI_FIELDS.    
-      if (IsFlagSet(m_bpRequestInfo.dwFields, BPREQI_BPLOCATION))    
-      {    
-         // Get the new BP_LOCATION_TYPE.    
-         *pBPLocationType = m_bpRequestInfo.bpLocation.bpLocationType;    
-         hr = S_OK;    
-      }    
-      else    
-      {    
-         hr = E_FAIL;    
-      }    
-   }    
-   else    
-   {    
-      hr = E_INVALIDARG;    
-   }    
-  
-   return hr;    
-}    
-```  
-  
-## See Also  
- [IDebugBreakpointRequest2](../../../extensibility/debugger/reference/idebugbreakpointrequest2.md)   
- [BP_LOCATION_TYPE](../../../extensibility/debugger/reference/bp-location-type.md)   
- [BPREQI_FIELDS](../../../extensibility/debugger/reference/bpreqi-fields.md)   
- [BP_REQUEST_INFO](../../../extensibility/debugger/reference/bp-request-info.md)
+Gets the breakpoint location type of this breakpoint request.
+
+## Syntax
+
+```cpp
+HRESULT GetLocationType( 
+   BP_LOCATION_TYPE* pBPLocationType
+);
+```
+
+```csharp
+int GetLocationType( 
+   out enum_BP_LOCATION_TYPE pBPLocationType
+);
+```
+
+#### Parameters
+`pBPLocationType`
+[out] Returns a value from the [BP_LOCATION_TYPE](../../../extensibility/debugger/reference/bp-location-type.md) enumeration that describes the location of this breakpoint request.
+
+## Return Value
+If successful, returns `S_OK`; otherwise, returns an error code. Returns `E_FAIL` if the `bpLocation` field in the associated [BP_REQUEST_INFO](../../../extensibility/debugger/reference/bp-request-info.md) structure is not valid.
+
+## Example
+The following example shows how to implement this method for a simple `CDebugBreakpointRequest` object that exposes the[IDebugBreakpointRequest2](../../../extensibility/debugger/reference/idebugbreakpointrequest2.md) interface.
+
+```
+HRESULT CDebugBreakpointRequest::GetLocationType(BP_LOCATION_TYPE* pBPLocationType)
+{
+   HRESULT hr;
+
+   if (pBPLocationType)
+   {
+      // Set default BP_LOCATION_TYPE.
+      *pBPLocationType = BPLT_NONE;
+
+      // Check if the BPREQI_BPLOCATION flag is set in BPREQI_FIELDS.
+      if (IsFlagSet(m_bpRequestInfo.dwFields, BPREQI_BPLOCATION))
+      {
+         // Get the new BP_LOCATION_TYPE.
+         *pBPLocationType = m_bpRequestInfo.bpLocation.bpLocationType;
+         hr = S_OK;
+      }
+      else
+      {
+         hr = E_FAIL;
+      }
+   }
+   else
+   {
+      hr = E_INVALIDARG;
+   }
+
+   return hr;
+}
+```
+
+## See Also
+[IDebugBreakpointRequest2](../../../extensibility/debugger/reference/idebugbreakpointrequest2.md)  
+[BP_LOCATION_TYPE](../../../extensibility/debugger/reference/bp-location-type.md)  
+[BPREQI_FIELDS](../../../extensibility/debugger/reference/bpreqi-fields.md)  
+[BP_REQUEST_INFO](../../../extensibility/debugger/reference/bp-request-info.md)


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.