### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/bp-type.md
+++ b/docs/extensibility/debugger/reference/bp-type.md
@@ -2,65 +2,65 @@
 title: "BP_TYPE | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-f1_keywords: 
+f1_keywords:
   - "BP_TYPE"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "BP_TYPE enumeration"
 ms.assetid: ef07191e-7966-43ab-96fb-1a0b1db3115d
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # BP_TYPE
-Specifies whether the breakpoint is at a code location, is a data location, or is another type of breakpoint.  
-  
-## Syntax  
-  
-```cpp  
-enum enum_BP_TYPE {   
-   BPT_NONE    = 0x0000,  
-   BPT_CODE    = 0x0001,  
-   BPT_DATA    = 0x0002,  
-   BPT_SPECIAL = 0x0003  
-};  
-typedef DWORD BP_TYPE;  
-```  
-  
-```csharp  
-public enum enum_BP_TYPE {   
-   BPT_NONE    = 0x0000,  
-   BPT_CODE    = 0x0001,  
-   BPT_DATA    = 0x0002,  
-   BPT_SPECIAL = 0x0003  
-};  
-```  
-  
-## Members  
- BPT_NONE  
- Specifies no breakpoint type.  
-  
- BPT_CODE  
- Specifies a code breakpoint.  
-  
- BPT_DATA  
- Specifies a data breakpoint.  
-  
- BPT_SPECIAL  
- Specifies a breakpoint that is neither a code nor a data type. This type is deprecated and should not be used.  
-  
-## Remarks  
- Passed as a parameter to the [GetBreakpointType](../../../extensibility/debugger/reference/idebugbreakpointresolution2-getbreakpointtype.md) and [GetBreakpointType](../../../extensibility/debugger/reference/idebugerrorbreakpointresolution2-getbreakpointtype.md) methods.  
-  
-## Requirements  
- Header: msdbg.h  
-  
- Namespace: Microsoft.VisualStudio.Debugger.Interop  
-  
- Assembly: Microsoft.VisualStudio.Debugger.Interop.dll  
-  
-## See Also  
- [Enumerations](../../../extensibility/debugger/reference/enumerations-visual-studio-debugging.md)   
- [GetBreakpointType](../../../extensibility/debugger/reference/idebugbreakpointresolution2-getbreakpointtype.md)   
- [GetBreakpointType](../../../extensibility/debugger/reference/idebugerrorbreakpointresolution2-getbreakpointtype.md)
+Specifies whether the breakpoint is at a code location, is a data location, or is another type of breakpoint.
+
+## Syntax
+
+```cpp
+enum enum_BP_TYPE {
+   BPT_NONE    = 0x0000,
+   BPT_CODE    = 0x0001,
+   BPT_DATA    = 0x0002,
+   BPT_SPECIAL = 0x0003
+};
+typedef DWORD BP_TYPE;
+```
+
+```csharp
+public enum enum_BP_TYPE {
+   BPT_NONE    = 0x0000,
+   BPT_CODE    = 0x0001,
+   BPT_DATA    = 0x0002,
+   BPT_SPECIAL = 0x0003
+};
+```
+
+## Members
+BPT_NONE  
+Specifies no breakpoint type.
+
+BPT_CODE  
+Specifies a code breakpoint.
+
+BPT_DATA  
+Specifies a data breakpoint.
+
+BPT_SPECIAL  
+Specifies a breakpoint that is neither a code nor a data type. This type is deprecated and should not be used.
+
+## Remarks
+Passed as a parameter to the [GetBreakpointType](../../../extensibility/debugger/reference/idebugbreakpointresolution2-getbreakpointtype.md) and [GetBreakpointType](../../../extensibility/debugger/reference/idebugerrorbreakpointresolution2-getbreakpointtype.md) methods.
+
+## Requirements
+Header: msdbg.h
+
+Namespace: Microsoft.VisualStudio.Debugger.Interop
+
+Assembly: Microsoft.VisualStudio.Debugger.Interop.dll
+
+## See Also
+[Enumerations](../../../extensibility/debugger/reference/enumerations-visual-studio-debugging.md)  
+[GetBreakpointType](../../../extensibility/debugger/reference/idebugbreakpointresolution2-getbreakpointtype.md)  
+[GetBreakpointType](../../../extensibility/debugger/reference/idebugerrorbreakpointresolution2-getbreakpointtype.md)

--- a/docs/extensibility/debugger/reference/bp-type.md
+++ b/docs/extensibility/debugger/reference/bp-type.md
@@ -20,20 +20,20 @@ Specifies whether the breakpoint is at a code location, is a data location, or i
 
 ```cpp
 enum enum_BP_TYPE {
-   BPT_NONE    = 0x0000,
-   BPT_CODE    = 0x0001,
-   BPT_DATA    = 0x0002,
-   BPT_SPECIAL = 0x0003
+    BPT_NONE    = 0x0000,
+    BPT_CODE    = 0x0001,
+    BPT_DATA    = 0x0002,
+    BPT_SPECIAL = 0x0003
 };
 typedef DWORD BP_TYPE;
 ```
 
 ```csharp
 public enum enum_BP_TYPE {
-   BPT_NONE    = 0x0000,
-   BPT_CODE    = 0x0001,
-   BPT_DATA    = 0x0002,
-   BPT_SPECIAL = 0x0003
+    BPT_NONE    = 0x0000,
+    BPT_CODE    = 0x0001,
+    BPT_DATA    = 0x0002,
+    BPT_SPECIAL = 0x0003
 };
 ```
 


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.