### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/bp-resolution-data.md
+++ b/docs/extensibility/debugger/reference/bp-resolution-data.md
@@ -20,19 +20,19 @@ Describes the result of binding a data breakpoint.
 
 ```cpp
 typedef struct _BP_RESOLUTION_DATA {
-   BSTR              bstrDataExpr;
-   BSTR              bstrFunc;
-   BSTR              bstrImage;
-   BP_RES_DATA_FLAGS dwFlags;
+    BSTR              bstrDataExpr;
+    BSTR              bstrFunc;
+    BSTR              bstrImage;
+    BP_RES_DATA_FLAGS dwFlags;
 } BP_RESOLUTION_DATA;
 ```
 
 ```csharp
 public struct BP_RESOLUTION_DATA {
-   public string bstrDataExpr;
-   public string bstrFunc;
-   public string bstrImage;
-   public uint   dwFlags;
+    public string bstrDataExpr;
+    public string bstrFunc;
+    public string bstrImage;
+    public uint   dwFlags;
 };
 ```
 

--- a/docs/extensibility/debugger/reference/bp-resolution-data.md
+++ b/docs/extensibility/debugger/reference/bp-resolution-data.md
@@ -2,65 +2,65 @@
 title: "BP_RESOLUTION_DATA | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-f1_keywords: 
+f1_keywords:
   - "BP_RESOLUTION_DATA"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "BP_RESOLUTION_DATA structure"
 ms.assetid: 9e0b9000-6a84-47b9-b07a-367a75764389
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # BP_RESOLUTION_DATA
-Describes the result of binding a data breakpoint.  
-  
-## Syntax  
-  
-```cpp  
-typedef struct _BP_RESOLUTION_DATA {   
-   BSTR              bstrDataExpr;  
-   BSTR              bstrFunc;  
-   BSTR              bstrImage;  
-   BP_RES_DATA_FLAGS dwFlags;  
-} BP_RESOLUTION_DATA;  
-```  
-  
-```csharp  
-public struct BP_RESOLUTION_DATA {   
-   public string bstrDataExpr;  
-   public string bstrFunc;  
-   public string bstrImage;  
-   public uint   dwFlags;  
-};  
-```  
-  
-## Members  
- `bstrDataExpr`  
- The data expression that has been bound.  
-  
- `bstrFunc`  
- The name of the function the data breakpoint has bound in (if any).  
-  
- `bstrImage`  
- The name of the module (MyModule.dll, for example) that the data breakpoint has bound in.  
-  
- `dwFlags`  
- A value from the [BP_RES_DATA_FLAGS](../../../extensibility/debugger/reference/bp-res-data-flags.md) enumeration, describing how the data breakpoint is implemented.  
-  
-## Remarks  
- This structure is a member of the [BP_RESOLUTION_LOCATION](../../../extensibility/debugger/reference/bp-resolution-location.md) structure, which is in turn a member of the [BP_RESOLUTION_INFO](../../../extensibility/debugger/reference/bp-resolution-info.md) structure returned by the [GetResolutionInfo](../../../extensibility/debugger/reference/idebugbreakpointresolution2-getresolutioninfo.md) method.  
-  
-## Requirements  
- Header: msdbg.h  
-  
- Namespace: Microsoft.VisualStudio.Debugger.Interop  
-  
- Assembly: Microsoft.VisualStudio.Debugger.Interop.dll  
-  
-## See Also  
- [Structures and Unions](../../../extensibility/debugger/reference/structures-and-unions.md)   
- [BP_RESOLUTION_LOCATION](../../../extensibility/debugger/reference/bp-resolution-location.md)   
- [BP_RESOLUTION_INFO](../../../extensibility/debugger/reference/bp-resolution-info.md)   
- [GetResolutionInfo](../../../extensibility/debugger/reference/idebugbreakpointresolution2-getresolutioninfo.md)
+Describes the result of binding a data breakpoint.
+
+## Syntax
+
+```cpp
+typedef struct _BP_RESOLUTION_DATA {
+   BSTR              bstrDataExpr;
+   BSTR              bstrFunc;
+   BSTR              bstrImage;
+   BP_RES_DATA_FLAGS dwFlags;
+} BP_RESOLUTION_DATA;
+```
+
+```csharp
+public struct BP_RESOLUTION_DATA {
+   public string bstrDataExpr;
+   public string bstrFunc;
+   public string bstrImage;
+   public uint   dwFlags;
+};
+```
+
+## Members
+`bstrDataExpr`  
+The data expression that has been bound.
+
+`bstrFunc`  
+The name of the function the data breakpoint has bound in (if any).
+
+`bstrImage`  
+The name of the module (MyModule.dll, for example) that the data breakpoint has bound in.
+
+`dwFlags`  
+A value from the [BP_RES_DATA_FLAGS](../../../extensibility/debugger/reference/bp-res-data-flags.md) enumeration, describing how the data breakpoint is implemented.
+
+## Remarks
+This structure is a member of the [BP_RESOLUTION_LOCATION](../../../extensibility/debugger/reference/bp-resolution-location.md) structure, which is in turn a member of the [BP_RESOLUTION_INFO](../../../extensibility/debugger/reference/bp-resolution-info.md) structure returned by the [GetResolutionInfo](../../../extensibility/debugger/reference/idebugbreakpointresolution2-getresolutioninfo.md) method.
+
+## Requirements
+Header: msdbg.h
+
+Namespace: Microsoft.VisualStudio.Debugger.Interop
+
+Assembly: Microsoft.VisualStudio.Debugger.Interop.dll
+
+## See Also
+[Structures and Unions](../../../extensibility/debugger/reference/structures-and-unions.md)  
+[BP_RESOLUTION_LOCATION](../../../extensibility/debugger/reference/bp-resolution-location.md)  
+[BP_RESOLUTION_INFO](../../../extensibility/debugger/reference/bp-resolution-info.md)  
+[GetResolutionInfo](../../../extensibility/debugger/reference/idebugbreakpointresolution2-getresolutioninfo.md)


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.