### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/idebugcomplussymbolprovider-getentrypoint.md
+++ b/docs/extensibility/debugger/reference/idebugcomplussymbolprovider-getentrypoint.md
@@ -2,84 +2,84 @@
 title: "IDebugComPlusSymbolProvider::GetEntryPoint | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "IDebugComPlusSymbolProvider::GetEntryPoint"
   - "GetEntryPoint"
 ms.assetid: 9640e121-1da1-41f9-8e66-76efca36baf2
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # IDebugComPlusSymbolProvider::GetEntryPoint
-Retrieves the application entry point.  
-  
-## Syntax  
-  
-```cpp  
-HRESULT GetEntryPoint(  
-   ULONG32         ulAppDomainID,  
-   GUID            guidModule,  
-   IDebugAddress** ppAddress  
-);  
-```  
-  
-```csharp  
-int GetEntryPoint(  
-   uint              ulAppDomainID,  
-   Guid              guidModule,  
-   out IDebugAddress ppAddress  
-);  
-```  
-  
-#### Parameters  
- `ulAppDomainID`  
- [in] Identifier for the application domain.  
-  
- `guidModule`  
- [in] Unique identifier for the module.  
-  
- `ppAddress`  
- [out] Returns the entry point represented by an [IDebugAddress](../../../extensibility/debugger/reference/idebugaddress.md) interface.  
-  
-## Return Value  
- If successful, returns `S_OK`; otherwise, returns an error code.  
-  
-## Example  
- The following example shows how to implement this method for a **CDebugSymbolProvider** object that exposes the [IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md) interface.  
-  
-```cpp  
-HRESULT CDebugSymbolProvider::GetEntryPoint(  
-    ULONG32 ulAppDomainID,  
-    GUID guidModule,  
-    IDebugAddress **ppAddress  
-)  
-{  
-    HRESULT hr = S_OK;  
-    CComPtr<CModule> pModule;  
-    Module_ID idModule(ulAppDomainID, guidModule);  
-  
-    ASSERT(IsValidObjectPtr(this, CDebugSymbolProvider));  
-    ASSERT(IsValidWritePtr(ppAddress, IDebugAddress *));  
-  
-    METHOD_ENTRY( CDebugSymbolProvider::GetEntryPoint );  
-  
-    IfFalseGo( ppAddress, E_INVALIDARG );  
-  
-    *ppAddress = NULL;  
-  
-    IfFailGo( GetModule( idModule, &pModule) );  
-  
-    IfFailGo( pModule->GetEntryPoint( ppAddress ) );  
-  
-Error:  
-  
-    METHOD_EXIT( CDebugSymbolProvider::GetEntryPoint, hr );  
-  
-    return hr;  
-}  
-```  
-  
-## See Also  
- [IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md)
+Retrieves the application entry point.
+
+## Syntax
+
+```cpp
+HRESULT GetEntryPoint(
+   ULONG32         ulAppDomainID,
+   GUID            guidModule,
+   IDebugAddress** ppAddress
+);
+```
+
+```csharp
+int GetEntryPoint(
+   uint              ulAppDomainID,
+   Guid              guidModule,
+   out IDebugAddress ppAddress
+);
+```
+
+#### Parameters
+`ulAppDomainID`  
+[in] Identifier for the application domain.
+
+`guidModule`  
+[in] Unique identifier for the module.
+
+`ppAddress`  
+[out] Returns the entry point represented by an [IDebugAddress](../../../extensibility/debugger/reference/idebugaddress.md) interface.
+
+## Return Value
+If successful, returns `S_OK`; otherwise, returns an error code.
+
+## Example
+The following example shows how to implement this method for a **CDebugSymbolProvider** object that exposes the [IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md) interface.
+
+```cpp
+HRESULT CDebugSymbolProvider::GetEntryPoint(
+    ULONG32 ulAppDomainID,
+    GUID guidModule,
+    IDebugAddress **ppAddress
+)
+{
+    HRESULT hr = S_OK;
+    CComPtr<CModule> pModule;
+    Module_ID idModule(ulAppDomainID, guidModule);
+
+    ASSERT(IsValidObjectPtr(this, CDebugSymbolProvider));
+    ASSERT(IsValidWritePtr(ppAddress, IDebugAddress *));
+
+    METHOD_ENTRY( CDebugSymbolProvider::GetEntryPoint );
+
+    IfFalseGo( ppAddress, E_INVALIDARG );
+
+    *ppAddress = NULL;
+
+    IfFailGo( GetModule( idModule, &pModule) );
+
+    IfFailGo( pModule->GetEntryPoint( ppAddress ) );
+
+Error:
+
+    METHOD_EXIT( CDebugSymbolProvider::GetEntryPoint, hr );
+
+    return hr;
+}
+```
+
+## See Also
+[IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md)

--- a/docs/extensibility/debugger/reference/idebugcomplussymbolprovider-getentrypoint.md
+++ b/docs/extensibility/debugger/reference/idebugcomplussymbolprovider-getentrypoint.md
@@ -19,17 +19,17 @@ Retrieves the application entry point.
 
 ```cpp
 HRESULT GetEntryPoint(
-   ULONG32         ulAppDomainID,
-   GUID            guidModule,
-   IDebugAddress** ppAddress
+    ULONG32         ulAppDomainID,
+    GUID            guidModule,
+    IDebugAddress** ppAddress
 );
 ```
 
 ```csharp
 int GetEntryPoint(
-   uint              ulAppDomainID,
-   Guid              guidModule,
-   out IDebugAddress ppAddress
+    uint              ulAppDomainID,
+    Guid              guidModule,
+    out IDebugAddress ppAddress
 );
 ```
 


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.