### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/bp-location-resolution.md
+++ b/docs/extensibility/debugger/reference/bp-location-resolution.md
@@ -20,7 +20,7 @@ Describes the resolution of a breakpoint at a specific location.
 
 ```cpp
 typedef struct _BP_LOCATION_RESOLUTION {
-   IDebugBreakpointResolution2* pResolution;
+    IDebugBreakpointResolution2* pResolution;
 } BP_LOCATION_RESOLUTION;
 ```
 

--- a/docs/extensibility/debugger/reference/bp-location-resolution.md
+++ b/docs/extensibility/debugger/reference/bp-location-resolution.md
@@ -2,43 +2,43 @@
 title: "BP_LOCATION_RESOLUTION | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-f1_keywords: 
+f1_keywords:
   - "BP_LOCATION_RESOLUTION"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "BP_LOCATION_RESOLUTION structure"
 ms.assetid: 86ea2c8a-54a3-48e8-83c7-18a515273129
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # BP_LOCATION_RESOLUTION
-Describes the resolution of a breakpoint at a specific location.  
-  
-## Syntax  
-  
-```cpp  
-typedef struct _BP_LOCATION_RESOLUTION {   
-   IDebugBreakpointResolution2* pResolution;  
-} BP_LOCATION_RESOLUTION;  
-```  
-  
-## Members  
- pResolution  
- The [IDebugBreakpointResolution2](../../../extensibility/debugger/reference/idebugbreakpointresolution2.md) object that determines the type of the breakpoint and its resolution information.  
-  
-## Remarks  
- This structure is a member of the [BP_LOCATION](../../../extensibility/debugger/reference/bp-location.md) structure as part of a union.  
-  
-## Requirements  
- Header: msdbg.h  
-  
- Namespace: Microsoft.VisualStudio.Debugger.Interop  
-  
- Assembly: Microsoft.VisualStudio.Debugger.Interop.dll  
-  
-## See Also  
- [Structures and Unions](../../../extensibility/debugger/reference/structures-and-unions.md)   
- [BP_LOCATION](../../../extensibility/debugger/reference/bp-location.md)   
- [IDebugBreakpointResolution2](../../../extensibility/debugger/reference/idebugbreakpointresolution2.md)
+Describes the resolution of a breakpoint at a specific location.
+
+## Syntax
+
+```cpp
+typedef struct _BP_LOCATION_RESOLUTION {
+   IDebugBreakpointResolution2* pResolution;
+} BP_LOCATION_RESOLUTION;
+```
+
+## Members
+pResolution  
+The [IDebugBreakpointResolution2](../../../extensibility/debugger/reference/idebugbreakpointresolution2.md) object that determines the type of the breakpoint and its resolution information.
+
+## Remarks
+This structure is a member of the [BP_LOCATION](../../../extensibility/debugger/reference/bp-location.md) structure as part of a union.
+
+## Requirements
+Header: msdbg.h
+
+Namespace: Microsoft.VisualStudio.Debugger.Interop
+
+Assembly: Microsoft.VisualStudio.Debugger.Interop.dll
+
+## See Also
+[Structures and Unions](../../../extensibility/debugger/reference/structures-and-unions.md)  
+[BP_LOCATION](../../../extensibility/debugger/reference/bp-location.md)  
+[IDebugBreakpointResolution2](../../../extensibility/debugger/reference/idebugbreakpointresolution2.md)


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.