### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/constructor-enum.md
+++ b/docs/extensibility/debugger/reference/constructor-enum.md
@@ -2,58 +2,58 @@
 title: "CONSTRUCTOR_ENUM | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-f1_keywords: 
+f1_keywords:
   - "CONSTRUCTOR_ENUM"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "CONSTRUCTOR_ENUM enumeration"
 ms.assetid: 6d335b2c-66bc-460c-a4a6-4f3f1b697c2c
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # CONSTRUCTOR_ENUM
-Selects different types of constructors.  
-  
-## Syntax  
-  
-```cpp  
-typedef enum ConstructorMatchOptions {   
-   crAll       = 0,  
-   crNonStatic = 1,  
-   crStatic    = 2  
-} CONSTRUCTOR_ENUM;  
-```  
-  
-```csharp  
-public enum ConstructorMatchOptions {   
-   crAll       = 0,  
-   crNonStatic = 1,  
-   crStatic    = 2  
-};  
-```  
-  
-## Members  
- crAll  
- Selects all constructors.  
-  
- crNonStatic  
- Selects non-static constructors.  
-  
- crStatic  
- Selects static constructors.  
-  
-## Remarks  
- Passed as an argument to the [EnumConstructors](../../../extensibility/debugger/reference/idebugclassfield-enumconstructors.md) method.  
-  
-## Requirements  
- Header: sh.h  
-  
- Namespace: Microsoft.VisualStudio.Debugger.Interop  
-  
- Assembly: Microsoft.VisualStudio.Debugger.Interop.dll  
-  
-## See Also  
- [Enumerations](../../../extensibility/debugger/reference/enumerations-visual-studio-debugging.md)   
- [GetReason](../../../extensibility/debugger/reference/idebugcanstopevent2-getreason.md)
+Selects different types of constructors.
+
+## Syntax
+
+```cpp
+typedef enum ConstructorMatchOptions {
+   crAll       = 0,
+   crNonStatic = 1,
+   crStatic    = 2
+} CONSTRUCTOR_ENUM;
+```
+
+```csharp
+public enum ConstructorMatchOptions {
+   crAll       = 0,
+   crNonStatic = 1,
+   crStatic    = 2
+};
+```
+
+## Members
+crAll  
+Selects all constructors.
+
+crNonStatic  
+Selects non-static constructors.
+
+crStatic  
+Selects static constructors.
+
+## Remarks
+Passed as an argument to the [EnumConstructors](../../../extensibility/debugger/reference/idebugclassfield-enumconstructors.md) method.
+
+## Requirements
+Header: sh.h
+
+Namespace: Microsoft.VisualStudio.Debugger.Interop
+
+Assembly: Microsoft.VisualStudio.Debugger.Interop.dll
+
+## See Also
+[Enumerations](../../../extensibility/debugger/reference/enumerations-visual-studio-debugging.md)  
+[GetReason](../../../extensibility/debugger/reference/idebugcanstopevent2-getreason.md)

--- a/docs/extensibility/debugger/reference/constructor-enum.md
+++ b/docs/extensibility/debugger/reference/constructor-enum.md
@@ -20,17 +20,17 @@ Selects different types of constructors.
 
 ```cpp
 typedef enum ConstructorMatchOptions {
-   crAll       = 0,
-   crNonStatic = 1,
-   crStatic    = 2
+    crAll       = 0,
+    crNonStatic = 1,
+    crStatic    = 2
 } CONSTRUCTOR_ENUM;
 ```
 
 ```csharp
 public enum ConstructorMatchOptions {
-   crAll       = 0,
-   crNonStatic = 1,
-   crStatic    = 2
+    crAll       = 0,
+    crNonStatic = 1,
+    crStatic    = 2
 };
 ```
 


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.