### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/debug-reference-info.md
+++ b/docs/extensibility/debugger/reference/debug-reference-info.md
@@ -20,25 +20,25 @@ Describes a reference.
 
 ```cpp
 typedef struct tagDEBUG_REFERENCE_INFO {
-   DEBUGREF_INFO_FLAGS dwFields;
-   BSTR                bstrName;
-   BSTR                bstrType;
-   BSTR                bstrValue;
-   DBG_ATTRIB_FLAGS    dwAttrib;
-   REFERENCE_TYPE.     dwRefType;
-   IDebugReference2*   m_pReference;
+    DEBUGREF_INFO_FLAGS dwFields;
+    BSTR                bstrName;
+    BSTR                bstrType;
+    BSTR                bstrValue;
+    DBG_ATTRIB_FLAGS    dwAttrib;
+    REFERENCE_TYPE.     dwRefType;
+    IDebugReference2*   m_pReference;
 } DEBUG_REFERENCE_INFO;
 ```
 
 ```csharp
 public struct DEBUG_REFERENCE_INFO {
-   public uint             dwFields;
-   public string           bstrName;
-   public string           bstrType;
-   public string           bstrValue;
-   public ulong            dwAttrib;
-   public uint.            dwRefType;
-   public IDebugReference2 m_pReference;
+    public uint             dwFields;
+    public string           bstrName;
+    public string           bstrType;
+    public string           bstrValue;
+    public ulong            dwAttrib;
+    public uint.            dwRefType;
+    public IDebugReference2 m_pReference;
 };
 ```
 

--- a/docs/extensibility/debugger/reference/debug-reference-info.md
+++ b/docs/extensibility/debugger/reference/debug-reference-info.md
@@ -2,84 +2,84 @@
 title: "DEBUG_REFERENCE_INFO | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-f1_keywords: 
