### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/disassembly-stream-scope.md
+++ b/docs/extensibility/debugger/reference/disassembly-stream-scope.md
@@ -2,67 +2,67 @@
 title: "DISASSEMBLY_STREAM_SCOPE | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-f1_keywords: 
+f1_keywords:
   - "DISASSEMBLY_STREAM_SCOPE"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "DISASSEMBLY_STREAM_SCOPE enumeration"
 ms.assetid: 43e2b364-cbbe-4755-a7e6-a03f3054c965
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # DISASSEMBLY_STREAM_SCOPE
-Specifies the scope of the disassembly stream.  
-  
-## Syntax  
-  
-```cpp  
-enum enum_DISASSEMBLY_STREAM_SCOPE {   
-   DSS_HUGE     = 0x10000000,  
-   DSS_FUNCTION = 0x0001,  
-   DSS_MODULE   = (DSS_HUGE) | 0x0002,  
-   DSS_ALL      = (DSS_HUGE) | 0x0003  
-};  
-typedef DWORD DISASSEMBLY_STREAM_SCOPE;  
-```  
-  
-```csharp  
-public enum enum_DISASSEMBLY_STREAM_SCOPE {   
-   DSS_HUGE     = 0x10000000,  
-   DSS_FUNCTION = 0x0001,  
-   DSS_MODULE   = (DSS_HUGE) | 0x0002,  
-   DSS_ALL      = (DSS_HUGE) | 0x0003  
-};  
-```  
-  
-## Members  
- DSS_HUGE  
- Specifies that disassembling the code context would generate more output than a client would typically want to retrieve in a single call.  
-  
- DSS_FUNCTION  
- Specifies that the function contained by the code context should be disassembled. Specifies that the disassembly stream represents a function, when returned by the [GetScope](../../../extensibility/debugger/reference/idebugdisassemblystream2-getscope.md) method.  
-  
- DSS_MODULE  
- When returned by the `IDebugDisassemblyStream2::GetScope` method, specifies that the disassembly stream represents a module.  
-  
- DSS_ALL  
- Specifies disassembly for the entire address space.  
-  
-## Remarks  
- Passed as an argument to the [GetDisassemblyStream](../../../extensibility/debugger/reference/idebugprogram2-getdisassemblystream.md) method and returned by the [GetScope](../../../extensibility/debugger/reference/idebugdisassemblystream2-getscope.md) method.  
-  
- These values may be combined with a bitwise `OR`.  
-  
-## Requirements  
- Header: msdbg.h  
-  
- Namespace: Microsoft.VisualStudio.Debugger.Interop  
-  
- Assembly: Microsoft.VisualStudio.Debugger.Interop.dll  
-  
-## See Also  
- [Enumerations](../../../extensibility/debugger/reference/enumerations-visual-studio-debugging.md)   
- [GetDisassemblyStream](../../../extensibility/debugger/reference/idebugprogram2-getdisassemblystream.md)   
- [GetScope](../../../extensibility/debugger/reference/idebugdisassemblystream2-getscope.md)
+Specifies the scope of the disassembly stream.
+
+## Syntax
+
+```cpp
+enum enum_DISASSEMBLY_STREAM_SCOPE {
+   DSS_HUGE     = 0x10000000,
+   DSS_FUNCTION = 0x0001,
+   DSS_MODULE   = (DSS_HUGE) | 0x0002,
+   DSS_ALL      = (DSS_HUGE) | 0x0003
+};
+typedef DWORD DISASSEMBLY_STREAM_SCOPE;
+```
+
+```csharp
+public enum enum_DISASSEMBLY_STREAM_SCOPE {
+   DSS_HUGE     = 0x10000000,
+   DSS_FUNCTION = 0x0001,
+   DSS_MODULE   = (DSS_HUGE) | 0x0002,
+   DSS_ALL      = (DSS_HUGE) | 0x0003
+};
+```
+
+## Members
+DSS_HUGE  
+Specifies that disassembling the code context would generate more output than a client would typically want to retrieve in a single call.
+
+DSS_FUNCTION  
+Specifies that the function contained by the code context should be disassembled. Specifies that the disassembly stream represents a function, when returned by the [GetScope](../../../extensibility/debugger/reference/idebugdisassemblystream2-getscope.md) method.
+
+DSS_MODULE  
+When returned by the `IDebugDisassemblyStream2::GetScope` method, specifies that the disassembly stream represents a module.
+
+DSS_ALL  
+Specifies disassembly for the entire address space.
+
+## Remarks
+Passed as an argument to the [GetDisassemblyStream](../../../extensibility/debugger/reference/idebugprogram2-getdisassemblystream.md) method and returned by the [GetScope](../../../extensibility/debugger/reference/idebugdisassemblystream2-getscope.md) method.
+
+These values may be combined with a bitwise `OR`.
+
+## Requirements
+Header: msdbg.h
+
+Namespace: Microsoft.VisualStudio.Debugger.Interop
+
+Assembly: Microsoft.VisualStudio.Debugger.Interop.dll
+
+## See Also
+[Enumerations](../../../extensibility/debugger/reference/enumerations-visual-studio-debugging.md)  
+[GetDisassemblyStream](../../../extensibility/debugger/reference/idebugprogram2-getdisassemblystream.md)  
+[GetScope](../../../extensibility/debugger/reference/idebugdisassemblystream2-getscope.md)

--- a/docs/extensibility/debugger/reference/disassembly-stream-scope.md
+++ b/docs/extensibility/debugger/reference/disassembly-stream-scope.md
@@ -20,20 +20,20 @@ Specifies the scope of the disassembly stream.
 
 ```cpp
 enum enum_DISASSEMBLY_STREAM_SCOPE {
-   DSS_HUGE     = 0x10000000,
-   DSS_FUNCTION = 0x0001,
-   DSS_MODULE   = (DSS_HUGE) | 0x0002,
-   DSS_ALL      = (DSS_HUGE) | 0x0003
+    DSS_HUGE     = 0x10000000,
+    DSS_FUNCTION = 0x0001,
+    DSS_MODULE   = (DSS_HUGE) | 0x0002,
+    DSS_ALL      = (DSS_HUGE) | 0x0003
 };
 typedef DWORD DISASSEMBLY_STREAM_SCOPE;
 ```
 
 ```csharp
 public enum enum_DISASSEMBLY_STREAM_SCOPE {
-   DSS_HUGE     = 0x10000000,
-   DSS_FUNCTION = 0x0001,
-   DSS_MODULE   = (DSS_HUGE) | 0x0002,
-   DSS_ALL      = (DSS_HUGE) | 0x0003
+    DSS_HUGE     = 0x10000000,
+    DSS_FUNCTION = 0x0001,
+    DSS_MODULE   = (DSS_HUGE) | 0x0002,
+    DSS_ALL      = (DSS_HUGE) | 0x0003
 };
 ```
 


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.