### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/attach-reason.md
+++ b/docs/extensibility/debugger/reference/attach-reason.md
@@ -20,18 +20,18 @@ Specifies the reason for the debug engine (DE) to attach to a program node.
 
 ```cpp
 enum enum_ATTACH_REASON {
-   ATTACH_REASON_LAUNCH = 0x0001,
-   ATTACH_REASON_USER   = 0x0002,
-   ATTACH_REASON_AUTO   = 0x0003
+    ATTACH_REASON_LAUNCH = 0x0001,
+    ATTACH_REASON_USER   = 0x0002,
+    ATTACH_REASON_AUTO   = 0x0003
 };
 typedef DWORD ATTACH_REASON;
 ```
 
 ```csharp
 public enum enum_ATTACH_REASON {
-   ATTACH_REASON_LAUNCH = 0x0001,
-   ATTACH_REASON_USER   = 0x0002,
-   ATTACH_REASON_AUTO   = 0x0003
+    ATTACH_REASON_LAUNCH = 0x0001,
+    ATTACH_REASON_USER   = 0x0002,
+    ATTACH_REASON_AUTO   = 0x0003
 };
 ```
 

--- a/docs/extensibility/debugger/reference/attach-reason.md
+++ b/docs/extensibility/debugger/reference/attach-reason.md
@@ -2,60 +2,60 @@
 title: "ATTACH_REASON | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-f1_keywords: 
+f1_keywords:
   - "ATTACH_REASON"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "ATTACH_REASON enumeration"
 ms.assetid: 159fb70b-a344-4ba6-9115-b7eaa16e228f
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # ATTACH_REASON
-Specifies the reason for the debug engine (DE) to attach to a program node.  
-  
-## Syntax  
-  
-```cpp  
-enum enum_ATTACH_REASON {   
-   ATTACH_REASON_LAUNCH = 0x0001,  
-   ATTACH_REASON_USER   = 0x0002,  
-   ATTACH_REASON_AUTO   = 0x0003  
-};  
-typedef DWORD ATTACH_REASON;  
-```  
-  
-```csharp  
-public enum enum_ATTACH_REASON {   
-   ATTACH_REASON_LAUNCH = 0x0001,  
-   ATTACH_REASON_USER   = 0x0002,  
-   ATTACH_REASON_AUTO   = 0x0003  
-};  
-```  
-  
-## Members  
- ATTACH_REASON_AUTO  
- Attach because the process is currently in debug mode.  
-  
- ATTACH_REASON_LAUNCH  
- Attach because the process has been launched.  
-  
- ATTACH_REASON_USER  
- Attach because of a user request.  
-  
-## Remarks  
- These values are used as a parameter to the [Attach](../../../extensibility/debugger/reference/idebugengine2-attach.md) and [Attach](../../../extensibility/debugger/reference/idebugprogramex2-attach.md) methods.  
-  
-## Requirements  
- Header: msdbg.h  
-  
- Namespace: Microsoft.VisualStudio.Debugger.Interop  
-  
- Assembly: Microsoft.VisualStudio.Debugger.Interop.dll  
-  
-## See Also  
- [Enumerations](../../../extensibility/debugger/reference/enumerations-visual-studio-debugging.md)   
- [Attach](../../../extensibility/debugger/reference/idebugengine2-attach.md)   
- [Attach](../../../extensibility/debugger/reference/idebugprogramex2-attach.md)
+Specifies the reason for the debug engine (DE) to attach to a program node.
+
+## Syntax
+
+```cpp
+enum enum_ATTACH_REASON {
+   ATTACH_REASON_LAUNCH = 0x0001,
+   ATTACH_REASON_USER   = 0x0002,
+   ATTACH_REASON_AUTO   = 0x0003
+};
+typedef DWORD ATTACH_REASON;
+```
+
+```csharp
+public enum enum_ATTACH_REASON {
+   ATTACH_REASON_LAUNCH = 0x0001,
+   ATTACH_REASON_USER   = 0x0002,
+   ATTACH_REASON_AUTO   = 0x0003
+};
+```
+
+## Members
+ATTACH_REASON_AUTO  
+Attach because the process is currently in debug mode.
+
+ATTACH_REASON_LAUNCH  
+Attach because the process has been launched.
+
+ATTACH_REASON_USER  
+Attach because of a user request.
+
+## Remarks
+These values are used as a parameter to the [Attach](../../../extensibility/debugger/reference/idebugengine2-attach.md) and [Attach](../../../extensibility/debugger/reference/idebugprogramex2-attach.md) methods.
+
+## Requirements
+Header: msdbg.h
+
+Namespace: Microsoft.VisualStudio.Debugger.Interop
+
+Assembly: Microsoft.VisualStudio.Debugger.Interop.dll
+
+## See Also
+[Enumerations](../../../extensibility/debugger/reference/enumerations-visual-studio-debugging.md)  
+[Attach](../../../extensibility/debugger/reference/idebugengine2-attach.md)  
+[Attach](../../../extensibility/debugger/reference/idebugprogramex2-attach.md)


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.