### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/idebugclassfield-getenclosingclass.md
+++ b/docs/extensibility/debugger/reference/idebugclassfield-getenclosingclass.md
@@ -2,51 +2,51 @@
 title: "IDebugClassField::GetEnclosingClass | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-f1_keywords: 
+f1_keywords:
   - "IDebugClassField::GetEnclosingClass"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "IDebugClassField::GetEnclosingClass method"
 ms.assetid: a0c12e3c-9ea0-4dfb-9e45-8cea18725022
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # IDebugClassField::GetEnclosingClass
-Gets the class that encloses this class.  
-  
-## Syntax  
-  
-```cpp  
-HRESULT GetEnclosingClass(   
-   IDebugClassField** ppClassField  
-);  
-```  
-  
-```csharp  
-int GetEnclosingClass(  
-   out IDebugClassField ppClassField  
-);  
-```  
-  
-#### Parameters  
- `ppClassField`  
- [out] Returns an [IDebugClassField](../../../extensibility/debugger/reference/idebugclassfield.md) object representing the enclosing class. Returns a null value if there is no enclosing class.  
-  
-## Return Value  
- If successful, returns S_OK; otherwise, returns an error code.  
-  
-## Remarks  
- If the class represented by this [IDebugClassField](../../../extensibility/debugger/reference/idebugclassfield.md) object is a nested class, then the `ppClassField` parameter returns an `IDebugClassField` object representing the enclosing class. For example, given this class definition:  
-  
-```  
-class RootClass {  
-   class NestedClass { }  
-};  
-```  
-  
- Calling the `GetEnclosingClass` method on the `IDebugClassField` object representing the `NestedClass` class returns an `IDebugClassField` object representing the class `RootClass`.  
-  
-## See Also  
- [IDebugClassField](../../../extensibility/debugger/reference/idebugclassfield.md)
+Gets the class that encloses this class.
+
+## Syntax
+
+```cpp
+HRESULT GetEnclosingClass(
+   IDebugClassField** ppClassField
+);
+```
+
+```csharp
+int GetEnclosingClass(
+   out IDebugClassField ppClassField
+);
+```
+
+#### Parameters
+`ppClassField`  
+[out] Returns an [IDebugClassField](../../../extensibility/debugger/reference/idebugclassfield.md) object representing the enclosing class. Returns a null value if there is no enclosing class.
+
+## Return Value
+If successful, returns S_OK; otherwise, returns an error code.
+
+## Remarks
+If the class represented by this [IDebugClassField](../../../extensibility/debugger/reference/idebugclassfield.md) object is a nested class, then the `ppClassField` parameter returns an `IDebugClassField` object representing the enclosing class. For example, given this class definition:
+
+```
+class RootClass {
+   class NestedClass { }
+};
+```
+
+Calling the `GetEnclosingClass` method on the `IDebugClassField` object representing the `NestedClass` class returns an `IDebugClassField` object representing the class `RootClass`.
+
+## See Also
+[IDebugClassField](../../../extensibility/debugger/reference/idebugclassfield.md)

--- a/docs/extensibility/debugger/reference/idebugclassfield-getenclosingclass.md
+++ b/docs/extensibility/debugger/reference/idebugclassfield-getenclosingclass.md
@@ -20,13 +20,13 @@ Gets the class that encloses this class.
 
 ```cpp
 HRESULT GetEnclosingClass(
-   IDebugClassField** ppClassField
+    IDebugClassField** ppClassField
 );
 ```
 
 ```csharp
 int GetEnclosingClass(
-   out IDebugClassField ppClassField
+    out IDebugClassField ppClassField
 );
 ```
 
@@ -42,7 +42,7 @@ If the class represented by this [IDebugClassField](../../../extensibility/debug
 
 ```
 class RootClass {
-   class NestedClass { }
+    class NestedClass { }
 };
 ```
 


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.