### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/bp-condition.md
+++ b/docs/extensibility/debugger/reference/bp-condition.md
@@ -20,21 +20,21 @@ Describes the conditions under which a breakpoint fires.
 
 ```cpp
 typedef struct _BP_CONDITION {
-   IDebugThread2* pThread;
-   BP_COND_STYLE  styleCondition;
-   BSTR           bstrContext;
-   BSTR           bstrCondition;
-   UINT           nRadix;
+    IDebugThread2* pThread;
+    BP_COND_STYLE  styleCondition;
+    BSTR           bstrContext;
+    BSTR           bstrCondition;
+    UINT           nRadix;
 } BP_CONDITION;
 ```
 
 ```csharp
 public struct BP_CONDITION {
-   public IDebugThread2 pThread;
-   public uint          styleCondition;
-   public string        bstrContext;
-   public string        bstrCondition;
-   public uint          nRadix;
+    public IDebugThread2 pThread;
+    public uint          styleCondition;
+    public string        bstrContext;
+    public string        bstrCondition;
+    public uint          nRadix;
 };
 ```
 

--- a/docs/extensibility/debugger/reference/bp-condition.md
+++ b/docs/extensibility/debugger/reference/bp-condition.md
@@ -2,75 +2,75 @@
 title: "BP_CONDITION | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-f1_keywords: 
+f1_keywords:
   - "BP_CONDITION"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "BP_CONDITION structure"
 ms.assetid: 407f87a3-2878-429b-8c65-b68feb36622a
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # BP_CONDITION
-Describes the conditions under which a breakpoint fires.  
-  
-## Syntax  
-  
-```cpp  
-typedef struct _BP_CONDITION {   
-   IDebugThread2* pThread;  
-   BP_COND_STYLE  styleCondition;  
-   BSTR           bstrContext;  
-   BSTR           bstrCondition;  
-   UINT           nRadix;  
-} BP_CONDITION;  
-```  
-  
-```csharp  
-public struct BP_CONDITION {   
-   public IDebugThread2 pThread;  
-   public uint          styleCondition;  
-   public string        bstrContext;  
-   public string        bstrCondition;  
-   public uint          nRadix;  
-};  
-```  
-  
-## Members  
- `pThread`  
- The [IDebugThread2](../../../extensibility/debugger/reference/idebugthread2.md) object that represents the active thread for the application that contains the breakpoint.  
-  
- `styleCondition`  
- A value from the [BP_COND_STYLE](../../../extensibility/debugger/reference/bp-cond-style.md) enumeration describing the style of this breakpoint condition.  
-  
- `bstrContext`  
- The location of the breakpoint.  
-  
- `bstrCondition`  
- The firing condition of the breakpoint.  
-  
- `nRadix`  
- Radix to be used in evaluating any numerical information.  
-  
-## Remarks  
- This structure is a member of the [BP_REQUEST_INFO](../../../extensibility/debugger/reference/bp-request-info.md) and [BP_REQUEST_INFO2](../../../extensibility/debugger/reference/bp-request-info2.md) structures.  
-  
- This structure is also passed as a parameter to the [SetCondition](../../../extensibility/debugger/reference/idebugboundbreakpoint2-setcondition.md) and [SetCondition](../../../extensibility/debugger/reference/idebugpendingbreakpoint2-setcondition.md) methods.  
-  
-## Requirements  
- Header: msdbg.h  
-  
- Namespace: Microsoft.VisualStudio.Debugger.Interop  
-  
- Assembly: Microsoft.VisualStudio.Debugger.Interop.dll  
-  
-## See Also  
- [Structures and Unions](../../../extensibility/debugger/reference/structures-and-unions.md)   
- [BP_REQUEST_INFO](../../../extensibility/debugger/reference/bp-request-info.md)   
- [BP_REQUEST_INFO2](../../../extensibility/debugger/reference/bp-request-info2.md)   
- [SetCondition](../../../extensibility/debugger/reference/idebugboundbreakpoint2-setcondition.md)   
- [SetCondition](../../../extensibility/debugger/reference/idebugpendingbreakpoint2-setcondition.md)   
- [IDebugThread2](../../../extensibility/debugger/reference/idebugthread2.md)   
- [BP_COND_STYLE](../../../extensibility/debugger/reference/bp-cond-style.md)
+Describes the conditions under which a breakpoint fires.
+
+## Syntax
+
+```cpp
+typedef struct _BP_CONDITION {
+   IDebugThread2* pThread;
+   BP_COND_STYLE  styleCondition;
+   BSTR           bstrContext;
+   BSTR           bstrCondition;
+   UINT           nRadix;
+} BP_CONDITION;
+```
+
+```csharp
+public struct BP_CONDITION {
+   public IDebugThread2 pThread;
+   public uint          styleCondition;
+   public string        bstrContext;
+   public string        bstrCondition;
+   public uint          nRadix;
+};
+```
+
+## Members
+`pThread`  
+The [IDebugThread2](../../../extensibility/debugger/reference/idebugthread2.md) object that represents the active thread for the application that contains the breakpoint.
+
+`styleCondition`  
+A value from the [BP_COND_STYLE](../../../extensibility/debugger/reference/bp-cond-style.md) enumeration describing the style of this breakpoint condition.
+
+`bstrContext`  
+The location of the breakpoint.
+
+`bstrCondition`  
+The firing condition of the breakpoint.
+
+`nRadix`  
+Radix to be used in evaluating any numerical information.
+
+## Remarks
+This structure is a member of the [BP_REQUEST_INFO](../../../extensibility/debugger/reference/bp-request-info.md) and [BP_REQUEST_INFO2](../../../extensibility/debugger/reference/bp-request-info2.md) structures.
+
+This structure is also passed as a parameter to the [SetCondition](../../../extensibility/debugger/reference/idebugboundbreakpoint2-setcondition.md) and [SetCondition](../../../extensibility/debugger/reference/idebugpendingbreakpoint2-setcondition.md) methods.
+
+## Requirements
+Header: msdbg.h
+
+Namespace: Microsoft.VisualStudio.Debugger.Interop
+
+Assembly: Microsoft.VisualStudio.Debugger.Interop.dll
+
+## See Also
+[Structures and Unions](../../../extensibility/debugger/reference/structures-and-unions.md)  
+[BP_REQUEST_INFO](../../../extensibility/debugger/reference/bp-request-info.md)  
+[BP_REQUEST_INFO2](../../../extensibility/debugger/reference/bp-request-info2.md)  
+[SetCondition](../../../extensibility/debugger/reference/idebugboundbreakpoint2-setcondition.md)  
+[SetCondition](../../../extensibility/debugger/reference/idebugpendingbreakpoint2-setcondition.md)  
+[IDebugThread2](../../../extensibility/debugger/reference/idebugthread2.md)  
+[BP_COND_STYLE](../../../extensibility/debugger/reference/bp-cond-style.md)


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.