### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/dumptype.md
+++ b/docs/extensibility/debugger/reference/dumptype.md
@@ -2,54 +2,54 @@
 title: "DUMPTYPE | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-f1_keywords: 
+f1_keywords:
   - "DUMPTYPE"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "DUMPTYPE enumeration"
 ms.assetid: ea8160db-8732-4056-a1d7-892ef72da71e
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # DUMPTYPE
-Specifies how much of a program's state (such as running threads, stack frames, and current instruction address) to dump.  
-  
-## Syntax  
-  
-```cpp  
-enum enum_DUMPTYPE {   
-   DUMP_MINIDUMP = 0,  
-   DUMP_FULLDUMP = 1  
-};  
-typedef DWORD DUMPTYPE;  
-```  
-  
-```csharp  
-public enum enum_DUMPTYPE {   
-   DUMP_MINIDUMP = 0,  
-   DUMP_FULLDUMP = 1  
-};  
-```  
-  
-## Members  
- DUMP_MINIDUMP  
- Specifies a small, compact dump.  
-  
- DUMP_FULLDUMP  
- Specifies a large, complete dump.  
-  
-## Remarks  
- Passed as an argument to the [WriteDump](../../../extensibility/debugger/reference/idebugprogram2-writedump.md) method.  
-  
-## Requirements  
- Header: msdbg.h  
-  
- Namespace: Microsoft.VisualStudio.Debugger.Interop  
-  
- Assembly: Microsoft.VisualStudio.Debugger.Interop.dll  
-  
-## See Also  
- [Enumerations](../../../extensibility/debugger/reference/enumerations-visual-studio-debugging.md)   
- [WriteDump](../../../extensibility/debugger/reference/idebugprogram2-writedump.md)
+Specifies how much of a program's state (such as running threads, stack frames, and current instruction address) to dump.
+
+## Syntax
+
+```cpp
+enum enum_DUMPTYPE {
+   DUMP_MINIDUMP = 0,
+   DUMP_FULLDUMP = 1
+};
+typedef DWORD DUMPTYPE;
+```
+
+```csharp
+public enum enum_DUMPTYPE {
+   DUMP_MINIDUMP = 0,
+   DUMP_FULLDUMP = 1
+};
+```
+
+## Members
+DUMP_MINIDUMP  
+Specifies a small, compact dump.
+
+DUMP_FULLDUMP  
+Specifies a large, complete dump.
+
+## Remarks
+Passed as an argument to the [WriteDump](../../../extensibility/debugger/reference/idebugprogram2-writedump.md) method.
+
+## Requirements
+Header: msdbg.h
+
+Namespace: Microsoft.VisualStudio.Debugger.Interop
+
+Assembly: Microsoft.VisualStudio.Debugger.Interop.dll
+
+## See Also
+[Enumerations](../../../extensibility/debugger/reference/enumerations-visual-studio-debugging.md)  
+[WriteDump](../../../extensibility/debugger/reference/idebugprogram2-writedump.md)

--- a/docs/extensibility/debugger/reference/dumptype.md
+++ b/docs/extensibility/debugger/reference/dumptype.md
@@ -20,16 +20,16 @@ Specifies how much of a program's state (such as running threads, stack frames, 
 
 ```cpp
 enum enum_DUMPTYPE {
-   DUMP_MINIDUMP = 0,
-   DUMP_FULLDUMP = 1
+    DUMP_MINIDUMP = 0,
+    DUMP_FULLDUMP = 1
 };
 typedef DWORD DUMPTYPE;
 ```
 
 ```csharp
 public enum enum_DUMPTYPE {
-   DUMP_MINIDUMP = 0,
-   DUMP_FULLDUMP = 1
+    DUMP_MINIDUMP = 0,
+    DUMP_FULLDUMP = 1
 };
 ```
 


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.