### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/bp-resolution-code.md
+++ b/docs/extensibility/debugger/reference/bp-resolution-code.md
@@ -2,51 +2,51 @@
 title: "BP_RESOLUTION_CODE | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-f1_keywords: 
+f1_keywords:
   - "BP_RESOLUTION_CODE"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "BP_RESOLUTION_CODE structure"
 ms.assetid: ac103ec5-771c-4667-92de-b5abb53bbb52
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # BP_RESOLUTION_CODE
-Describes the location of a code breakpoint.  
-  
-## Syntax  
-  
-```cpp  
-typedef struct _BP_RESOLUTION_CODE {   
-   IDebugCodeContext2* pCodeContext;  
-} BP_RESOLUTION_CODE;  
-```  
-  
-```csharp  
-public struct BP_RESOLUTION_CODE {   
-   public IDebugCodeContext2 pCodeContext;  
-};  
-```  
-  
-## Members  
- `pCodeContext`  
- The [IDebugCodeContext2](../../../extensibility/debugger/reference/idebugcodecontext2.md) object that identifies the position of the breakpoint in the code.  
-  
-## Remarks  
- This structure is a member of the [BP_RESOLUTION_LOCATION](../../../extensibility/debugger/reference/bp-resolution-location.md) structure, which is in turn a member of the [BP_RESOLUTION_INFO](../../../extensibility/debugger/reference/bp-resolution-info.md) structure returned by the [GetResolutionInfo](../../../extensibility/debugger/reference/idebugbreakpointresolution2-getresolutioninfo.md) method.  
-  
-## Requirements  
- Header: msdbg.h  
-  
- Namespace: Microsoft.VisualStudio.Debugger.Interop  
-  
- Assembly: Microsoft.VisualStudio.Debugger.Interop.dll  
-  
-## See Also  
- [Structures and Unions](../../../extensibility/debugger/reference/structures-and-unions.md)   
- [BP_RESOLUTION_LOCATION](../../../extensibility/debugger/reference/bp-resolution-location.md)   
- [BP_RESOLUTION_INFO](../../../extensibility/debugger/reference/bp-resolution-info.md)   
- [GetResolutionInfo](../../../extensibility/debugger/reference/idebugbreakpointresolution2-getresolutioninfo.md)   
- [IDebugCodeContext2](../../../extensibility/debugger/reference/idebugcodecontext2.md)
+Describes the location of a code breakpoint.
+
+## Syntax
+
+```cpp
+typedef struct _BP_RESOLUTION_CODE {
+   IDebugCodeContext2* pCodeContext;
+} BP_RESOLUTION_CODE;
+```
+
+```csharp
+public struct BP_RESOLUTION_CODE {
+   public IDebugCodeContext2 pCodeContext;
+};
+```
+
+## Members
+`pCodeContext`  
+The [IDebugCodeContext2](../../../extensibility/debugger/reference/idebugcodecontext2.md) object that identifies the position of the breakpoint in the code.
+
+## Remarks
+This structure is a member of the [BP_RESOLUTION_LOCATION](../../../extensibility/debugger/reference/bp-resolution-location.md) structure, which is in turn a member of the [BP_RESOLUTION_INFO](../../../extensibility/debugger/reference/bp-resolution-info.md) structure returned by the [GetResolutionInfo](../../../extensibility/debugger/reference/idebugbreakpointresolution2-getresolutioninfo.md) method.
+
+## Requirements
+Header: msdbg.h
+
+Namespace: Microsoft.VisualStudio.Debugger.Interop
+
+Assembly: Microsoft.VisualStudio.Debugger.Interop.dll
+
+## See Also
+[Structures and Unions](../../../extensibility/debugger/reference/structures-and-unions.md)  
+[BP_RESOLUTION_LOCATION](../../../extensibility/debugger/reference/bp-resolution-location.md)  
+[BP_RESOLUTION_INFO](../../../extensibility/debugger/reference/bp-resolution-info.md)  
+[GetResolutionInfo](../../../extensibility/debugger/reference/idebugbreakpointresolution2-getresolutioninfo.md)  
+[IDebugCodeContext2](../../../extensibility/debugger/reference/idebugcodecontext2.md)

--- a/docs/extensibility/debugger/reference/bp-resolution-code.md
+++ b/docs/extensibility/debugger/reference/bp-resolution-code.md
@@ -20,13 +20,13 @@ Describes the location of a code breakpoint.
 
 ```cpp
 typedef struct _BP_RESOLUTION_CODE {
-   IDebugCodeContext2* pCodeContext;
+    IDebugCodeContext2* pCodeContext;
 } BP_RESOLUTION_CODE;
 ```
 
 ```csharp
 public struct BP_RESOLUTION_CODE {
-   public IDebugCodeContext2 pCodeContext;
+    public IDebugCodeContext2 pCodeContext;
 };
 ```
 


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.