### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/idebugcomplussymbolprovider-getfunctionlineoffset.md
+++ b/docs/extensibility/debugger/reference/idebugcomplussymbolprovider-getfunctionlineoffset.md
@@ -2,97 +2,97 @@
 title: "IDebugComPlusSymbolProvider::GetFunctionLineOffset | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "IDebugComPlusSymbolProvider::GetFunctionLineOffset"
   - "GetFunctionLineOffset"
 ms.assetid: 51460f5a-4e98-427a-8315-27246e24fb61
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # IDebugComPlusSymbolProvider::GetFunctionLineOffset
-Retrieves the address within a function that represents the given line offset.  
-  
-## Syntax  
-  
-```cpp  
-HRESULT GetFunctionLineOffset(  
-   IDebugAddress*  pAddress,   
-   DWORD           dwLine,   
-   IDebugAddress** ppNewAddress   
-);  
-```  
-  
-```csharp  
-int GetFunctionLineOffset(  
-   IDebugAddress     pAddress,   
-   uint              dwLine,   
-   out IDebugAddress ppNewAddress  
-);  
-```  
-  
-#### Parameters  
- `pAddress`  
- [in] Address that represents function.  
-  
- `dwLine`  
- [in] Line offset from beginning of function.  
-  
- `ppNewAddress`  
- [out] New address that represents line offset from beginning of function.  
-  
-## Return Value  
- If successful, returns `S_OK`; otherwise, returns an error code.  
-  
-## Example  
- The following example shows how to implement this method for a **CDebugSymbolProvider** object that exposes the [IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md) interface.  
-  
-```cpp  
-HRESULT CDebugSymbolProvider::GetFunctionLineOffset(  
-    IDebugAddress *pAddress,  
-    DWORD dwLine,  
-    IDebugAddress **ppNewAddress  
-)  
-{  
-    HRESULT hr = S_OK;  
-    CDEBUG_ADDRESS address;  
-    CComPtr<CModule> pModule;  
-    DWORD dwOffset;  
-    CDebugAddress* paddr = NULL;  
-  
-    METHOD_ENTRY(CDebugSymbolProvider::GetFunctionLineOffset);  
-  
-    IfFalseGo( pAddress, S_FALSE );  
-    IfFailGo( pAddress->GetAddress( &address ) );  
-  
-    ASSERT(address.addr.dwKind == ADDRESS_KIND_METADATA_METHOD);  
-    IfFalseGo( address.addr.dwKind == ADDRESS_KIND_METADATA_METHOD, S_FALSE );  
-  
-    IfFailGo( GetModule( address.GetModule(), &pModule) );  
-  
-    // Find the first offset for dwLine in the function  
-  
-    IfFailGo( pModule->GetFunctionLineOffset( address.addr.addr.addrMethod.tokMethod,  
-              address.addr.addr.addrMethod.dwVersion,  
-              dwLine,  
-              &dwOffset ) );  
-  
-    // Create the new Address  
-  
-    address.addr.addr.addrMethod.dwOffset = dwOffset;  
-    IfNullGo( paddr = new CDebugAddress(address), E_OUTOFMEMORY );  
-    IfFailGo( paddr->QueryInterface( __uuidof(IDebugAddress),  
-                                     (void**) ppNewAddress ) );  
-  
-Error:  
-  
-    METHOD_EXIT(CDebugSymbolProvider::GetFunctionLineOffset, hr);  
-    RELEASE( paddr );  
-    return hr;  
-}  
-```  
-  
-## See Also  
- [IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md)
+Retrieves the address within a function that represents the given line offset.
+
+## Syntax
+
+```cpp
+HRESULT GetFunctionLineOffset(
+   IDebugAddress*  pAddress,
+   DWORD           dwLine,
+   IDebugAddress** ppNewAddress
+);
+```
+
+```csharp
+int GetFunctionLineOffset(
+   IDebugAddress     pAddress,
+   uint              dwLine,
+   out IDebugAddress ppNewAddress
+);
+```
+
+#### Parameters
+`pAddress`  
+[in] Address that represents function.
+
+`dwLine`  
+[in] Line offset from beginning of function.
+
+`ppNewAddress`  
+[out] New address that represents line offset from beginning of function.
+
+## Return Value
+If successful, returns `S_OK`; otherwise, returns an error code.
+
+## Example
+The following example shows how to implement this method for a **CDebugSymbolProvider** object that exposes the [IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md) interface.
+
+```cpp
+HRESULT CDebugSymbolProvider::GetFunctionLineOffset(
+    IDebugAddress *pAddress,
+    DWORD dwLine,
+    IDebugAddress **ppNewAddress
+)
+{
+    HRESULT hr = S_OK;
+    CDEBUG_ADDRESS address;
+    CComPtr<CModule> pModule;
+    DWORD dwOffset;
+    CDebugAddress* paddr = NULL;
+
+    METHOD_ENTRY(CDebugSymbolProvider::GetFunctionLineOffset);
+
+    IfFalseGo( pAddress, S_FALSE );
+    IfFailGo( pAddress->GetAddress( &address ) );
+
+    ASSERT(address.addr.dwKind == ADDRESS_KIND_METADATA_METHOD);
+    IfFalseGo( address.addr.dwKind == ADDRESS_KIND_METADATA_METHOD, S_FALSE );
+
+    IfFailGo( GetModule( address.GetModule(), &pModule) );
+
+    // Find the first offset for dwLine in the function
+
+    IfFailGo( pModule->GetFunctionLineOffset( address.addr.addr.addrMethod.tokMethod,
+              address.addr.addr.addrMethod.dwVersion,
+              dwLine,
+              &dwOffset ) );
+
+    // Create the new Address
+
+    address.addr.addr.addrMethod.dwOffset = dwOffset;
+    IfNullGo( paddr = new CDebugAddress(address), E_OUTOFMEMORY );
+    IfFailGo( paddr->QueryInterface( __uuidof(IDebugAddress),
+                                     (void**) ppNewAddress ) );
+
+Error:
+
+    METHOD_EXIT(CDebugSymbolProvider::GetFunctionLineOffset, hr);
+    RELEASE( paddr );
+    return hr;
+}
+```
+
+## See Also
+[IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md)

--- a/docs/extensibility/debugger/reference/idebugcomplussymbolprovider-getfunctionlineoffset.md
+++ b/docs/extensibility/debugger/reference/idebugcomplussymbolprovider-getfunctionlineoffset.md
@@ -19,17 +19,17 @@ Retrieves the address within a function that represents the given line offset.
 
 ```cpp
 HRESULT GetFunctionLineOffset(
-   IDebugAddress*  pAddress,
-   DWORD           dwLine,
-   IDebugAddress** ppNewAddress
+    IDebugAddress*  pAddress,
+    DWORD           dwLine,
+    IDebugAddress** ppNewAddress
 );
 ```
 
 ```csharp
 int GetFunctionLineOffset(
-   IDebugAddress     pAddress,
-   uint              dwLine,
-   out IDebugAddress ppNewAddress
+    IDebugAddress     pAddress,
+    uint              dwLine,
+    out IDebugAddress ppNewAddress
 );
 ```
 


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.