### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/gethostname-type.md
+++ b/docs/extensibility/debugger/reference/gethostname-type.md
@@ -20,16 +20,16 @@ Specifies the type of host name.
 
 ```cpp
 enum enum_GETHOSTNAME_TYPE {
-   GHN_FRIENDLY_NAME = 0,
-   GHN_FILE_NAME     = 1
+    GHN_FRIENDLY_NAME = 0,
+    GHN_FILE_NAME     = 1
 };
 typedef DWORD GETHOSTNAME_TYPE;
 ```
 
 ```csharp
 public enum enum_GETHOSTNAME_TYPE {
-   GHN_FRIENDLY_NAME = 0,
-   GHN_FILE_NAME     = 1
+    GHN_FRIENDLY_NAME = 0,
+    GHN_FILE_NAME     = 1
 };
 ```
 

--- a/docs/extensibility/debugger/reference/gethostname-type.md
+++ b/docs/extensibility/debugger/reference/gethostname-type.md
@@ -2,54 +2,54 @@
 title: "GETHOSTNAME_TYPE | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-f1_keywords: 
+f1_keywords:
   - "GETHOSTNAME_TYPE"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "GETHOSTNAME_TYPE enumeration"
 ms.assetid: 2be92bea-8133-412b-9015-1833baf16e1b
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # GETHOSTNAME_TYPE
-Specifies the type of host name.  
-  
-## Syntax  
-  
-```cpp  
-enum enum_GETHOSTNAME_TYPE {   
-   GHN_FRIENDLY_NAME = 0,  
-   GHN_FILE_NAME     = 1  
-};  
-typedef DWORD GETHOSTNAME_TYPE;  
-```  
-  
-```csharp  
-public enum enum_GETHOSTNAME_TYPE {   
-   GHN_FRIENDLY_NAME = 0,  
-   GHN_FILE_NAME     = 1  
-};  
-```  
-  
-## Members  
- GHN_FRIENDLY_NAME  
- Specifies a friendly name of the host.  
-  
- GHN_FILE_NAME  
- Specifies a file name of the host.  
-  
-## Remarks  
- These values are passed as an argument to the [GetHostName](../../../extensibility/debugger/reference/idebugprogramnode2-gethostname.md) method to retrieve a host name in different formats.  
-  
-## Requirements  
- Header: msdbg.h  
-  
- Namespace: Microsoft.VisualStudio.Debugger.Interop  
-  
- Assembly: Microsoft.VisualStudio.Debugger.Interop.dll  
-  
-## See Also  
- [Enumerations](../../../extensibility/debugger/reference/enumerations-visual-studio-debugging.md)   
- [GetHostName](../../../extensibility/debugger/reference/idebugprogramnode2-gethostname.md)
+Specifies the type of host name.
+
+## Syntax
+
+```cpp
+enum enum_GETHOSTNAME_TYPE {
+   GHN_FRIENDLY_NAME = 0,
+   GHN_FILE_NAME     = 1
+};
+typedef DWORD GETHOSTNAME_TYPE;
+```
+
+```csharp
+public enum enum_GETHOSTNAME_TYPE {
+   GHN_FRIENDLY_NAME = 0,
+   GHN_FILE_NAME     = 1
+};
+```
+
+## Members
+GHN_FRIENDLY_NAME  
+Specifies a friendly name of the host.
+
+GHN_FILE_NAME  
+Specifies a file name of the host.
+
+## Remarks
+These values are passed as an argument to the [GetHostName](../../../extensibility/debugger/reference/idebugprogramnode2-gethostname.md) method to retrieve a host name in different formats.
+
+## Requirements
+Header: msdbg.h
+
+Namespace: Microsoft.VisualStudio.Debugger.Interop
+
+Assembly: Microsoft.VisualStudio.Debugger.Interop.dll
+
+## See Also
+[Enumerations](../../../extensibility/debugger/reference/enumerations-visual-studio-debugging.md)  
+[GetHostName](../../../extensibility/debugger/reference/idebugprogramnode2-gethostname.md)


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.