### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/bp-location-data-string.md
+++ b/docs/extensibility/debugger/reference/bp-location-data-string.md
@@ -20,10 +20,10 @@ Used for setting data breakpoints that are based on a string that the user can e
 
 ```cpp
 typedef struct _BP_LOCATION_DATA_STRING {
-   IDebugThread2* pThread;
-   BSTR           bstrContext;
-   BSTR           bstrDataExpr;
-   DWORD          dwNumElements;
+    IDebugThread2* pThread;
+    BSTR           bstrContext;
+    BSTR           bstrDataExpr;
+    DWORD          dwNumElements;
 } BP_LOCATION_DATA_STRING;
 ```
 

--- a/docs/extensibility/debugger/reference/bp-location-data-string.md
+++ b/docs/extensibility/debugger/reference/bp-location-data-string.md
@@ -2,55 +2,55 @@
 title: "BP_LOCATION_DATA_STRING | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-f1_keywords: 
+f1_keywords:
   - "BP_LOCATION_DATA_STRING"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "BP_LOCATION_DATA_STRING structure"
 ms.assetid: 445d6f3f-95b0-47ac-85e2-51b778240687
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # BP_LOCATION_DATA_STRING
-Used for setting data breakpoints that are based on a string that the user can enter from the integrated development environment (IDE).  
-  
-## Syntax  
-  
-```cpp  
-typedef struct _BP_LOCATION_DATA_STRING {   
-   IDebugThread2* pThread;  
-   BSTR           bstrContext;  
-   BSTR           bstrDataExpr;  
-   DWORD          dwNumElements;  
-} BP_LOCATION_DATA_STRING;  
-```  
-  
-## Members  
- `pThread`  
- The [IDebugThread2](../../../extensibility/debugger/reference/idebugthread2.md) object that represents the thread on which the breakpoint occurs.  
-  
- `bstrContext`  
- The context of the breakpoint within the code, typically a method or function name as seen on a call stack.  
-  
- `bstrDataExpr`  
- The data string the user enters to set the breakpoint.  
-  
- `dwNumElements`  
- The number of elements in the data string in which the breakpoint occurs.  
-  
-## Remarks  
- This structure is a member of the [BP_LOCATION](../../../extensibility/debugger/reference/bp-location.md) structure as part of a union.  
-  
-## Requirements  
- Header: msdbg.h  
-  
- Namespace: Microsoft.VisualStudio.Debugger.Interop  
-  
- Assembly: Microsoft.VisualStudio.Debugger.Interop.dll  
-  
-## See Also  
- [Structures and Unions](../../../extensibility/debugger/reference/structures-and-unions.md)   
- [BP_LOCATION](../../../extensibility/debugger/reference/bp-location.md)   
- [IDebugThread2](../../../extensibility/debugger/reference/idebugthread2.md)
+Used for setting data breakpoints that are based on a string that the user can enter from the integrated development environment (IDE).
+
+## Syntax
+
+```cpp
+typedef struct _BP_LOCATION_DATA_STRING {
+   IDebugThread2* pThread;
+   BSTR           bstrContext;
+   BSTR           bstrDataExpr;
+   DWORD          dwNumElements;
+} BP_LOCATION_DATA_STRING;
+```
+
+## Members
+`pThread`  
+The [IDebugThread2](../../../extensibility/debugger/reference/idebugthread2.md) object that represents the thread on which the breakpoint occurs.
+
+`bstrContext`  
+The context of the breakpoint within the code, typically a method or function name as seen on a call stack.
+
+`bstrDataExpr`  
+The data string the user enters to set the breakpoint.
+
+`dwNumElements`  
+The number of elements in the data string in which the breakpoint occurs.
+
+## Remarks
+This structure is a member of the [BP_LOCATION](../../../extensibility/debugger/reference/bp-location.md) structure as part of a union.
+
+## Requirements
+Header: msdbg.h
+
+Namespace: Microsoft.VisualStudio.Debugger.Interop
+
+Assembly: Microsoft.VisualStudio.Debugger.Interop.dll
+
+## See Also
+[Structures and Unions](../../../extensibility/debugger/reference/structures-and-unions.md)  
+[BP_LOCATION](../../../extensibility/debugger/reference/bp-location.md)  
+[IDebugThread2](../../../extensibility/debugger/reference/idebugthread2.md)


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.