### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/bp-resolution-info.md
+++ b/docs/extensibility/debugger/reference/bp-resolution-info.md
@@ -20,19 +20,19 @@ Describes the bound breakpoint information for either a code breakpoint or a dat
 
 ```cpp
 typedef struct _BP_RESOLUTION_INFO {
-   BPRESI_FIELDS          dwFields;
-   BP_RESOLUTION_LOCATION bpResLocation;
-   IDebugProgram2*        pProgram;
-   IDebugThread2*         pThread;
+    BPRESI_FIELDS          dwFields;
+    BP_RESOLUTION_LOCATION bpResLocation;
+    IDebugProgram2*        pProgram;
+    IDebugThread2*         pThread;
 } BP_RESOLUTION_INFO;
 ```
 
 ```csharp
 public struct BP_RESOLUTION_INFO {
-   public uint                   dwFields;
-   public BP_RESOLUTION_LOCATION bpResLocation;
-   public IDebugProgram2         pProgram;
-   public IDebugThread2          pThread;
+    public uint                   dwFields;
+    public BP_RESOLUTION_LOCATION bpResLocation;
+    public IDebugProgram2         pProgram;
+    public IDebugThread2          pThread;
 };
 ```
 

--- a/docs/extensibility/debugger/reference/bp-resolution-info.md
+++ b/docs/extensibility/debugger/reference/bp-resolution-info.md
@@ -2,67 +2,67 @@
 title: "BP_RESOLUTION_INFO | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-f1_keywords: 
+f1_keywords:
   - "BP_RESOLUTION_INFO"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "BP_RESOLUTION_INFO structure"
 ms.assetid: ba0c162a-61e8-4a0b-811f-4c1d8a5d82f0
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # BP_RESOLUTION_INFO
-Describes the bound breakpoint information for either a code breakpoint or a data breakpoint.  
-  
-## Syntax  
-  
-```cpp  
-typedef struct _BP_RESOLUTION_INFO {   
-   BPRESI_FIELDS          dwFields;  
-   BP_RESOLUTION_LOCATION bpResLocation;  
-   IDebugProgram2*        pProgram;  
-   IDebugThread2*         pThread;  
-} BP_RESOLUTION_INFO;  
-```  
-  
-```csharp  
-public struct BP_RESOLUTION_INFO {   
-   public uint                   dwFields;  
-   public BP_RESOLUTION_LOCATION bpResLocation;  
-   public IDebugProgram2         pProgram;  
-   public IDebugThread2          pThread;  
-};  
-```  
-  
-## Members  
- `dwFields`  
- A collection of flags from the [BPRESI_FIELDS](../../../extensibility/debugger/reference/bpresi-fields.md) enumerations that specifies which fields are filled out.  
-  
- `bpResLocation`  
- The [BP_RESOLUTION_LOCATION](../../../extensibility/debugger/reference/bp-resolution-location.md) structure that specifies the location of the breakpoint in code or data.  
-  
- `pProgram`  
- The [IDebugProgram2](../../../extensibility/debugger/reference/idebugprogram2.md) object that represents the application in which the breakpoint error occurred.  
-  
- `pThread`  
- The [IDebugThread2](../../../extensibility/debugger/reference/idebugthread2.md) object that represents the thread in which the application that contains the breakpoint error is running.  
-  
-## Remarks  
- This structure is returned by [GetResolutionInfo](../../../extensibility/debugger/reference/idebugbreakpointresolution2-getresolutioninfo.md).  
-  
-## Requirements  
- Header: msdbg.h  
-  
- Namespace: Microsoft.VisualStudio.Debugger.Interop  
-  
- Assembly: Microsoft.VisualStudio.Debugger.Interop.dll  
-  
-## See Also  
- [Structures and Unions](../../../extensibility/debugger/reference/structures-and-unions.md)   
- [GetResolutionInfo](../../../extensibility/debugger/reference/idebugbreakpointresolution2-getresolutioninfo.md)   
- [BPRESI_FIELDS](../../../extensibility/debugger/reference/bpresi-fields.md)   
- [BP_RESOLUTION_LOCATION](../../../extensibility/debugger/reference/bp-resolution-location.md)   
- [IDebugProgram2](../../../extensibility/debugger/reference/idebugprogram2.md)   
- [IDebugThread2](../../../extensibility/debugger/reference/idebugthread2.md)
+Describes the bound breakpoint information for either a code breakpoint or a data breakpoint.
+
+## Syntax
+
+```cpp
+typedef struct _BP_RESOLUTION_INFO {
+   BPRESI_FIELDS          dwFields;
+   BP_RESOLUTION_LOCATION bpResLocation;
+   IDebugProgram2*        pProgram;
+   IDebugThread2*         pThread;
+} BP_RESOLUTION_INFO;
+```
+
+```csharp
+public struct BP_RESOLUTION_INFO {
+   public uint                   dwFields;
+   public BP_RESOLUTION_LOCATION bpResLocation;
+   public IDebugProgram2         pProgram;
+   public IDebugThread2          pThread;
+};
+```
+
+## Members
+`dwFields`  
+A collection of flags from the [BPRESI_FIELDS](../../../extensibility/debugger/reference/bpresi-fields.md) enumerations that specifies which fields are filled out.
+
+`bpResLocation`  
+The [BP_RESOLUTION_LOCATION](../../../extensibility/debugger/reference/bp-resolution-location.md) structure that specifies the location of the breakpoint in code or data.
+
+`pProgram`  
+The [IDebugProgram2](../../../extensibility/debugger/reference/idebugprogram2.md) object that represents the application in which the breakpoint error occurred.
+
+`pThread`  
+The [IDebugThread2](../../../extensibility/debugger/reference/idebugthread2.md) object that represents the thread in which the application that contains the breakpoint error is running.
+
+## Remarks
+This structure is returned by [GetResolutionInfo](../../../extensibility/debugger/reference/idebugbreakpointresolution2-getresolutioninfo.md).
+
+## Requirements
+Header: msdbg.h
+
+Namespace: Microsoft.VisualStudio.Debugger.Interop
+
+Assembly: Microsoft.VisualStudio.Debugger.Interop.dll
+
+## See Also
+[Structures and Unions](../../../extensibility/debugger/reference/structures-and-unions.md)  
+[GetResolutionInfo](../../../extensibility/debugger/reference/idebugbreakpointresolution2-getresolutioninfo.md)  
+[BPRESI_FIELDS](../../../extensibility/debugger/reference/bpresi-fields.md)  
+[BP_RESOLUTION_LOCATION](../../../extensibility/debugger/reference/bp-resolution-location.md)  
+[IDebugProgram2](../../../extensibility/debugger/reference/idebugprogram2.md)  
+[IDebugThread2](../../../extensibility/debugger/reference/idebugthread2.md)


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.