### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/debugger/debug-interface-access/udtkind.md
+++ b/docs/debugger/debug-interface-access/udtkind.md
@@ -20,10 +20,10 @@ Describes the variety of user-defined type (UDT).
 
 ```C++
 enum UdtKind {
-   UdtStruct,
-   UdtClass,
-   UdtUnion,
-   UdtInterface
+    UdtStruct,
+    UdtClass,
+    UdtUnion,
+    UdtInterface
 };
 ```
 

--- a/docs/debugger/debug-interface-access/udtkind.md
+++ b/docs/debugger/debug-interface-access/udtkind.md
@@ -2,50 +2,50 @@
 title: "UdtKind | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-dev_langs: 
+dev_langs:
   - "C++"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "UdtKind enumeration"
 ms.assetid: 400b59b9-373c-42cb-aae1-570494214328
 author: "mikejo5000"
 ms.author: "mikejo"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "multiple"
 ---
 # UdtKind
-Describes the variety of user-defined type (UDT).  
-  
-## Syntax  
-  
-```C++  
-enum UdtKind {   
-   UdtStruct,  
-   UdtClass,  
-   UdtUnion,  
-   UdtInterface  
-};  
-```  
-  
-## Elements  
- UdtStruct  
- UDT is a structure.  
-  
- UdtClass  
- UDT is a class.  
-  
- UdtUnion  
- UDT is a union.  
-  
- UdtInterface  
- UDT is an interface.  
-  
-## Remarks  
- The values in this enumeration are returned by the [IDiaSymbol::get_udtKind](../../debugger/debug-interface-access/idiasymbol-get-udtkind.md) method.  
-  
-## Requirements  
- Header: cvconst.h  
-  
-## See Also  
- [Enumerations and Structures](../../debugger/debug-interface-access/enumerations-and-structures.md)   
- [IDiaSymbol::get_udtKind](../../debugger/debug-interface-access/idiasymbol-get-udtkind.md)
+Describes the variety of user-defined type (UDT).
+
+## Syntax
+
+```C++
+enum UdtKind {
+   UdtStruct,
+   UdtClass,
+   UdtUnion,
+   UdtInterface
+};
+```
+
+## Elements
+UdtStruct  
+UDT is a structure.
+
+UdtClass  
+UDT is a class.
+
+UdtUnion  
+UDT is a union.
+
+UdtInterface  
+UDT is an interface.
+
+## Remarks
+The values in this enumeration are returned by the [IDiaSymbol::get_udtKind](../../debugger/debug-interface-access/idiasymbol-get-udtkind.md) method.
+
+## Requirements
+Header: cvconst.h
+
+## See Also
+[Enumerations and Structures](../../debugger/debug-interface-access/enumerations-and-structures.md)  
+[IDiaSymbol::get_udtKind](../../debugger/debug-interface-access/idiasymbol-get-udtkind.md)


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.