### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/idebugbreakpointunboundevent2-getbreakpoint.md
+++ b/docs/extensibility/debugger/reference/idebugbreakpointunboundevent2-getbreakpoint.md
@@ -2,71 +2,71 @@
 title: "IDebugBreakpointUnboundEvent2::GetBreakpoint | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-f1_keywords: 
+f1_keywords:
   - "IDebugBreakpointUnboundEvent2::GetBreakpoint"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "IDebugBreakpointUnboundEvent2::GetBreakpoint"
 ms.assetid: ad73a207-b778-4dc5-b645-5ec668a63333
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # IDebugBreakpointUnboundEvent2::GetBreakpoint
-Gets the breakpoint that became unbound.  
-  
-## Syntax  
-  
-```cpp  
-HRESULT GetBreakpoint(   
-   IDebugBoundBreakpoint2** ppBP  
-);  
-```  
-  
-```csharp  
-int GetBreakpoint(   
-   out IDebugBoundBreakpoint2 ppBP  
-);  
-```  
-  
-#### Parameters  
- `ppBP`  
- [out] Returns an [IDebugBoundBreakpoint2](../../../extensibility/debugger/reference/idebugboundbreakpoint2.md) object that represents the breakpoint that became unbound.  
-  
-## Return Value  
- If successful, returns `S_OK`; otherwise, returns an error code.  
-  
-## Example  
- The following example shows how to implement this method for a **CBreakpointUnboundDebugEventBase** object that exposes the [IDebugBreakpointUnboundEvent2](../../../extensibility/debugger/reference/idebugbreakpointunboundevent2.md) interface.  
-  
-```cpp  
-STDMETHODIMP CBreakpointUnboundDebugEventBase::GetBreakpoint(  
-    IDebugBoundBreakpoint2 **ppbp)  
-{  
-    HRESULT hRes = E_FAIL;  
-  
-    if ( ppbp )  
-    {  
-        if ( m_pbp )  
-        {  
-            IDebugBoundBreakpoint2 *pibp;  
-  
-            hRes = m_pbp->QueryInterface(IID_IDebugBoundBreakpoint2, (void **) & pibp);  
-  
-            if ( S_OK == hRes )  
-                *ppbp = pibp;  
-        }  
-        else  
-            hRes = E_FAIL;  
-    }  
-    else  
-        hRes = E_INVALIDARG;  
-  
-    return ( hRes );  
-}  
-```  
-  
-## See Also  
- [IDebugBreakpointUnboundEvent2](../../../extensibility/debugger/reference/idebugbreakpointunboundevent2.md)   
- [IDebugBoundBreakpoint2](../../../extensibility/debugger/reference/idebugboundbreakpoint2.md)
+Gets the breakpoint that became unbound.
+
+## Syntax
+
+```cpp
+HRESULT GetBreakpoint( 
+   IDebugBoundBreakpoint2** ppBP
+);
+```
+
+```csharp
+int GetBreakpoint( 
+   out IDebugBoundBreakpoint2 ppBP
+);
+```
+
+#### Parameters
+`ppBP`  
+[out] Returns an [IDebugBoundBreakpoint2](../../../extensibility/debugger/reference/idebugboundbreakpoint2.md) object that represents the breakpoint that became unbound.
+
+## Return Value
+If successful, returns `S_OK`; otherwise, returns an error code.
+
+## Example
+The following example shows how to implement this method for a **CBreakpointUnboundDebugEventBase** object that exposes the [IDebugBreakpointUnboundEvent2](../../../extensibility/debugger/reference/idebugbreakpointunboundevent2.md) interface.
+
+```cpp
+STDMETHODIMP CBreakpointUnboundDebugEventBase::GetBreakpoint(
+    IDebugBoundBreakpoint2 **ppbp)
+{
+    HRESULT hRes = E_FAIL;
+
+    if ( ppbp )
+    {
+        if ( m_pbp )
+        {
+            IDebugBoundBreakpoint2 *pibp;
+
+            hRes = m_pbp->QueryInterface(IID_IDebugBoundBreakpoint2, (void **) & pibp);
+
+            if ( S_OK == hRes )
+                *ppbp = pibp;
+        }
+        else
+            hRes = E_FAIL;
+    }
+    else
+        hRes = E_INVALIDARG;
+
+    return ( hRes );
+}
+```
+
+## See Also
+[IDebugBreakpointUnboundEvent2](../../../extensibility/debugger/reference/idebugbreakpointunboundevent2.md)  
+[IDebugBoundBreakpoint2](../../../extensibility/debugger/reference/idebugboundbreakpoint2.md)

--- a/docs/extensibility/debugger/reference/idebugbreakpointunboundevent2-getbreakpoint.md
+++ b/docs/extensibility/debugger/reference/idebugbreakpointunboundevent2-getbreakpoint.md
@@ -19,14 +19,14 @@ Gets the breakpoint that became unbound.
 ## Syntax
 
 ```cpp
-HRESULT GetBreakpoint( 
-   IDebugBoundBreakpoint2** ppBP
+HRESULT GetBreakpoint(
+    IDebugBoundBreakpoint2** ppBP
 );
 ```
 
 ```csharp
-int GetBreakpoint( 
-   out IDebugBoundBreakpoint2 ppBP
+int GetBreakpoint(
+    out IDebugBoundBreakpoint2 ppBP
 );
 ```
 


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.