### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/canstop-reason.md
+++ b/docs/extensibility/debugger/reference/canstop-reason.md
@@ -20,16 +20,16 @@ Used to determine if a program can stop execution after reaching a particular po
 
 ```cpp
 enum enum_CANSTOP_REASON {
-   CANSTOP_ENTRYPOINT = 0x0000,
-   CANSTOP_STEPIN     = 0x0001
+    CANSTOP_ENTRYPOINT = 0x0000,
+    CANSTOP_STEPIN     = 0x0001
 };
 typedef DWORD CANSTOP_REASON;
 ```
 
 ```csharp
 public enum enum_CANSTOP_REASON {
-   CANSTOP_ENTRYPOINT = 0x0000,
-   CANSTOP_STEPIN     = 0x0001
+    CANSTOP_ENTRYPOINT = 0x0000,
+    CANSTOP_STEPIN     = 0x0001
 };
 ```
 

--- a/docs/extensibility/debugger/reference/canstop-reason.md
+++ b/docs/extensibility/debugger/reference/canstop-reason.md
@@ -2,54 +2,54 @@
 title: "CANSTOP_REASON | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-f1_keywords: 
+f1_keywords:
   - "CANSTOP_REASON"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "CANSTOP_REASON enumeration"
 ms.assetid: 6da944eb-36cd-4a8c-8d71-544c775cfcc1
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # CANSTOP_REASON
-Used to determine if a program can stop execution after reaching a particular point in the execution.  
-  
-## Syntax  
-  
-```cpp  
-enum enum_CANSTOP_REASON {   
-   CANSTOP_ENTRYPOINT = 0x0000,  
-   CANSTOP_STEPIN     = 0x0001  
-};  
-typedef DWORD CANSTOP_REASON;  
-```  
-  
-```csharp  
-public enum enum_CANSTOP_REASON {   
-   CANSTOP_ENTRYPOINT = 0x0000,  
-   CANSTOP_STEPIN     = 0x0001  
-};  
-```  
-  
-## Members  
- CANSTOP_ENTRYPOINT  
- Specifies the entry point of the given program.  
-  
- CANSTOP_STEPIN  
- Specifies stepping into a function.  
-  
-## Remarks  
- Passed as an argument to the [GetReason](../../../extensibility/debugger/reference/idebugcanstopevent2-getreason.md) method to confirm with the Session Debug Manager (SDM) if it is okay to stop after reaching the entry point of the program or after stepping into a function or method.  
-  
-## Requirements  
- Header: msdbg.h  
-  
- Namespace: Microsoft.VisualStudio.Debugger.Interop  
-  
- Assembly: Microsoft.VisualStudio.Debugger.Interop.dll  
-  
-## See Also  
- [Enumerations](../../../extensibility/debugger/reference/enumerations-visual-studio-debugging.md)   
- [GetReason](../../../extensibility/debugger/reference/idebugcanstopevent2-getreason.md)
+Used to determine if a program can stop execution after reaching a particular point in the execution.
+
+## Syntax
+
+```cpp
+enum enum_CANSTOP_REASON {
+   CANSTOP_ENTRYPOINT = 0x0000,
+   CANSTOP_STEPIN     = 0x0001
+};
+typedef DWORD CANSTOP_REASON;
+```
+
+```csharp
+public enum enum_CANSTOP_REASON {
+   CANSTOP_ENTRYPOINT = 0x0000,
+   CANSTOP_STEPIN     = 0x0001
+};
+```
+
+## Members
+CANSTOP_ENTRYPOINT  
+Specifies the entry point of the given program.
+
+CANSTOP_STEPIN  
+Specifies stepping into a function.
+
+## Remarks
+Passed as an argument to the [GetReason](../../../extensibility/debugger/reference/idebugcanstopevent2-getreason.md) method to confirm with the Session Debug Manager (SDM) if it is okay to stop after reaching the entry point of the program or after stepping into a function or method.
+
+## Requirements
+Header: msdbg.h
+
+Namespace: Microsoft.VisualStudio.Debugger.Interop
+
+Assembly: Microsoft.VisualStudio.Debugger.Interop.dll
+
+## See Also
+[Enumerations](../../../extensibility/debugger/reference/enumerations-visual-studio-debugging.md)  
+[GetReason](../../../extensibility/debugger/reference/idebugcanstopevent2-getreason.md)


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.