### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/idebugcomplussymbolprovider-getassemblyname.md
+++ b/docs/extensibility/debugger/reference/idebugcomplussymbolprovider-getassemblyname.md
@@ -20,18 +20,18 @@ Retrieves the name of the assembly given its module and application domain.
 ```
 [C++]
 HRESULT GetAssemblyName(
-   ULONG32 ulAppDomainID,
-   GUID    guidModule,
-   BSTR*   pbstrName
+    ULONG32 ulAppDomainID,
+    GUID    guidModule,
+    BSTR*   pbstrName
 );
 ```
 
 ```
 [C#]
 int GetAssemblyName(
-   uint   ulAppDomainID,
-   Guid   guidModule,
-   string pbstrName
+    uint   ulAppDomainID,
+    Guid   guidModule,
+    string pbstrName
 );
 ```
 

--- a/docs/extensibility/debugger/reference/idebugcomplussymbolprovider-getassemblyname.md
+++ b/docs/extensibility/debugger/reference/idebugcomplussymbolprovider-getassemblyname.md
@@ -2,80 +2,80 @@
 title: "IDebugComPlusSymbolProvider::GetAssemblyName | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "IDebugComPlusSymbolProvider::GetAssemblyName"
   - "GetAssemblyName"
 ms.assetid: a08cd609-b9b9-47bd-bf73-cbf851285907
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # IDebugComPlusSymbolProvider::GetAssemblyName
-Retrieves the name of the assembly given its module and application domain.  
-  
-## Syntax  
-  
-```  
-[C++]  
-HRESULT GetAssemblyName(  
-   ULONG32 ulAppDomainID,  
-   GUID    guidModule,  
-   BSTR*   pbstrName  
-);  
-```  
-  
-```  
-[C#]  
-int GetAssemblyName(  
-   uint   ulAppDomainID,  
-   Guid   guidModule,  
-   string pbstrName  
-);  
-```  
-  
-#### Parameters  
- `ulAppDomainID`  
- [in] Identifier for the application domain.  
-  
- `guidModule`  
- [in] Unique identifier for the module.  
-  
- `pbstrName`  
- [out] Returns the name of the assembly.  
-  
-## Return Value  
- If successful, returns `S_OK`; otherwise, returns an error code.  
-  
-## Example  
- The following example shows how to implement this method for a **CDebugSymbolProvider** object that exposes the [IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md) interface.  
-  
-```cpp  
-HRESULT CDebugSymbolProvider::GetAssemblyName(  
-    ULONG32 ulAppDomainID,  
-    GUID guidModule,  
-    BSTR* pbstrName  
-)  
-{  
-    HRESULT hr = S_OK;  
-    Module_ID idModule(ulAppDomainID, guidModule);  
-    CComPtr<IMetaDataImport> pMetadata;  
-  
-    METHOD_ENTRY( CDebugSymbolProvider::GetMetadataForModule );  
-  
-    IfFalseGo( pbstrName, E_INVALIDARG );  
-    *pbstrName = NULL;  
-  
-    IfFailGo( GetMetadata( idModule, &pMetadata ) );  
-    IfFailGo( GetAssemblyName( pMetadata, 0, pbstrName ) );  
-  
-Error:  
-  
-    METHOD_EXIT( CDebugSymbolProvider::GetMetadataForModule, hr );  
-    return hr;  
-}  
-```  
-  
-## See Also  
- [IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md)
+Retrieves the name of the assembly given its module and application domain.
+
+## Syntax
+
+```
+[C++]
+HRESULT GetAssemblyName(
+   ULONG32 ulAppDomainID,
+   GUID    guidModule,
+   BSTR*   pbstrName
+);
+```
+
+```
+[C#]
+int GetAssemblyName(
+   uint   ulAppDomainID,
+   Guid   guidModule,
+   string pbstrName
+);
+```
+
+#### Parameters
+`ulAppDomainID`  
+[in] Identifier for the application domain.
+
+`guidModule`  
+[in] Unique identifier for the module.
+
+`pbstrName`  
+[out] Returns the name of the assembly.
+
+## Return Value
+If successful, returns `S_OK`; otherwise, returns an error code.
+
+## Example
+The following example shows how to implement this method for a **CDebugSymbolProvider** object that exposes the [IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md) interface.
+
+```cpp
+HRESULT CDebugSymbolProvider::GetAssemblyName(
+    ULONG32 ulAppDomainID,
+    GUID guidModule,
+    BSTR* pbstrName
+)
+{
+    HRESULT hr = S_OK;
+    Module_ID idModule(ulAppDomainID, guidModule);
+    CComPtr<IMetaDataImport> pMetadata;
+
+    METHOD_ENTRY( CDebugSymbolProvider::GetMetadataForModule );
+
+    IfFalseGo( pbstrName, E_INVALIDARG );
+    *pbstrName = NULL;
+
+    IfFailGo( GetMetadata( idModule, &pMetadata ) );
+    IfFailGo( GetAssemblyName( pMetadata, 0, pbstrName ) );
+
+Error:
+
+    METHOD_EXIT( CDebugSymbolProvider::GetMetadataForModule, hr );
+    return hr;
+}
+```
+
+## See Also
+[IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md)


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.