### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/idebugcodecontext3-getmodule.md
+++ b/docs/extensibility/debugger/reference/idebugcodecontext3-getmodule.md
@@ -18,13 +18,13 @@ Retrieves a reference to the interface of the debug module.
 
 ```cpp
 HRESULT GetModule(
-   IDebugModule2 **ppModule
+    IDebugModule2 **ppModule
 );
 ```
 
 ```csharp
 public int GetModule(
-   out IDebugModule2 ppModule
+    out IDebugModule2 ppModule
 );
 ```
 

--- a/docs/extensibility/debugger/reference/idebugcodecontext3-getmodule.md
+++ b/docs/extensibility/debugger/reference/idebugcodecontext3-getmodule.md
@@ -2,59 +2,59 @@
 title: "IDebugCodeContext3::GetModule | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "IDebugCodeContext3::GetModule"
 ms.assetid: 8e4317b8-8255-486c-a896-a68ed94f8aa1
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # IDebugCodeContext3::GetModule
-Retrieves a reference to the interface of the debug module.  
-  
-## Syntax  
-  
-```cpp  
-HRESULT GetModule(   
-   IDebugModule2 **ppModule  
-);  
-```  
-  
-```csharp  
-public int GetModule(   
-   out IDebugModule2 ppModule  
-);  
-```  
-  
-#### Parameters  
- `ppModule`  
- [out] Reference to the debug module interface.  
-  
-## Return Value  
- If successful, returns `S_OK`; otherwise, returns an error code.  
-  
-## Example  
- The following example shows how to implement this method for a **CDebugCodeContext** object that exposes the [IDebugBeforeSymbolSearchEvent2](../../../extensibility/debugger/reference/idebugbeforesymbolsearchevent2.md) interface.  
-  
-```cpp  
-HRESULT CDebugCodeContext::GetModule(IDebugModule2** ppModule)  
-{  
-    HRESULT hr = S_OK;  
-    CComPtr<CModule> pModule;  
-  
-    IfFalseGo( ppModule, E_INVALIDARG );  
-    *ppModule = NULL;  
-  
-    IfFailGo( this->GetModule(&pModule) );  
-    IfFailGo( pModule->QueryInterface(IID_IDebugModule2, (void**) ppModule) );  
-  
-Error:  
-  
-    return hr;  
-}  
-```  
-  
-## See Also  
- [IDebugCodeContext3](../../../extensibility/debugger/reference/idebugcodecontext3.md)
+Retrieves a reference to the interface of the debug module.
+
+## Syntax
+
+```cpp
+HRESULT GetModule(
+   IDebugModule2 **ppModule
+);
+```
+
+```csharp
+public int GetModule(
+   out IDebugModule2 ppModule
+);
+```
+
+#### Parameters
+`ppModule`  
+[out] Reference to the debug module interface.
+
+## Return Value
+If successful, returns `S_OK`; otherwise, returns an error code.
+
+## Example
+The following example shows how to implement this method for a **CDebugCodeContext** object that exposes the [IDebugBeforeSymbolSearchEvent2](../../../extensibility/debugger/reference/idebugbeforesymbolsearchevent2.md) interface.
+
+```cpp
+HRESULT CDebugCodeContext::GetModule(IDebugModule2** ppModule)
+{
+    HRESULT hr = S_OK;
+    CComPtr<CModule> pModule;
+
+    IfFalseGo( ppModule, E_INVALIDARG );
+    *ppModule = NULL;
+
+    IfFailGo( this->GetModule(&pModule) );
+    IfFailGo( pModule->QueryInterface(IID_IDebugModule2, (void**) ppModule) );
+
+Error:
+
+    return hr;
+}
+```
+
+## See Also
+[IDebugCodeContext3](../../../extensibility/debugger/reference/idebugcodecontext3.md)


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.