### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/bp-location-code-string.md
+++ b/docs/extensibility/debugger/reference/bp-location-code-string.md
@@ -2,46 +2,46 @@
 title: "BP_LOCATION_CODE_STRING | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-f1_keywords: 
+f1_keywords:
   - "BP_LOCATION_CODE_STRING"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "BP_LOCATION_CODE_STRING structure"
 ms.assetid: a4cd71c6-5052-45fe-907b-ebc6ca1df2e4
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # BP_LOCATION_CODE_STRING
-Used for setting code breakpoints based on a string that the user can enter from the integrated development environment (IDE).  
-  
-## Syntax  
-  
-```cpp  
-typedef struct _BP_LOCATION_CODE_STRING {   
-   BSTR bstrContext;  
-   BSTR bstrCodeExpr;  
-} BP_LOCATION_CODE_STRING;  
-```  
-  
-## Members  
- `bstrContext`  
- The context of the breakpoint within the code, typically a method or function name as seen on a call stack.  
-  
- `bstrCodeExpr`  
- The string that the user types in to describe the code breakpoint.  
-  
-## Remarks  
- This structure is a member of the [BP_LOCATION](../../../extensibility/debugger/reference/bp-location.md) structure as part of a union.  
-  
-## Requirements  
- Header: msdbg.h  
-  
- Namespace: Microsoft.VisualStudio.Debugger.Interop  
-  
- Assembly: Microsoft.VisualStudio.Debugger.Interop.dll  
-  
-## See Also  
- [Structures and Unions](../../../extensibility/debugger/reference/structures-and-unions.md)   
- [BP_LOCATION](../../../extensibility/debugger/reference/bp-location.md)
+Used for setting code breakpoints based on a string that the user can enter from the integrated development environment (IDE).
+
+## Syntax
+
+```cpp
+typedef struct _BP_LOCATION_CODE_STRING {
+   BSTR bstrContext;
+   BSTR bstrCodeExpr;
+} BP_LOCATION_CODE_STRING;
+```
+
+## Members
+`bstrContext`  
+The context of the breakpoint within the code, typically a method or function name as seen on a call stack.
+
+`bstrCodeExpr`  
+The string that the user types in to describe the code breakpoint.
+
+## Remarks
+This structure is a member of the [BP_LOCATION](../../../extensibility/debugger/reference/bp-location.md) structure as part of a union.
+
+## Requirements
+Header: msdbg.h
+
+Namespace: Microsoft.VisualStudio.Debugger.Interop
+
+Assembly: Microsoft.VisualStudio.Debugger.Interop.dll
+
+## See Also
+[Structures and Unions](../../../extensibility/debugger/reference/structures-and-unions.md)  
+[BP_LOCATION](../../../extensibility/debugger/reference/bp-location.md)

--- a/docs/extensibility/debugger/reference/bp-location-code-string.md
+++ b/docs/extensibility/debugger/reference/bp-location-code-string.md
@@ -20,8 +20,8 @@ Used for setting code breakpoints based on a string that the user can enter from
 
 ```cpp
 typedef struct _BP_LOCATION_CODE_STRING {
-   BSTR bstrContext;
-   BSTR bstrCodeExpr;
+    BSTR bstrContext;
+    BSTR bstrCodeExpr;
 } BP_LOCATION_CODE_STRING;
 ```
 


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.