### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/bp-location-code-func-offset.md
+++ b/docs/extensibility/debugger/reference/bp-location-code-func-offset.md
@@ -2,49 +2,49 @@
 title: "BP_LOCATION_CODE_FUNC_OFFSET | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-f1_keywords: 
+f1_keywords:
   - "BP_LOCATION_CODE_FUNC_OFFSET"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "BP_LOCATION_CODE_FUNC_OFFSET structure"
 ms.assetid: ab38f7ca-fa01-4cf3-a06c-56cbb7207617
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # BP_LOCATION_CODE_FUNC_OFFSET
-Describes the offset location of a breakpoint in a function in code.  
-  
-## Syntax  
-  
-```cpp  
-typedef struct _BP_LOCATION_CODE_FUNC_OFFSET {   
-   BSTR                     bstrContext;  
-   IDebugFunctionPosition2* pFuncPos;  
-} BP_LOCATION_CODE_FUNC_OFFSET;  
-```  
-  
-## Members  
- `bstrContext`  
- The context of the breakpoint, typically a method or function name as seen on a call stack.  
-  
- `pFuncPos`  
- The [IDebugFunctionPosition2](../../../extensibility/debugger/reference/idebugfunctionposition2.md) object that describes the name of the function and the relative position from the beginning of the function.  
-  
-## Remarks  
- This structure is a member of the [BP_LOCATION](../../../extensibility/debugger/reference/bp-location.md) structure as part of a union.  
-  
- The `pFuncPos` member indicates where to set the function breakpoint.  
-  
-## Requirements  
- Header: msdbg.h  
-  
- Namespace: Microsoft.VisualStudio.Debugger.Interop  
-  
- Assembly: Microsoft.VisualStudio.Debugger.Interop.dll  
-  
-## See Also  
- [Structures and Unions](../../../extensibility/debugger/reference/structures-and-unions.md)   
- [BP_LOCATION](../../../extensibility/debugger/reference/bp-location.md)   
- [IDebugFunctionPosition2](../../../extensibility/debugger/reference/idebugfunctionposition2.md)
+Describes the offset location of a breakpoint in a function in code.
+
+## Syntax
+
+```cpp
+typedef struct _BP_LOCATION_CODE_FUNC_OFFSET {
+   BSTR                     bstrContext;
+   IDebugFunctionPosition2* pFuncPos;
+} BP_LOCATION_CODE_FUNC_OFFSET;
+```
+
+## Members
+`bstrContext`  
+The context of the breakpoint, typically a method or function name as seen on a call stack.
+
+`pFuncPos`  
+The [IDebugFunctionPosition2](../../../extensibility/debugger/reference/idebugfunctionposition2.md) object that describes the name of the function and the relative position from the beginning of the function.
+
+## Remarks
+This structure is a member of the [BP_LOCATION](../../../extensibility/debugger/reference/bp-location.md) structure as part of a union.
+
+The `pFuncPos` member indicates where to set the function breakpoint.
+
+## Requirements
+Header: msdbg.h
+
+Namespace: Microsoft.VisualStudio.Debugger.Interop
+
+Assembly: Microsoft.VisualStudio.Debugger.Interop.dll
+
+## See Also
+[Structures and Unions](../../../extensibility/debugger/reference/structures-and-unions.md)  
+[BP_LOCATION](../../../extensibility/debugger/reference/bp-location.md)  
+[IDebugFunctionPosition2](../../../extensibility/debugger/reference/idebugfunctionposition2.md)

--- a/docs/extensibility/debugger/reference/bp-location-code-func-offset.md
+++ b/docs/extensibility/debugger/reference/bp-location-code-func-offset.md
@@ -20,8 +20,8 @@ Describes the offset location of a breakpoint in a function in code.
 
 ```cpp
 typedef struct _BP_LOCATION_CODE_FUNC_OFFSET {
-   BSTR                     bstrContext;
-   IDebugFunctionPosition2* pFuncPos;
+    BSTR                     bstrContext;
+    IDebugFunctionPosition2* pFuncPos;
 } BP_LOCATION_CODE_FUNC_OFFSET;
 ```
 


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.