### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/idebugcomplussymbolprovider-createtypefromprimitive.md
+++ b/docs/extensibility/debugger/reference/idebugcomplussymbolprovider-createtypefromprimitive.md
@@ -2,91 +2,91 @@
 title: "IDebugComPlusSymbolProvider::CreateTypeFromPrimitive | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "IDebugComPlusSymbolProvider::CreateTypeFromPrimitive"
   - "CreateTypeFromPrimitive"
 ms.assetid: 37213cc2-a038-42ea-9b28-3ae40d4cfe69
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # IDebugComPlusSymbolProvider::CreateTypeFromPrimitive
-Creates a type from the specified primitive type.  
-  
-## Syntax  
-  
-```  
-[C++]  
-HRESULT CreateTypeFromPrimitive(  
-   DWORD          dwPrimType,  
-   IDebugAddress* pAddress,  
-   IDebugField**  ppType  
-);  
-```  
-  
-```  
-[C#]  
-int CreateTypeFromPrimitive(  
-   uint          dwPrimType,  
-   IDebugAddress pAddress,  
-   IDebugField   ppType  
-);  
-```  
-  
-#### Parameters  
- `dwPrimType`  
- [in] Value from the [CorElementType Enumeration](/dotnet/framework/unmanaged-api/metadata/corelementtype-enumeration) that represents the primitive type.  
-  
- `pAddress`  
- [in] An address object represented by an [IDebugAddress](../../../extensibility/debugger/reference/idebugaddress.md) interface.  
-  
- `ppType`  
- [in] Returns an [IDebugField](../../../extensibility/debugger/reference/idebugfield.md) object that describes the type.  
-  
-## Return Value  
- If successful, returns `S_OK`; otherwise, returns an error code.  
-  
-## Example  
- The following example shows how to implement this method for a **CDebugSymbolProvider** object that exposes the [IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md) interface.  
-  
-```cpp  
-HRESULT CDebugSymbolProvider::CreateTypeFromPrimitive(  
-    DWORD dwPrimType,  
-    IDebugAddress* pAddress,  
-    IDebugField** ppType)  
-{  
-    HRESULT hr = S_OK;  
-    CDEBUG_ADDRESS addr;  
-    const COR_SIGNATURE* pTypeInfo = (const COR_SIGNATURE*) & dwPrimType;  
-    CDebugGenericParamScope* pGenScope = NULL;  
-  
-    //  
-    // This function will only work for primitive types  
-    //  
-  
-    METHOD_ENTRY( CDebugSymbolProvider::CreateTypeFromPrimitive );  
-  
-    IfFailGo( pAddress->GetAddress( &addr ) );  
-  
-    IfNullGo( pGenScope = new CDebugGenericParamScope(addr.GetModule(), addr.tokClass, addr.GetMethod()), E_OUTOFMEMORY );  
-  
-    IfFailGo( CreateType( pTypeInfo,  
-                          1,  
-                          addr.GetModule(),  
-                          addr.GetMethod(),  
-                          pGenScope,  
-                          ppType ) );  
-  
-    METHOD_EXIT( CDebugSymbolProvider::CreateTypeFromPrimitive, hr );  
-  
-Error:  
-  
-    RELEASE( pGenScope );  
-    return hr;  
-}  
-```  
-  
-## See Also  
- [IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md)
+Creates a type from the specified primitive type.
+
+## Syntax
+
+```
+[C++]
+HRESULT CreateTypeFromPrimitive(
+   DWORD          dwPrimType,
+   IDebugAddress* pAddress,
+   IDebugField**  ppType
+);
+```
+
+```
+[C#]
+int CreateTypeFromPrimitive(
+   uint          dwPrimType,
+   IDebugAddress pAddress,
+   IDebugField   ppType
+);
+```
+
+#### Parameters
+`dwPrimType`  
+[in] Value from the [CorElementType Enumeration](/dotnet/framework/unmanaged-api/metadata/corelementtype-enumeration) that represents the primitive type.
+
+`pAddress`  
+[in] An address object represented by an [IDebugAddress](../../../extensibility/debugger/reference/idebugaddress.md) interface.
+
+`ppType`  
+[in] Returns an [IDebugField](../../../extensibility/debugger/reference/idebugfield.md) object that describes the type.
+
+## Return Value
+If successful, returns `S_OK`; otherwise, returns an error code.
+
+## Example
+The following example shows how to implement this method for a **CDebugSymbolProvider** object that exposes the [IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md) interface.
+
+```cpp
+HRESULT CDebugSymbolProvider::CreateTypeFromPrimitive(
+    DWORD dwPrimType,
+    IDebugAddress* pAddress,
+    IDebugField** ppType)
+{
+    HRESULT hr = S_OK;
+    CDEBUG_ADDRESS addr;
+    const COR_SIGNATURE* pTypeInfo = (const COR_SIGNATURE*) & dwPrimType;
+    CDebugGenericParamScope* pGenScope = NULL;
+
+    //
+    // This function will only work for primitive types
+    //
+
+    METHOD_ENTRY( CDebugSymbolProvider::CreateTypeFromPrimitive );
+
+    IfFailGo( pAddress->GetAddress( &addr ) );
+
+    IfNullGo( pGenScope = new CDebugGenericParamScope(addr.GetModule(), addr.tokClass, addr.GetMethod()), E_OUTOFMEMORY );
+
+    IfFailGo( CreateType( pTypeInfo,
+                          1,
+                          addr.GetModule(),
+                          addr.GetMethod(),
+                          pGenScope,
+                          ppType ) );
+
+    METHOD_EXIT( CDebugSymbolProvider::CreateTypeFromPrimitive, hr );
+
+Error:
+
+    RELEASE( pGenScope );
+    return hr;
+}
+```
+
+## See Also
+[IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md)

--- a/docs/extensibility/debugger/reference/idebugcomplussymbolprovider-createtypefromprimitive.md
+++ b/docs/extensibility/debugger/reference/idebugcomplussymbolprovider-createtypefromprimitive.md
@@ -20,18 +20,18 @@ Creates a type from the specified primitive type.
 ```
 [C++]
 HRESULT CreateTypeFromPrimitive(
-   DWORD          dwPrimType,
-   IDebugAddress* pAddress,
-   IDebugField**  ppType
+    DWORD          dwPrimType,
+    IDebugAddress* pAddress,
+    IDebugField**  ppType
 );
 ```
 
 ```
 [C#]
 int CreateTypeFromPrimitive(
-   uint          dwPrimType,
-   IDebugAddress pAddress,
-   IDebugField   ppType
+    uint          dwPrimType,
+    IDebugAddress pAddress,
+    IDebugField   ppType
 );
 ```
 


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.