### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/idebugcodecontext3-getprocess.md
+++ b/docs/extensibility/debugger/reference/idebugcodecontext3-getprocess.md
@@ -2,61 +2,61 @@
 title: "IDebugCodeContext3::GetProcess | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "IDebugCodeContext3::GetProcess"
 ms.assetid: e082e494-2255-4d9d-a5a9-6dadd904bea8
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # IDebugCodeContext3::GetProcess
-Retrieves a reference to the interface of the debug process.  
-  
-## Syntax  
-  
-```cpp  
-HRESULT GetProcess(   
-   IDebugProcess2 **ppProcess  
-);  
-```  
-  
-```csharp  
-public int GetProcess(   
-   out IDebugProcess2 ppProcess  
-);  
-```  
-  
-#### Parameters  
- `ppProcess`  
- [out] Reference to the debug process interface.  
-  
-## Return Value  
- If successful, returns `S_OK`; otherwise, returns an error code.  
-  
-## Example  
- The following example shows how to implement this method for a **CDebugCodeContext** object that exposes the [IDebugBeforeSymbolSearchEvent2](../../../extensibility/debugger/reference/idebugbeforesymbolsearchevent2.md) interface.  
-  
-```cpp  
-HRESULT CDebugCodeContext::GetProcess(IDebugProcess2** ppProcess)  
-{  
-    HRESULT hr = S_OK;  
-    CComPtr<CDebugEngine> pEngine;  
-    CComPtr<IDebugPort2> pPort2;  
-  
-    IfFalseGo( ppProcess, E_INVALIDARG );  
-    *ppProcess = NULL;  
-  
-    IfFalseGo( m_pProgram, E_FAIL );  
-    IfFailGo( ((CDebugProgram *)m_pProgram)->GetEngine(&pEngine) );  
-    IfFailGo( pEngine->GetSDMProcess(ppProcess) );  
-  
-Error:  
-  
-    return hr;  
-}  
-```  
-  
-## See Also  
- [IDebugCodeContext3](../../../extensibility/debugger/reference/idebugcodecontext3.md)
+Retrieves a reference to the interface of the debug process.
+
+## Syntax
+
+```cpp
+HRESULT GetProcess(
+   IDebugProcess2 **ppProcess
+);
+```
+
+```csharp
+public int GetProcess(
+   out IDebugProcess2 ppProcess
+);
+```
+
+#### Parameters
+`ppProcess`  
+[out] Reference to the debug process interface.
+
+## Return Value
+If successful, returns `S_OK`; otherwise, returns an error code.
+
+## Example
+The following example shows how to implement this method for a **CDebugCodeContext** object that exposes the [IDebugBeforeSymbolSearchEvent2](../../../extensibility/debugger/reference/idebugbeforesymbolsearchevent2.md) interface.
+
+```cpp
+HRESULT CDebugCodeContext::GetProcess(IDebugProcess2** ppProcess)
+{
+    HRESULT hr = S_OK;
+    CComPtr<CDebugEngine> pEngine;
+    CComPtr<IDebugPort2> pPort2;
+
+    IfFalseGo( ppProcess, E_INVALIDARG );
+    *ppProcess = NULL;
+
+    IfFalseGo( m_pProgram, E_FAIL );
+    IfFailGo( ((CDebugProgram *)m_pProgram)->GetEngine(&pEngine) );
+    IfFailGo( pEngine->GetSDMProcess(ppProcess) );
+
+Error:
+
+    return hr;
+}
+```
+
+## See Also
+[IDebugCodeContext3](../../../extensibility/debugger/reference/idebugcodecontext3.md)

--- a/docs/extensibility/debugger/reference/idebugcodecontext3-getprocess.md
+++ b/docs/extensibility/debugger/reference/idebugcodecontext3-getprocess.md
@@ -18,13 +18,13 @@ Retrieves a reference to the interface of the debug process.
 
 ```cpp
 HRESULT GetProcess(
-   IDebugProcess2 **ppProcess
+    IDebugProcess2 **ppProcess
 );
 ```
 
 ```csharp
 public int GetProcess(
-   out IDebugProcess2 ppProcess
+    out IDebugProcess2 ppProcess
 );
 ```
 


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.