### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/bp-location-code-file-line.md
+++ b/docs/extensibility/debugger/reference/bp-location-code-file-line.md
@@ -2,47 +2,47 @@
 title: "BP_LOCATION_CODE_FILE_LINE | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-f1_keywords: 
+f1_keywords:
   - "BP_LOCATION_CODE_FILE_LINE"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "BP_LOCATION_CODE_FILE_LINE structure"
 ms.assetid: 3ff32032-d412-44d3-91bf-870cc354a09e
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # BP_LOCATION_CODE_FILE_LINE
-Contains the data for the location of a breakpoint at a specific line in a code source file.  
-  
-## Syntax  
-  
-```cpp  
-typedef struct _BP_LOCATION_CODE_FILE_LINE {   
-   BSTR                     bstrContext;  
-   IDebugDocumentPosition2* pDocPos;  
-} BP_LOCATION_CODE_FILE_LINE;  
-```  
-  
-## Members  
- `bstrContext`  
- The context of the breakpoint, typically a method or function name as seen on a call stack.  
-  
- `pDocPos`  
- The [IDebugDocumentPosition2](../../../extensibility/debugger/reference/idebugdocumentposition2.md) object that represents the document position of the breakpoint.  
-  
-## Remarks  
- This structure is a member of the [BP_LOCATION](../../../extensibility/debugger/reference/bp-location.md) structure as part of a union.  
-  
-## Requirements  
- Header: msdbg.h  
-  
- Namespace: Microsoft.VisualStudio.Debugger.Interop  
-  
- Assembly: Microsoft.VisualStudio.Debugger.Interop.dll  
-  
-## See Also  
- [Structures and Unions](../../../extensibility/debugger/reference/structures-and-unions.md)   
- [BP_LOCATION](../../../extensibility/debugger/reference/bp-location.md)   
- [IDebugDocumentPosition2](../../../extensibility/debugger/reference/idebugdocumentposition2.md)
+Contains the data for the location of a breakpoint at a specific line in a code source file.
+
+## Syntax
+
+```cpp
+typedef struct _BP_LOCATION_CODE_FILE_LINE {
+   BSTR                     bstrContext;
+   IDebugDocumentPosition2* pDocPos;
+} BP_LOCATION_CODE_FILE_LINE;
+```
+
+## Members
+`bstrContext`  
+The context of the breakpoint, typically a method or function name as seen on a call stack.
+
+`pDocPos`  
+The [IDebugDocumentPosition2](../../../extensibility/debugger/reference/idebugdocumentposition2.md) object that represents the document position of the breakpoint.
+
+## Remarks
+This structure is a member of the [BP_LOCATION](../../../extensibility/debugger/reference/bp-location.md) structure as part of a union.
+
+## Requirements
+Header: msdbg.h
+
+Namespace: Microsoft.VisualStudio.Debugger.Interop
+
+Assembly: Microsoft.VisualStudio.Debugger.Interop.dll
+
+## See Also
+[Structures and Unions](../../../extensibility/debugger/reference/structures-and-unions.md)  
+[BP_LOCATION](../../../extensibility/debugger/reference/bp-location.md)  
+[IDebugDocumentPosition2](../../../extensibility/debugger/reference/idebugdocumentposition2.md)

--- a/docs/extensibility/debugger/reference/bp-location-code-file-line.md
+++ b/docs/extensibility/debugger/reference/bp-location-code-file-line.md
@@ -20,8 +20,8 @@ Contains the data for the location of a breakpoint at a specific line in a code 
 
 ```cpp
 typedef struct _BP_LOCATION_CODE_FILE_LINE {
-   BSTR                     bstrContext;
-   IDebugDocumentPosition2* pDocPos;
+    BSTR                     bstrContext;
+    IDebugDocumentPosition2* pDocPos;
 } BP_LOCATION_CODE_FILE_LINE;
 ```
 


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.
