### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/bperesi-fields.md
+++ b/docs/extensibility/debugger/reference/bperesi-fields.md
@@ -20,24 +20,24 @@ Specifies the information to be retrieved about a failed resolution of a breakpo
 
 ```cpp
 enum enum_BPERESI_FIELDS {
-   PERESI_BPRESLOCATION = 0x0001,
-   BPERESI_PROGRAM      = 0x0002,
-   BPERESI_THREAD       = 0x0004,
-   BPERESI_MESSAGE      = 0x0008,
-   BPERESI_TYPE         = 0x0010,
-   BPERESI_ALLFIELDS    = 0xffffffff
+    PERESI_BPRESLOCATION = 0x0001,
+    BPERESI_PROGRAM      = 0x0002,
+    BPERESI_THREAD       = 0x0004,
+    BPERESI_MESSAGE      = 0x0008,
+    BPERESI_TYPE         = 0x0010,
+    BPERESI_ALLFIELDS    = 0xffffffff
 };
 typedef DWORD BPERESI_FIELDS;
 ```
 
 ```csharp
 public enum enum_BPERESI_FIELDS {
-   PERESI_BPRESLOCATION = 0x0001,
-   BPERESI_PROGRAM      = 0x0002,
-   BPERESI_THREAD       = 0x0004,
-   BPERESI_MESSAGE      = 0x0008,
-   BPERESI_TYPE         = 0x0010,
-   BPERESI_ALLFIELDS    = 0xffffffff
+    PERESI_BPRESLOCATION = 0x0001,
+    BPERESI_PROGRAM      = 0x0002,
+    BPERESI_THREAD       = 0x0004,
+    BPERESI_MESSAGE      = 0x0008,
+    BPERESI_TYPE         = 0x0010,
+    BPERESI_ALLFIELDS    = 0xffffffff
 };
 ```
 

--- a/docs/extensibility/debugger/reference/bperesi-fields.md
+++ b/docs/extensibility/debugger/reference/bperesi-fields.md
@@ -2,79 +2,79 @@
 title: "BPERESI_FIELDS | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-f1_keywords: 
