### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/bp-flags.md
+++ b/docs/extensibility/debugger/reference/bp-flags.md
@@ -20,18 +20,18 @@ Provides optional flags that may be used to specify additional information when 
 
 ```cpp
 enum enum_BP_FLAGS {
-   BP_FLAG_NONE            = 0x0000,
-   BP_FLAG_MAP_DOCPOSITION = 0x0001,
-   BP_FLAG_DONT_STOP       = 0x0002
+    BP_FLAG_NONE            = 0x0000,
+    BP_FLAG_MAP_DOCPOSITION = 0x0001,
+    BP_FLAG_DONT_STOP       = 0x0002
 };
 typedef DWORD BP_FLAGS;
 ```
 
 ```csharp
 public enum enum_BP_FLAGS {
-   BP_FLAG_NONE            = 0x0000,
-   BP_FLAG_MAP_DOCPOSITION = 0x0001,
-   BP_FLAG_DONT_STOP       = 0x0002
+    BP_FLAG_NONE            = 0x0000,
+    BP_FLAG_MAP_DOCPOSITION = 0x0001,
+    BP_FLAG_DONT_STOP       = 0x0002
 };
 ```
 

--- a/docs/extensibility/debugger/reference/bp-flags.md
+++ b/docs/extensibility/debugger/reference/bp-flags.md
@@ -2,63 +2,63 @@
 title: "BP_FLAGS | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-f1_keywords: 
+f1_keywords:
   - "BP_FLAGS"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "BP_FLAGS enumeration"
 ms.assetid: c45dfc74-5e7f-4f1e-a147-ab2a55dccbd0
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # BP_FLAGS
-Provides optional flags that may be used to specify additional information when setting a breakpoint.  
-  
-## Syntax  
-  
-```cpp  
-enum enum_BP_FLAGS {   
-   BP_FLAG_NONE            = 0x0000,  
-   BP_FLAG_MAP_DOCPOSITION = 0x0001,  
-   BP_FLAG_DONT_STOP       = 0x0002  
-};  
-typedef DWORD BP_FLAGS;  
-```  
-  
-```csharp  
-public enum enum_BP_FLAGS {   
-   BP_FLAG_NONE            = 0x0000,  
-   BP_FLAG_MAP_DOCPOSITION = 0x0001,  
-   BP_FLAG_DONT_STOP       = 0x0002  
-};  
-```  
-  
-## Members  
- BP_FLAG_NONE  
- Specifies no breakpoint flag.  
-  
- BP_FLAG_MAP_DOCPOSITION  
- Specifies that the debug engine (DE) should map the breakpoint using the document position. This is applicable only to breakpoints set in script-oriented source files such as Active Server Pages (ASP).  
-  
- BP_FLAG_DONT_STOP  
- Specifies that the breakpoint should be processed by the debug engine, but that the debug engine ultimately should not stop there (that is, an [IDebugBreakpointEvent2](../../../extensibility/debugger/reference/idebugbreakpointevent2.md) event object should not be sent). This flag is designed to be used primarily with tracepoints.  
-  
-## Remarks  
- Used for the `dwFlags` member of the [BP_REQUEST_INFO](../../../extensibility/debugger/reference/bp-request-info.md) and [BP_REQUEST_INFO2](../../../extensibility/debugger/reference/bp-request-info2.md) structures.  
-  
- These values may be combined with a bitwise `OR`.  
-  
-## Requirements  
- Header: msdbg.h  
-  
- Namespace: Microsoft.VisualStudio.Debugger.Interop  
-  
- Assembly: Microsoft.VisualStudio.Debugger.Interop.dll  
-  
-## See Also  
- [Enumerations](../../../extensibility/debugger/reference/enumerations-visual-studio-debugging.md)   
- [BP_REQUEST_INFO](../../../extensibility/debugger/reference/bp-request-info.md)   
- [BP_REQUEST_INFO2](../../../extensibility/debugger/reference/bp-request-info2.md)   
- [IDebugBreakpointEvent2](../../../extensibility/debugger/reference/idebugbreakpointevent2.md)
+Provides optional flags that may be used to specify additional information when setting a breakpoint.
+
+## Syntax
+
+```cpp
+enum enum_BP_FLAGS {
+   BP_FLAG_NONE            = 0x0000,
+   BP_FLAG_MAP_DOCPOSITION = 0x0001,
+   BP_FLAG_DONT_STOP       = 0x0002
+};
+typedef DWORD BP_FLAGS;
+```
+
+```csharp
+public enum enum_BP_FLAGS {
+   BP_FLAG_NONE            = 0x0000,
+   BP_FLAG_MAP_DOCPOSITION = 0x0001,
+   BP_FLAG_DONT_STOP       = 0x0002
+};
+```
+
+## Members
+BP_FLAG_NONE  
+Specifies no breakpoint flag.
+
+BP_FLAG_MAP_DOCPOSITION  
+Specifies that the debug engine (DE) should map the breakpoint using the document position. This is applicable only to breakpoints set in script-oriented source files such as Active Server Pages (ASP).
+
+BP_FLAG_DONT_STOP  
+Specifies that the breakpoint should be processed by the debug engine, but that the debug engine ultimately should not stop there (that is, an [IDebugBreakpointEvent2](../../../extensibility/debugger/reference/idebugbreakpointevent2.md) event object should not be sent). This flag is designed to be used primarily with tracepoints.
+
+## Remarks
+Used for the `dwFlags` member of the [BP_REQUEST_INFO](../../../extensibility/debugger/reference/bp-request-info.md) and [BP_REQUEST_INFO2](../../../extensibility/debugger/reference/bp-request-info2.md) structures.
+
+These values may be combined with a bitwise `OR`.
+
+## Requirements
+Header: msdbg.h
+
+Namespace: Microsoft.VisualStudio.Debugger.Interop
+
+Assembly: Microsoft.VisualStudio.Debugger.Interop.dll
+
+## See Also
+[Enumerations](../../../extensibility/debugger/reference/enumerations-visual-studio-debugging.md)  
+[BP_REQUEST_INFO](../../../extensibility/debugger/reference/bp-request-info.md)  
+[BP_REQUEST_INFO2](../../../extensibility/debugger/reference/bp-request-info2.md)  
+[IDebugBreakpointEvent2](../../../extensibility/debugger/reference/idebugbreakpointevent2.md)


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.