### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/bp-passcount.md
+++ b/docs/extensibility/debugger/reference/bp-passcount.md
@@ -20,15 +20,15 @@ Describes the count and conditions upon which a conditional breakpoint is fired.
 
 ```cpp
 typedef struct _BP_PASSCOUNT {
-   DWORD              dwPassCount;
-   BP_PASSCOUNT_STYLE stylePassCount;
+    DWORD              dwPassCount;
+    BP_PASSCOUNT_STYLE stylePassCount;
 } BP_PASSCOUNT;
 ```
 
 ```csharp
 public struct BP_PASSCOUNT {
-   public uint dwPassCount;
-   public uint stylePassCount;
+    public uint dwPassCount;
+    public uint stylePassCount;
 };
 ```
 

--- a/docs/extensibility/debugger/reference/bp-passcount.md
+++ b/docs/extensibility/debugger/reference/bp-passcount.md
@@ -2,58 +2,58 @@
 title: "BP_PASSCOUNT | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-f1_keywords: 
+f1_keywords:
   - "BP_PASSCOUNT"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "BP_PASSCOUNT structure"
 ms.assetid: 791ac175-b897-4c70-873e-240da7e0ac89
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # BP_PASSCOUNT
-Describes the count and conditions upon which a conditional breakpoint is fired.  
-  
-## Syntax  
-  
-```cpp  
-typedef struct _BP_PASSCOUNT {   
-   DWORD              dwPassCount;  
-   BP_PASSCOUNT_STYLE stylePassCount;  
-} BP_PASSCOUNT;  
-```  
-  
-```csharp  
-public struct BP_PASSCOUNT {   
-   public uint dwPassCount;  
-   public uint stylePassCount;  
-};  
-```  
-  
-## Members  
- `dwPassCount`  
- The number of times to pass over the breakpoint before firing it.  
-  
- `stylePassCount`  
- A value from the [BP_PASSCOUNT_STYLE](../../../extensibility/debugger/reference/bp-passcount-style.md) enumeration that specifies the style of the breakpoint pass count.  
-  
-## Remarks  
- This structure is a member of the [BP_REQUEST_INFO](../../../extensibility/debugger/reference/bp-request-info.md) structure.  
-  
- This structure is also passed as a parameter to the[SetPassCount](../../../extensibility/debugger/reference/idebugboundbreakpoint2-setpasscount.md) and[SetPassCount](../../../extensibility/debugger/reference/idebugpendingbreakpoint2-setpasscount.md) methods.  
-  
-## Requirements  
- Header: msdbg.h  
-  
- Namespace: Microsoft.VisualStudio.Debugger.Interop  
-  
- Assembly: Microsoft.VisualStudio.Debugger.Interop.dll  
-  
-## See Also  
- [Structures and Unions](../../../extensibility/debugger/reference/structures-and-unions.md)   
- [BP_REQUEST_INFO](../../../extensibility/debugger/reference/bp-request-info.md)   
- [SetPassCount](../../../extensibility/debugger/reference/idebugboundbreakpoint2-setpasscount.md)   
- [SetPassCount](../../../extensibility/debugger/reference/idebugpendingbreakpoint2-setpasscount.md)   
- [BP_PASSCOUNT_STYLE](../../../extensibility/debugger/reference/bp-passcount-style.md)
+Describes the count and conditions upon which a conditional breakpoint is fired.
+
+## Syntax
+
+```cpp
+typedef struct _BP_PASSCOUNT {
+   DWORD              dwPassCount;
+   BP_PASSCOUNT_STYLE stylePassCount;
+} BP_PASSCOUNT;
+```
+
+```csharp
+public struct BP_PASSCOUNT {
+   public uint dwPassCount;
+   public uint stylePassCount;
+};
+```
+
+## Members
+`dwPassCount`  
+The number of times to pass over the breakpoint before firing it.
+
+`stylePassCount`  
+A value from the [BP_PASSCOUNT_STYLE](../../../extensibility/debugger/reference/bp-passcount-style.md) enumeration that specifies the style of the breakpoint pass count.
+
+## Remarks
+This structure is a member of the [BP_REQUEST_INFO](../../../extensibility/debugger/reference/bp-request-info.md) structure.
+
+This structure is also passed as a parameter to the[SetPassCount](../../../extensibility/debugger/reference/idebugboundbreakpoint2-setpasscount.md) and[SetPassCount](../../../extensibility/debugger/reference/idebugpendingbreakpoint2-setpasscount.md) methods.
+
+## Requirements
+Header: msdbg.h
+
+Namespace: Microsoft.VisualStudio.Debugger.Interop
+
+Assembly: Microsoft.VisualStudio.Debugger.Interop.dll
+
+## See Also
+[Structures and Unions](../../../extensibility/debugger/reference/structures-and-unions.md)  
+[BP_REQUEST_INFO](../../../extensibility/debugger/reference/bp-request-info.md)  
+[SetPassCount](../../../extensibility/debugger/reference/idebugboundbreakpoint2-setpasscount.md)  
+[SetPassCount](../../../extensibility/debugger/reference/idebugpendingbreakpoint2-setpasscount.md)  
+[BP_PASSCOUNT_STYLE](../../../extensibility/debugger/reference/bp-passcount-style.md)


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.