+f1_keywords:
   - "BPERESI_FIELDS"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "BPERESI_FIELDS enumeration"
 ms.assetid: dd7dd89c-1043-46a1-a929-099cc039c344
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # BPERESI_FIELDS
-Specifies the information to be retrieved about a failed resolution of a breakpoint.  
-  
-## Syntax  
-  
-```cpp  
-enum enum_BPERESI_FIELDS {   
-   PERESI_BPRESLOCATION = 0x0001,  
-   BPERESI_PROGRAM      = 0x0002,  
-   BPERESI_THREAD       = 0x0004,  
-   BPERESI_MESSAGE      = 0x0008,  
-   BPERESI_TYPE         = 0x0010,  
-   BPERESI_ALLFIELDS    = 0xffffffff  
-};  
-typedef DWORD BPERESI_FIELDS;  
-```  
-  
-```csharp  
-public enum enum_BPERESI_FIELDS {   
-   PERESI_BPRESLOCATION = 0x0001,  
-   BPERESI_PROGRAM      = 0x0002,  
-   BPERESI_THREAD       = 0x0004,  
-   BPERESI_MESSAGE      = 0x0008,  
-   BPERESI_TYPE         = 0x0010,  
-   BPERESI_ALLFIELDS    = 0xffffffff  
-};  
-```  
-  
-## Members  
- PERESI_BPRESLOCATION  
- Initialize/use the `bpResLocation` (breakpoint resolution location) field of the [BP_ERROR_RESOLUTION_INFO](../../../extensibility/debugger/reference/bp-error-resolution-info.md) structure.  
-  
- BPERESI_PROGRAM  
- Initialize/use the `pProgram` field of the `BP_ERROR_RESOLUTION_INFO` structure.  
-  
- BPERESI_THREAD  
- Initialize/use the `pThread` field of the `BP_ERROR_RESOLUTION_INFO` structure.  
-  
- BPERESI_MESSAGE  
- Initialize/use the `bstrMessage` field of the `BP_ERROR_RESOLUTION_INFO` structure.  
-  
- BPERESI_TYPE  
- Initialize/use the `dwType` (breakpoint type) field of the `BP_ERROR_RESOLUTION_INFO` structure.  
-  
- BPERESI_ALLFIELDS  
- Initialize/use all fields of the `BP_ERROR_RESOLUTION_INFO` structure.  
-  
-## Remarks  
- Passed as a parameter to the [GetResolutionInfo](../../../extensibility/debugger/reference/idebugerrorbreakpointresolution2-getresolutioninfo.md) method to indicate which fields of the [BP_ERROR_RESOLUTION_INFO](../../../extensibility/debugger/reference/bp-error-resolution-info.md) structure are to be initialized.  
-  
- These values are also used to indicate which fields in the `BP_ERROR_RESOLUTION_INFO` structure are used and valid when that structure is returned.  
-  
- These values may be combined with a bitwise `OR`.  
-  
-## Requirements  
- Header: msdbg.h  
-  
- Namespace: Microsoft.VisualStudio.Debugger.Interop  
-  
- Assembly: Microsoft.VisualStudio.Debugger.Interop.dll  
-  
-## See Also  
- [Enumerations](../../../extensibility/debugger/reference/enumerations-visual-studio-debugging.md)   
- [BP_ERROR_RESOLUTION_INFO](../../../extensibility/debugger/reference/bp-error-resolution-info.md)   
- [GetResolutionInfo](../../../extensibility/debugger/reference/idebugerrorbreakpointresolution2-getresolutioninfo.md)
+Specifies the information to be retrieved about a failed resolution of a breakpoint.
+
+## Syntax
+
+```cpp
+enum enum_BPERESI_FIELDS {
+   PERESI_BPRESLOCATION = 0x0001,
+   BPERESI_PROGRAM      = 0x0002,
+   BPERESI_THREAD       = 0x0004,
+   BPERESI_MESSAGE      = 0x0008,
+   BPERESI_TYPE         = 0x0010,
+   BPERESI_ALLFIELDS    = 0xffffffff
+};
+typedef DWORD BPERESI_FIELDS;
+```
+
+```csharp
+public enum enum_BPERESI_FIELDS {
+   PERESI_BPRESLOCATION = 0x0001,
+   BPERESI_PROGRAM      = 0x0002,
+   BPERESI_THREAD       = 0x0004,
+   BPERESI_MESSAGE      = 0x0008,
+   BPERESI_TYPE         = 0x0010,
+   BPERESI_ALLFIELDS    = 0xffffffff
+};
+```
+
+## Members
+PERESI_BPRESLOCATION  
+Initialize/use the `bpResLocation` (breakpoint resolution location) field of the [BP_ERROR_RESOLUTION_INFO](../../../extensibility/debugger/reference/bp-error-resolution-info.md) structure.
+
+BPERESI_PROGRAM  
+Initialize/use the `pProgram` field of the `BP_ERROR_RESOLUTION_INFO` structure.
+
+BPERESI_THREAD  
+Initialize/use the `pThread` field of the `BP_ERROR_RESOLUTION_INFO` structure.
+
+BPERESI_MESSAGE  
+Initialize/use the `bstrMessage` field of the `BP_ERROR_RESOLUTION_INFO` structure.
+
+BPERESI_TYPE  
+Initialize/use the `dwType` (breakpoint type) field of the `BP_ERROR_RESOLUTION_INFO` structure.
+
+BPERESI_ALLFIELDS  
+Initialize/use all fields of the `BP_ERROR_RESOLUTION_INFO` structure.
+
+## Remarks
+Passed as a parameter to the [GetResolutionInfo](../../../extensibility/debugger/reference/idebugerrorbreakpointresolution2-getresolutioninfo.md) method to indicate which fields of the [BP_ERROR_RESOLUTION_INFO](../../../extensibility/debugger/reference/bp-error-resolution-info.md) structure are to be initialized.
+
+These values are also used to indicate which fields in the `BP_ERROR_RESOLUTION_INFO` structure are used and valid when that structure is returned.
+
+These values may be combined with a bitwise `OR`.
+
+## Requirements
+Header: msdbg.h
+
+Namespace: Microsoft.VisualStudio.Debugger.Interop
+
+Assembly: Microsoft.VisualStudio.Debugger.Interop.dll
+
+## See Also
+[Enumerations](../../../extensibility/debugger/reference/enumerations-visual-studio-debugging.md)  
+[BP_ERROR_RESOLUTION_INFO](../../../extensibility/debugger/reference/bp-error-resolution-info.md)  
+[GetResolutionInfo](../../../extensibility/debugger/reference/idebugerrorbreakpointresolution2-getresolutioninfo.md)


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.