### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/bp-location-code-context.md
+++ b/docs/extensibility/debugger/reference/bp-location-code-context.md
@@ -20,7 +20,7 @@ Describes the location of a breakpoint that is bound directly to an address in t
 
 ```cpp
 typedef struct _BP_LOCATION_CODE_CONTEXT {
-   IDebugCodeContext2* pCodeContext;
+    IDebugCodeContext2* pCodeContext;
 } BP_LOCATION_CODE_CONTEXT;
 ```
 

--- a/docs/extensibility/debugger/reference/bp-location-code-context.md
+++ b/docs/extensibility/debugger/reference/bp-location-code-context.md
@@ -2,43 +2,43 @@
 title: "BP_LOCATION_CODE_CONTEXT | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-f1_keywords: 
+f1_keywords:
   - "BP_LOCATION_CODE_CONTEXT"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "BP_LOCATION_CODE_CONTEXT structure"
 ms.assetid: 37412896-021a-4f73-9bb7-4125502c2e18
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # BP_LOCATION_CODE_CONTEXT
-Describes the location of a breakpoint that is bound directly to an address in the program being debugged.  
-  
-## Syntax  
-  
-```cpp  
-typedef struct _BP_LOCATION_CODE_CONTEXT {   
-   IDebugCodeContext2* pCodeContext;  
-} BP_LOCATION_CODE_CONTEXT;  
-```  
-  
-## Members  
- pCodeContext  
- The [IDebugCodeContext2](../../../extensibility/debugger/reference/idebugcodecontext2.md) object that identifies the position of the breakpoint in the code.  
-  
-## Remarks  
- This structure is a member of the [BP_LOCATION](../../../extensibility/debugger/reference/bp-location.md) structure as part of a union.  
-  
-## Requirements  
- Header: msdbg.h  
-  
- Namespace: Microsoft.VisualStudio.Debugger.Interop  
-  
- Assembly: Microsoft.VisualStudio.Debugger.Interop.dll  
-  
-## See Also  
- [Structures and Unions](../../../extensibility/debugger/reference/structures-and-unions.md)   
- [BP_LOCATION](../../../extensibility/debugger/reference/bp-location.md)   
- [IDebugCodeContext2](../../../extensibility/debugger/reference/idebugcodecontext2.md)
+Describes the location of a breakpoint that is bound directly to an address in the program being debugged.
+
+## Syntax
+
+```cpp
+typedef struct _BP_LOCATION_CODE_CONTEXT {
+   IDebugCodeContext2* pCodeContext;
+} BP_LOCATION_CODE_CONTEXT;
+```
+
+## Members
+pCodeContext  
+The [IDebugCodeContext2](../../../extensibility/debugger/reference/idebugcodecontext2.md) object that identifies the position of the breakpoint in the code.
+
+## Remarks
+This structure is a member of the [BP_LOCATION](../../../extensibility/debugger/reference/bp-location.md) structure as part of a union.
+
+## Requirements
+Header: msdbg.h
+
+Namespace: Microsoft.VisualStudio.Debugger.Interop
+
+Assembly: Microsoft.VisualStudio.Debugger.Interop.dll
+
+## See Also
+[Structures and Unions](../../../extensibility/debugger/reference/structures-and-unions.md)  
+[BP_LOCATION](../../../extensibility/debugger/reference/bp-location.md)  
+[IDebugCodeContext2](../../../extensibility/debugger/reference/idebugcodecontext2.md)


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.