+f1_keywords:
   - "DEBUG_REFERENCE_INFO"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "DEBUG_REFERENCE_INFO structure"
 ms.assetid: 24b83d00-d756-42a1-8083-730f998761dc
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # DEBUG_REFERENCE_INFO
-Describes a reference.  
-  
-## Syntax  
-  
-```cpp  
-typedef struct tagDEBUG_REFERENCE_INFO {   
-   DEBUGREF_INFO_FLAGS dwFields;  
-   BSTR                bstrName;  
-   BSTR                bstrType;  
-   BSTR                bstrValue;  
-   DBG_ATTRIB_FLAGS    dwAttrib;  
-   REFERENCE_TYPE.     dwRefType;  
-   IDebugReference2*   m_pReference;  
-} DEBUG_REFERENCE_INFO;  
-```  
-  
-```csharp  
-public struct DEBUG_REFERENCE_INFO {   
-   public uint             dwFields;  
-   public string           bstrName;  
-   public string           bstrType;  
-   public string           bstrValue;  
-   public ulong            dwAttrib;  
-   public uint.            dwRefType;  
-   public IDebugReference2 m_pReference;  
-};  
-```  
-  
-## Members  
- dwFields  
- A combination of flags from the [DEBUGREF_INFO_FLAGS](../../../extensibility/debugger/reference/debugref-info-flags.md) enumeration that specifies which fields are filled out.  
-  
- bstrName  
- The user-specified name of the [IDebugReference2](../../../extensibility/debugger/reference/idebugreference2.md) object.  
-  
- bstrType  
- The reference type as a formatted string.  
-  
- bstrValue  
- The reference value as a formatted string  
-  
- dwAttrib  
- A combination of flags from the [DBG_ATTRIB_FLAGS](../../../extensibility/debugger/reference/dbg-attrib-flags.md) enumeration that specifies the flags for the debug property attributes.  
-  
- dwRefType  
- A value from the [REFERENCE_TYPE](../../../extensibility/debugger/reference/reference-type.md) enumeration that specifies whether the reference type is strong or weak.  
-  
- m_pReference  
- An [IDebugReference2](../../../extensibility/debugger/reference/idebugreference2.md) object that specifies the reference information.  
-  
-## Remarks  
- This structure is passed to a call to the [GetReferenceInfo](../../../extensibility/debugger/reference/idebugreference2-getreferenceinfo.md) method to be filled in. This structure is also returned as part of a list from the [IEnumDebugReferenceInfo2](../../../extensibility/debugger/reference/ienumdebugreferenceinfo2.md) interface which, in turn, is returned from a call to the [EnumChildren](../../../extensibility/debugger/reference/idebugreference2-enumchildren.md) method.  
-  
-## Requirements  
- Header: msdbg.h  
-  
- Namespace: Microsoft.VisualStudio.Debugger.Interop  
-  
- Assembly: Microsoft.VisualStudio.Debugger.Interop.dll  
-  
-## See Also  
- [Structures and Unions](../../../extensibility/debugger/reference/structures-and-unions.md)   
- [IDebugReference2](../../../extensibility/debugger/reference/idebugreference2.md)   
- [DEBUGREF_INFO_FLAGS](../../../extensibility/debugger/reference/debugref-info-flags.md)   
- [DBG_ATTRIB_FLAGS](../../../extensibility/debugger/reference/dbg-attrib-flags.md)   
- [REFERENCE_TYPE](../../../extensibility/debugger/reference/reference-type.md)   
- [GetReferenceInfo](../../../extensibility/debugger/reference/idebugreference2-getreferenceinfo.md)   
- [EnumChildren](../../../extensibility/debugger/reference/idebugreference2-enumchildren.md)   
- [IEnumDebugReferenceInfo2](../../../extensibility/debugger/reference/ienumdebugreferenceinfo2.md)
+Describes a reference.
+
+## Syntax
+
+```cpp
+typedef struct tagDEBUG_REFERENCE_INFO {
+   DEBUGREF_INFO_FLAGS dwFields;
+   BSTR                bstrName;
+   BSTR                bstrType;
+   BSTR                bstrValue;
+   DBG_ATTRIB_FLAGS    dwAttrib;
+   REFERENCE_TYPE.     dwRefType;
+   IDebugReference2*   m_pReference;
+} DEBUG_REFERENCE_INFO;
+```
+
+```csharp
+public struct DEBUG_REFERENCE_INFO {
+   public uint             dwFields;
+   public string           bstrName;
+   public string           bstrType;
+   public string           bstrValue;
+   public ulong            dwAttrib;
+   public uint.            dwRefType;
+   public IDebugReference2 m_pReference;
+};
+```
+
+## Members
+dwFields  
+A combination of flags from the [DEBUGREF_INFO_FLAGS](../../../extensibility/debugger/reference/debugref-info-flags.md) enumeration that specifies which fields are filled out.
+
+bstrName  
+The user-specified name of the [IDebugReference2](../../../extensibility/debugger/reference/idebugreference2.md) object.
+
+bstrType  
+The reference type as a formatted string.
+
+bstrValue  
+The reference value as a formatted string
+
+dwAttrib  
+A combination of flags from the [DBG_ATTRIB_FLAGS](../../../extensibility/debugger/reference/dbg-attrib-flags.md) enumeration that specifies the flags for the debug property attributes.
+
+dwRefType  
+A value from the [REFERENCE_TYPE](../../../extensibility/debugger/reference/reference-type.md) enumeration that specifies whether the reference type is strong or weak.
+
+m_pReference  
+An [IDebugReference2](../../../extensibility/debugger/reference/idebugreference2.md) object that specifies the reference information.
+
+## Remarks
+This structure is passed to a call to the [GetReferenceInfo](../../../extensibility/debugger/reference/idebugreference2-getreferenceinfo.md) method to be filled in. This structure is also returned as part of a list from the [IEnumDebugReferenceInfo2](../../../extensibility/debugger/reference/ienumdebugreferenceinfo2.md) interface which, in turn, is returned from a call to the [EnumChildren](../../../extensibility/debugger/reference/idebugreference2-enumchildren.md) method.
+
+## Requirements
+Header: msdbg.h
+
+Namespace: Microsoft.VisualStudio.Debugger.Interop
+
+Assembly: Microsoft.VisualStudio.Debugger.Interop.dll
+
+## See Also
+[Structures and Unions](../../../extensibility/debugger/reference/structures-and-unions.md)  
+[IDebugReference2](../../../extensibility/debugger/reference/idebugreference2.md)  
+[DEBUGREF_INFO_FLAGS](../../../extensibility/debugger/reference/debugref-info-flags.md)  
+[DBG_ATTRIB_FLAGS](../../../extensibility/debugger/reference/dbg-attrib-flags.md)  
+[REFERENCE_TYPE](../../../extensibility/debugger/reference/reference-type.md)  
+[GetReferenceInfo](../../../extensibility/debugger/reference/idebugreference2-getreferenceinfo.md)  
+[EnumChildren](../../../extensibility/debugger/reference/idebugreference2-enumchildren.md)  
+[IEnumDebugReferenceInfo2](../../../extensibility/debugger/reference/ienumdebugreferenceinfo2.md)


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.