### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/idebugbreakpointresolution2-getbreakpointtype.md
+++ b/docs/extensibility/debugger/reference/idebugbreakpointresolution2-getbreakpointtype.md
@@ -20,13 +20,13 @@ Gets the type of the breakpoint represented by this resolution.
 
 ```cpp
 HRESULT GetBreakpointType( 
-   BP_TYPE* pBPType
+    BP_TYPE* pBPType
 );
 ```
 
 ```csharp
 int GetBreakpointType( 
-   out enum_ BP_TYPE pBPType
+    out enum_ BP_TYPE pBPType
 );
 ```
 
@@ -46,31 +46,31 @@ The following example shows how to implement this method for a simple `CDebugBre
 ```
 HRESULT CDebugBreakpointResolution::GetBreakpointType(BP_TYPE* pBPType)
 {
-   HRESULT hr;
+    HRESULT hr;
 
-   if (pBPType)
-   {
-      // Set default BP_TYPE.
-      *pBPType = BPT_NONE;
+    if (pBPType)
+    {
+        // Set default BP_TYPE.
+        *pBPType = BPT_NONE;
 
-      // Check if the BPRESI_BPRESLOCATION flag is set in BPRESI_FIELDS.
-      if (IsFlagSet(m_bpResolutionInfo.dwFields, BPRESI_BPRESLOCATION))
-      {
-         // Set the new BP_TYPE.
-         *pBPType = m_bpResolutionInfo.bpResLocation.bpType;
-         hr = S_OK;
-      }
-      else
-      {
-         hr = E_FAIL;
-      }
-   }
-   else
-   {
-      hr = E_INVALIDARG;
-   }
+        // Check if the BPRESI_BPRESLOCATION flag is set in BPRESI_FIELDS.
+        if (IsFlagSet(m_bpResolutionInfo.dwFields, BPRESI_BPRESLOCATION))
+        {
+            // Set the new BP_TYPE.
+            *pBPType = m_bpResolutionInfo.bpResLocation.bpType;
+            hr = S_OK;
+        }
+        else
+        {
+            hr = E_FAIL;
+        }
+    }
+    else
+    {
+        hr = E_INVALIDARG;
+    }
 
-   return hr;
+    return hr;
 }
 ```
 

--- a/docs/extensibility/debugger/reference/idebugbreakpointresolution2-getbreakpointtype.md
+++ b/docs/extensibility/debugger/reference/idebugbreakpointresolution2-getbreakpointtype.md
@@ -2,81 +2,81 @@
 title: "IDebugBreakpointResolution2::GetBreakpointType | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-f1_keywords: 
+f1_keywords:
   - "IDebugBreakpointResolution2::GetBreakpointType"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "IDebugBreakpointResolution2::GetBreakpointType"
 ms.assetid: 2b707fb9-f703-4c78-91bf-7434f57790a0
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # IDebugBreakpointResolution2::GetBreakpointType
-Gets the type of the breakpoint represented by this resolution.  
-  
-## Syntax  
-  
-```cpp  
-HRESULT GetBreakpointType(   
-   BP_TYPE* pBPType  
-);  
-```  
-  
-```csharp  
-int GetBreakpointType(   
-   out enum_ BP_TYPE pBPType  
-);  
-```  
-  
-#### Parameters  
- `pBPType`  
- [out] Returns a value from the [BP_TYPE](../../../extensibility/debugger/reference/bp-type.md) enumeration that specifies the type of this breakpoint.  
-  
-## Return Value  
- If successful, returns `S_OK`; otherwise returns an error code. Returns E_FAIL if the `bpResLocation` field in the associated [BP_RESOLUTION_INFO](../../../extensibility/debugger/reference/bp-resolution-info.md) structure is not valid.  
-  
-## Remarks  
- The breakpoint may be a code or a data breakpoint, for example.  
-  
-## Example  
- The following example shows how to implement this method for a simple `CDebugBreakpointResolution` object that exposes the [IDebugBreakpointResolution2](../../../extensibility/debugger/reference/idebugbreakpointresolution2.md) interface.  
-  
-```  
-HRESULT CDebugBreakpointResolution::GetBreakpointType(BP_TYPE* pBPType)    
-{    
-   HRESULT hr;    
-  
-   if (pBPType)    
-   {    
-      // Set default BP_TYPE.    
-      *pBPType = BPT_NONE;    
-  
-      // Check if the BPRESI_BPRESLOCATION flag is set in BPRESI_FIELDS.    
-      if (IsFlagSet(m_bpResolutionInfo.dwFields, BPRESI_BPRESLOCATION))    
-      {    
-         // Set the new BP_TYPE.    
-         *pBPType = m_bpResolutionInfo.bpResLocation.bpType;    
-         hr = S_OK;    
-      }    
-      else    
-      {    
-         hr = E_FAIL;    
-      }    
-   }    
-   else    
-   {    
-      hr = E_INVALIDARG;    
-   }    
-  
-   return hr;    
-}    
-```  
-  
-## See Also  
- [IDebugBreakpointResolution2](../../../extensibility/debugger/reference/idebugbreakpointresolution2.md)   
- [BP_TYPE](../../../extensibility/debugger/reference/bp-type.md)   
- [BPRESI_FIELDS](../../../extensibility/debugger/reference/bpresi-fields.md)   
- [BP_RESOLUTION_LOCATION](../../../extensibility/debugger/reference/bp-resolution-location.md)   
- [BP_RESOLUTION_INFO](../../../extensibility/debugger/reference/bp-resolution-info.md)
+Gets the type of the breakpoint represented by this resolution.
+
+## Syntax
+
+```cpp
+HRESULT GetBreakpointType( 
+   BP_TYPE* pBPType
+);
+```
+
+```csharp
+int GetBreakpointType( 
+   out enum_ BP_TYPE pBPType
+);
+```
+
+#### Parameters
+`pBPType`  
+[out] Returns a value from the [BP_TYPE](../../../extensibility/debugger/reference/bp-type.md) enumeration that specifies the type of this breakpoint.
+
+## Return Value
+If successful, returns `S_OK`; otherwise returns an error code. Returns E_FAIL if the `bpResLocation` field in the associated [BP_RESOLUTION_INFO](../../../extensibility/debugger/reference/bp-resolution-info.md) structure is not valid.
+
+## Remarks
+The breakpoint may be a code or a data breakpoint, for example.
+
+## Example
+The following example shows how to implement this method for a simple `CDebugBreakpointResolution` object that exposes the [IDebugBreakpointResolution2](../../../extensibility/debugger/reference/idebugbreakpointresolution2.md) interface.
+
+```
+HRESULT CDebugBreakpointResolution::GetBreakpointType(BP_TYPE* pBPType)
+{
+   HRESULT hr;
+
+   if (pBPType)
+   {
+      // Set default BP_TYPE.
+      *pBPType = BPT_NONE;
+
+      // Check if the BPRESI_BPRESLOCATION flag is set in BPRESI_FIELDS.
+      if (IsFlagSet(m_bpResolutionInfo.dwFields, BPRESI_BPRESLOCATION))
+      {
+         // Set the new BP_TYPE.
+         *pBPType = m_bpResolutionInfo.bpResLocation.bpType;
+         hr = S_OK;
+      }
+      else
+      {
+         hr = E_FAIL;
+      }
+   }
+   else
+   {
+      hr = E_INVALIDARG;
+   }
+
+   return hr;
+}
+```
+
+## See Also
+[IDebugBreakpointResolution2](../../../extensibility/debugger/reference/idebugbreakpointresolution2.md)  
+[BP_TYPE](../../../extensibility/debugger/reference/bp-type.md)  
+[BPRESI_FIELDS](../../../extensibility/debugger/reference/bpresi-fields.md)  
+[BP_RESOLUTION_LOCATION](../../../extensibility/debugger/reference/bp-resolution-location.md)  
+[BP_RESOLUTION_INFO](../../../extensibility/debugger/reference/bp-resolution-info.md)


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.