### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/bp-res-data-flags.md
+++ b/docs/extensibility/debugger/reference/bp-res-data-flags.md
@@ -20,14 +20,14 @@ Specifies whether the data breakpoint is being emulated or implemented in hardwa
 
 ```cpp
 enum enum_BP_RES_DATA_FLAGS {
-   BP_RES_DATA_EMULATED = 0x0001
+    BP_RES_DATA_EMULATED = 0x0001
 };
 typedef DWORD BP_RES_DATA_FLAGS;
 ```
 
 ```csharp
 public enum enum_BP_RES_DATA_FLAGS {
-   BP_RES_DATA_EMULATED = 0x0001
+    BP_RES_DATA_EMULATED = 0x0001
 };
 ```
 

--- a/docs/extensibility/debugger/reference/bp-res-data-flags.md
+++ b/docs/extensibility/debugger/reference/bp-res-data-flags.md
@@ -2,49 +2,49 @@
 title: "BP_RES_DATA_FLAGS | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-f1_keywords: 
+f1_keywords:
   - "BP_RES_DATA_FLAGS"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "BP_RES_DATA_FLAGS enumeration"
 ms.assetid: d97611e2-def6-45a9-ad7d-eedf2ad4c82b
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # BP_RES_DATA_FLAGS
-Specifies whether the data breakpoint is being emulated or implemented in hardware.  
-  
-## Syntax  
-  
-```cpp  
-enum enum_BP_RES_DATA_FLAGS {   
-   BP_RES_DATA_EMULATED = 0x0001  
-};  
-typedef DWORD BP_RES_DATA_FLAGS;  
-```  
-  
-```csharp  
-public enum enum_BP_RES_DATA_FLAGS {   
-   BP_RES_DATA_EMULATED = 0x0001  
-};  
-```  
-  
-## Members  
- BP_RES_DATA_EMULATED  
- Specifies that the data breakpoint is being emulated.  
-  
-## Remarks  
- Used for the `dwFlags` member of the [BP_RESOLUTION_DATA](../../../extensibility/debugger/reference/bp-resolution-data.md) structure.  
-  
-## Requirements  
- Header: msdbg.h  
-  
- Namespace: Microsoft.VisualStudio.Debugger.Interop  
-  
- Assembly: Microsoft.VisualStudio.Debugger.Interop.dll  
-  
-## See Also  
- [Enumerations](../../../extensibility/debugger/reference/enumerations-visual-studio-debugging.md)   
- [BP_RESOLUTION_DATA](../../../extensibility/debugger/reference/bp-resolution-data.md)
+Specifies whether the data breakpoint is being emulated or implemented in hardware.
+
+## Syntax
+
+```cpp
+enum enum_BP_RES_DATA_FLAGS {
+   BP_RES_DATA_EMULATED = 0x0001
+};
+typedef DWORD BP_RES_DATA_FLAGS;
+```
+
+```csharp
+public enum enum_BP_RES_DATA_FLAGS {
+   BP_RES_DATA_EMULATED = 0x0001
+};
+```
+
+## Members
+BP_RES_DATA_EMULATED  
+Specifies that the data breakpoint is being emulated.
+
+## Remarks
+Used for the `dwFlags` member of the [BP_RESOLUTION_DATA](../../../extensibility/debugger/reference/bp-resolution-data.md) structure.
+
+## Requirements
+Header: msdbg.h
+
+Namespace: Microsoft.VisualStudio.Debugger.Interop
+
+Assembly: Microsoft.VisualStudio.Debugger.Interop.dll
+
+## See Also
+[Enumerations](../../../extensibility/debugger/reference/enumerations-visual-studio-debugging.md)  
+[BP_RESOLUTION_DATA](../../../extensibility/debugger/reference/bp-resolution-data.md)


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.