### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/idebugclassfield-enumnestedenums.md
+++ b/docs/extensibility/debugger/reference/idebugclassfield-enumnestedenums.md
@@ -2,55 +2,55 @@
 title: "IDebugClassField::EnumNestedEnums | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-f1_keywords: 
+f1_keywords:
   - "IDebugClassField::EnumNestedEnums"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "IDebugClassField::EnumNestedEnums method"
 ms.assetid: 90fd0cef-9145-4de6-91d4-6c881df39d6e
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # IDebugClassField::EnumNestedEnums
-Creates an enumerator for the nested enumerators of this class.  
-  
-## Syntax  
-  
-```cpp  
-HRESULT EnumNestedEnums(   
-   IEnumDebugFields** ppEnum  
-);  
-```  
-  
-```csharp  
-int EnumNestedEnums(  
-   out IEnumDebugFields ppEnum  
-);  
-```  
-  
-#### Parameters  
- `ppEnum`  
- [out] Returns an [IEnumDebugFields](../../../extensibility/debugger/reference/ienumdebugfields.md) object representing the list of nested enumerations. Returns a null value if there are no nested enumerations.  
-  
-## Return Value  
- If successful, returns S_OK or returns S_FALSE if there are no nested enumerators. Otherwise, returns an error code.  
-  
-## Remarks  
- Each element of the enumeration is an [IDebugEnumField](../../../extensibility/debugger/reference/idebugenumfield.md) object describing a nested enumeration.  
-  
- An enumeration declared inside a class is considered a nested enumeration. For example, given:  
-  
-```  
-class RootClass {  
-   enum NestedEnum { EnumValue = 0 }  
-};  
-```  
-  
- The `EnumNestedEnums` method would return an [IEnumDebugFields](../../../extensibility/debugger/reference/ienumdebugfields.md) object that contains one [IDebugEnumField](../../../extensibility/debugger/reference/idebugenumfield.md) object that represents the `NestedEnum` enumeration.  
-  
-## See Also  
- [IDebugClassField](../../../extensibility/debugger/reference/idebugclassfield.md)   
- [IEnumDebugFields](../../../extensibility/debugger/reference/ienumdebugfields.md)   
- [IDebugEnumField](../../../extensibility/debugger/reference/idebugenumfield.md)
+Creates an enumerator for the nested enumerators of this class.
+
+## Syntax
+
+```cpp
+HRESULT EnumNestedEnums(
+   IEnumDebugFields** ppEnum
+);
+```
+
+```csharp
+int EnumNestedEnums(
+   out IEnumDebugFields ppEnum
+);
+```
+
+#### Parameters
+`ppEnum`  
+[out] Returns an [IEnumDebugFields](../../../extensibility/debugger/reference/ienumdebugfields.md) object representing the list of nested enumerations. Returns a null value if there are no nested enumerations.
+
+## Return Value
+If successful, returns S_OK or returns S_FALSE if there are no nested enumerators. Otherwise, returns an error code.
+
+## Remarks
+Each element of the enumeration is an [IDebugEnumField](../../../extensibility/debugger/reference/idebugenumfield.md) object describing a nested enumeration.
+
+An enumeration declared inside a class is considered a nested enumeration. For example, given:
+
+```
+class RootClass {
+   enum NestedEnum { EnumValue = 0 }
+};
+```
+
+The `EnumNestedEnums` method would return an [IEnumDebugFields](../../../extensibility/debugger/reference/ienumdebugfields.md) object that contains one [IDebugEnumField](../../../extensibility/debugger/reference/idebugenumfield.md) object that represents the `NestedEnum` enumeration.
+
+## See Also
+[IDebugClassField](../../../extensibility/debugger/reference/idebugclassfield.md)  
+[IEnumDebugFields](../../../extensibility/debugger/reference/ienumdebugfields.md)  
+[IDebugEnumField](../../../extensibility/debugger/reference/idebugenumfield.md)

--- a/docs/extensibility/debugger/reference/idebugclassfield-enumnestedenums.md
+++ b/docs/extensibility/debugger/reference/idebugclassfield-enumnestedenums.md
@@ -20,13 +20,13 @@ Creates an enumerator for the nested enumerators of this class.
 
 ```cpp
 HRESULT EnumNestedEnums(
-   IEnumDebugFields** ppEnum
+    IEnumDebugFields** ppEnum
 );
 ```
 
 ```csharp
 int EnumNestedEnums(
-   out IEnumDebugFields ppEnum
+    out IEnumDebugFields ppEnum
 );
 ```
 
@@ -44,7 +44,7 @@ An enumeration declared inside a class is considered a nested enumeration. For e
 
 ```
 class RootClass {
-   enum NestedEnum { EnumValue = 0 }
+    enum NestedEnum { EnumValue = 0 }
 };
 ```
 


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.