### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/idebugcomplussymbolprovider-getattributedclassesforlanguage.md
+++ b/docs/extensibility/debugger/reference/idebugcomplussymbolprovider-getattributedclassesforlanguage.md
@@ -20,18 +20,18 @@ Retrieves the classes with the specified attribute that are implemented in the s
 ```
 [C++]
 HRESULT GetAttributedClassesForLanguage (
-   GUID               guidLanguage,
-   LPOLESTR           pstrAttribute,
-   IEnumDebugFields** ppEnum
+    GUID               guidLanguage,
+    LPOLESTR           pstrAttribute,
+    IEnumDebugFields** ppEnum
 );
 ```
 
 ```
 [C#]
 int GetAttributedClassesForLanguage (
-   Guid                 guidLanguage,
-   string               pstrAttribute,
-   out IEnumDebugFields ppEnum
+    Guid                 guidLanguage,
+    string               pstrAttribute,
+    out IEnumDebugFields ppEnum
 );
 ```
 

--- a/docs/extensibility/debugger/reference/idebugcomplussymbolprovider-getattributedclassesforlanguage.md
+++ b/docs/extensibility/debugger/reference/idebugcomplussymbolprovider-getattributedclassesforlanguage.md
@@ -2,182 +2,182 @@
 title: "IDebugComPlusSymbolProvider::GetAttributedClassesForLanguage | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "GetAttributedClassesForLanguage"
   - "IDebugComPlusSymbolProvider::GetAttributedClassesForLanguage"
 ms.assetid: e5b1b8b6-52a6-4ade-9a36-644abfa9f4b2
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # IDebugComPlusSymbolProvider::GetAttributedClassesForLanguage
-Retrieves the classes with the specified attribute that are implemented in the specified programming language.  
-  
-## Syntax  
-  
-```  
-[C++]  
-HRESULT GetAttributedClassesForLanguage (  
-   GUID               guidLanguage,  
-   LPOLESTR           pstrAttribute,  
-   IEnumDebugFields** ppEnum  
-);  
-```  
-  
-```  
-[C#]  
-int GetAttributedClassesForLanguage (  
-   Guid                 guidLanguage,  
-   string               pstrAttribute,  
-   out IEnumDebugFields ppEnum  
-);  
-```  
-  
-#### Parameters  
- `guidLanguage`  
- [in] Unique identifier for the language.  
-  
- `pstrAttribute`  
- [in] The attribute string.  
-  
- `ppEnum`  
- [out] Returns an enumeration of the attribute classes.  
-  
-## Return Value  
- If successful, returns `S_OK`; otherwise, returns an error code.  
-  
-## Example  
- The following example shows how to implement this method for a **CDebugSymbolProvider** object that exposes the [IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md) interface.  
-  
-```cpp  
-HRESULT CDebugSymbolProvider::GetAttributedClassesForLanguage(  
-    GUID guidLanguage,  
-    __in_z LPOLESTR pstrAttribute,  
-    IEnumDebugFields** ppEnum  
-)  
-{  
-    HRESULT hr = S_OK;  
-    CFieldList listFields;  
-    CModIter ModIter;  
-    CModule* pModule; // the iterator owns the reference  
-    ULONG cClasses = 0;  
-    DWORD iTypeDef = 0;  
-    mdTypeDef* rgTypeDefs = NULL;  
-    IDebugField** rgFields = NULL;  
-    DWORD ctField = 0;  
-    CEnumDebugFields* pEnumFields = NULL;  
-  
-    ASSERT(IsValidObjectPtr(this, CDebugSymbolProvider));  
-    ASSERT(IsValidWritePtr(ppEnum, IEnumDebugFields*));  
-  
-    METHOD_ENTRY( CDebugSymbolProvider::GetAttributedClassesForLanguage );  
-  
-    IfFalseGo( ppEnum, E_INVALIDARG );  
-    *ppEnum = NULL;  
-  
-    // For Each Module - call EnumFields  
-    IfFailGo( GetModuleIter(&ModIter) );  
-  
-    // Find the Max number of classes  
-    while (ModIter.GetNext(&pModule))  
-    {  
-        CComPtr<IMetaDataImport> pMetaData;  
-        HCORENUM hEnum = 0;  
-        ULONG cTypeDefs;  
-        ULONG cEnum;  
-  
-        pModule->GetMetaData( &pMetaData );  
-  
-        IfFailGo( pMetaData->EnumTypeDefs( &hEnum,  
-                                           NULL,  
-                                           0,  
-                                           &cTypeDefs ) );  
-        IfFailGo( pMetaData->CountEnum( hEnum, &cEnum ) );  
-        cClasses += cEnum;  
-    }  
-  
-    IfNullGo( rgTypeDefs = new mdTypeDef[cClasses], E_OUTOFMEMORY );  
-    IfNullGo( rgFields = new IDebugField * [cClasses], E_OUTOFMEMORY );  
-  
-    ModIter.Reset();  
-  
-    // Create the classes  
-    while (ModIter.GetNext(&pModule))  
-    {  
-        CComPtr<IMetaDataImport> pMetaData;  
-        HCORENUM hEnum = 0;  
-        ULONG cTypeDefs;  
-        ULONG cEnum;  
-        const void* pUnused;  
-        ULONG cbUnused;  
-  
-        pModule->GetMetaData( &pMetaData );  
-  
-        IfFailGo( pMetaData->EnumTypeDefs( &hEnum,  
-                                           NULL,  
-                                           0,  
-                                           &cTypeDefs ) );  
-        IfFailGo( pMetaData->CountEnum( hEnum, &cEnum ) );  
-        IfFailGo( pMetaData->EnumTypeDefs( &hEnum,  
-                                           rgTypeDefs,  
-                                           cEnum,  
-                                           &cTypeDefs ) );  
-  
-        pMetaData->CloseEnum(hEnum);  
-        hEnum = NULL;  
-  
-        for ( iTypeDef = 0; iTypeDef < cTypeDefs; iTypeDef++)  
-        {  
-  
-            if (pMetaData->GetCustomAttributeByName( rgTypeDefs[iTypeDef],  
-                    pstrAttribute,  
-                    &pUnused,  
-                    &cbUnused ) == S_OK)  
-            {  
-                // Only return classes implemeted in the correct language  
-  
-                if (pModule->ClassImplementedInLanguage( rgTypeDefs[iTypeDef],  
-                        guidLanguage) )  
-                {  
-                    if (CreateClassType( pModule->GetID(),  
-                                         rgTypeDefs[iTypeDef],  
-                                         rgFields + ctField) == S_OK)  
-                    {  
-                        ctField++;  
-                    }  
-                    else  
-                    {  
-                        ASSERT(!"Failed to Create Attributed Class");  
-                    }  
-                }  
-            }  
-        }  
-    }  
-  
-    IfNullGo( pEnumFields = new CEnumDebugFields, E_OUTOFMEMORY );  
-    IfFailGo( pEnumFields->Initialize(rgFields, ctField) );  
-    IfFailGo( pEnumFields->QueryInterface( __uuidof(IEnumDebugFields),  
-                                           (void**) ppEnum ) );  
-  
-Error:  
-  
-    METHOD_EXIT( CDebugSymbolProvider::GetAttributedClassesForLanguage, hr );  
-  
-    DELETERG( rgTypeDefs );  
-  
-    for ( iTypeDef = 0; iTypeDef < ctField; iTypeDef++)  
-    {  
-        RELEASE( rgFields[iTypeDef] );  
-    }  
-  
-    DELETERG( rgFields );  
-    RELEASE( pEnumFields );  
-  
-    return hr;  
-}  
-```  
-  
-## See Also  
- [IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md)
+Retrieves the classes with the specified attribute that are implemented in the specified programming language.
+
+## Syntax
+
+```
+[C++]
+HRESULT GetAttributedClassesForLanguage (
+   GUID               guidLanguage,
+   LPOLESTR           pstrAttribute,
+   IEnumDebugFields** ppEnum
+);
+```
+
+```
+[C#]
+int GetAttributedClassesForLanguage (
+   Guid                 guidLanguage,
+   string               pstrAttribute,
+   out IEnumDebugFields ppEnum
+);
+```
+
+#### Parameters
+`guidLanguage`  
+[in] Unique identifier for the language.
+
+`pstrAttribute`  
+[in] The attribute string.
+
+`ppEnum`  
+[out] Returns an enumeration of the attribute classes.
+
+## Return Value
+If successful, returns `S_OK`; otherwise, returns an error code.
+
+## Example
+The following example shows how to implement this method for a **CDebugSymbolProvider** object that exposes the [IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md) interface.
+
+```cpp
+HRESULT CDebugSymbolProvider::GetAttributedClassesForLanguage(
+    GUID guidLanguage,
+    __in_z LPOLESTR pstrAttribute,
+    IEnumDebugFields** ppEnum
+)
+{
+    HRESULT hr = S_OK;
+    CFieldList listFields;
+    CModIter ModIter;
+    CModule* pModule; // the iterator owns the reference
+    ULONG cClasses = 0;
+    DWORD iTypeDef = 0;
+    mdTypeDef* rgTypeDefs = NULL;
+    IDebugField** rgFields = NULL;
+    DWORD ctField = 0;
+    CEnumDebugFields* pEnumFields = NULL;
+
+    ASSERT(IsValidObjectPtr(this, CDebugSymbolProvider));
+    ASSERT(IsValidWritePtr(ppEnum, IEnumDebugFields*));
+
+    METHOD_ENTRY( CDebugSymbolProvider::GetAttributedClassesForLanguage );
+
+    IfFalseGo( ppEnum, E_INVALIDARG );
+    *ppEnum = NULL;
+
+    // For Each Module - call EnumFields
+    IfFailGo( GetModuleIter(&ModIter) );
+
+    // Find the Max number of classes
+    while (ModIter.GetNext(&pModule))
+    {
+        CComPtr<IMetaDataImport> pMetaData;
+        HCORENUM hEnum = 0;
+        ULONG cTypeDefs;
+        ULONG cEnum;
+
+        pModule->GetMetaData( &pMetaData );
+
+        IfFailGo( pMetaData->EnumTypeDefs( &hEnum,
+                                           NULL,
+                                           0,
+                                           &cTypeDefs ) );
+        IfFailGo( pMetaData->CountEnum( hEnum, &cEnum ) );
+        cClasses += cEnum;
+    }
+
+    IfNullGo( rgTypeDefs = new mdTypeDef[cClasses], E_OUTOFMEMORY );
+    IfNullGo( rgFields = new IDebugField * [cClasses], E_OUTOFMEMORY );
+
+    ModIter.Reset();
+
+    // Create the classes
+    while (ModIter.GetNext(&pModule))
+    {
+        CComPtr<IMetaDataImport> pMetaData;
+        HCORENUM hEnum = 0;
+        ULONG cTypeDefs;
+        ULONG cEnum;
+        const void* pUnused;
+        ULONG cbUnused;
+
+        pModule->GetMetaData( &pMetaData );
+
+        IfFailGo( pMetaData->EnumTypeDefs( &hEnum,
+                                           NULL,
+                                           0,
+                                           &cTypeDefs ) );
+        IfFailGo( pMetaData->CountEnum( hEnum, &cEnum ) );
+        IfFailGo( pMetaData->EnumTypeDefs( &hEnum,
+                                           rgTypeDefs,
+                                           cEnum,
+                                           &cTypeDefs ) );
+
+        pMetaData->CloseEnum(hEnum);
+        hEnum = NULL;
+
+        for ( iTypeDef = 0; iTypeDef < cTypeDefs; iTypeDef++)
+        {
+
+            if (pMetaData->GetCustomAttributeByName( rgTypeDefs[iTypeDef],
+                    pstrAttribute,
+                    &pUnused,
+                    &cbUnused ) == S_OK)
+            {
+                // Only return classes implemeted in the correct language
+
+                if (pModule->ClassImplementedInLanguage( rgTypeDefs[iTypeDef],
+                        guidLanguage) )
+                {
+                    if (CreateClassType( pModule->GetID(),
+                                         rgTypeDefs[iTypeDef],
+                                         rgFields + ctField) == S_OK)
+                    {
+                        ctField++;
+                    }
+                    else
+                    {
+                        ASSERT(!"Failed to Create Attributed Class");
+                    }
+                }
+            }
+        }
+    }
+
+    IfNullGo( pEnumFields = new CEnumDebugFields, E_OUTOFMEMORY );
+    IfFailGo( pEnumFields->Initialize(rgFields, ctField) );
+    IfFailGo( pEnumFields->QueryInterface( __uuidof(IEnumDebugFields),
+                                           (void**) ppEnum ) );
+
+Error:
+
+    METHOD_EXIT( CDebugSymbolProvider::GetAttributedClassesForLanguage, hr );
+
+    DELETERG( rgTypeDefs );
+
+    for ( iTypeDef = 0; iTypeDef < ctField; iTypeDef++)
+    {
+        RELEASE( rgFields[iTypeDef] );
+    }
+
+    DELETERG( rgFields );
+    RELEASE( pEnumFields );
+
+    return hr;
+}
+```
+
+## See Also
+[IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md)


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.