### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/idebugcomplussymbolprovider-getlocalvariablelayout.md
+++ b/docs/extensibility/debugger/reference/idebugcomplussymbolprovider-getlocalvariablelayout.md
@@ -2,107 +2,107 @@
 title: "IDebugComPlusSymbolProvider::GetLocalVariablelayout | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "GetLocalVariablelayout"
   - "IDebugComPlusSymbolProvider::GetLocalVariablelayout"
 ms.assetid: b7328d85-e5e9-4d9f-bcd1-e7711fd33878
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # IDebugComPlusSymbolProvider::GetLocalVariablelayout
-Retrieves the layout of local variables for a set of methods.  
-  
-## Syntax  
-  
-```cpp  
-HRESULT GetLocalVariablelayout(  
-   ULONG32   ulAppDomainID,  
-   GUID      guidModule,  
-   ULONG32   cMethods,  
-   _mdToken  rgMethodTokens[],  
-   IStream** pStreamLayout  
-);  
-```  
-  
-```csharp  
-int GetLocalVariablelayout(  
-   uint        ulAppDomainID,  
-   Guid        guidModule,  
-   uint        cMethods,  
-   int[]       rgMethodTokens,  
-   out IStream pStreamLayout  
-);  
-```  
-  
-#### Parameters  
- `ulAppDomainID`  
- [in] Identifier of the application domain.  
-  
- `guidModule`  
- [in] Unique identifier of the module.  
-  
- `cMethods`  
- [in] Number of method tokens in the `rgMethodTokens` array.  
-  
- `rgMethodTokens`  
- [in] Array of method tokens.  
-  
- `pStreamLayout`  
- [out] A text stream that contains the variable layout.  
-  
-## Return Value  
- If successful, returns `S_OK`; otherwise, returns an error code.  
-  
-## Example  
- The following example shows how to implement this method for a **CDebugSymbolProvider** object that exposes the [IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md) interface.  
-  
-```cpp  
-HRESULT CDebugSymbolProvider::GetLocalVariablelayout(  
-    ULONG32 ulAppDomainID,   
-    GUID guidModule,   
-    ULONG32 cMethods,   
-    _mdToken rgMethodTokens[],   
-    IStream** ppStreamLayout)  
-{  
-    HRESULT hr = S_OK;  
-  
-    METHOD_ENTRY(CDebugSymbolProvider::GetLocalVariablelayout);  
-  
-    CComPtr<ISymUnmanagedReader> symReader;  
-    IfFailRet(GetSymUnmanagedReader(ulAppDomainID, guidModule, (IUnknown **) &symReader));  
-    CComPtr<IStream> stream;  
-    IfFailRet(CreateStreamOnHGlobal(NULL, true, &stream));  
-  
-    for (ULONG32 iMethod = 0; iMethod < cMethods; iMethod += 1)  
-    {  
-        CComPtr<ISymUnmanagedMethod> method;  
-        IfFailRet(symReader->GetMethod(rgMethodTokens[iMethod], &method));  
-        CComPtr<ISymUnmanagedScope> rootScope;  
-        IfFailRet(method->GetRootScope(&rootScope));  
-  
-        //  
-        // Add the method's variables to the stream  
-        //  
-        IfFailRet(AddScopeToStream(rootScope, 0, stream));  
-  
-        // do end of method marker  
-        ULONG32 depth = 0xFFFFFFFF;  
-        ULONG cb = 0;  
-        IfFailRet(stream->Write(&depth, sizeof(depth), &cb));  
-    }  
-  
-    LARGE_INTEGER pos;  
-    pos.QuadPart = 0;  
-    IfFailRet(stream->Seek(pos, STREAM_SEEK_SET, 0));  
-    *ppStreamLayout = stream.Detach();  
-  
-    METHOD_EXIT(CDebugSymbolProvider::GetLocalVariablelayout, hr);  
-    return hr;  
-}  
-```  
-  
-## See Also  
- [IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md)
+Retrieves the layout of local variables for a set of methods.
+
+## Syntax
+
+```cpp
+HRESULT GetLocalVariablelayout(
+   ULONG32   ulAppDomainID,
+   GUID      guidModule,
+   ULONG32   cMethods,
+   _mdToken  rgMethodTokens[],
+   IStream** pStreamLayout
+);
+```
+
+```csharp
+int GetLocalVariablelayout(
+   uint        ulAppDomainID,
+   Guid        guidModule,
+   uint        cMethods,
+   int[]       rgMethodTokens,
+   out IStream pStreamLayout
+);
+```
+
+#### Parameters
+`ulAppDomainID`  
+[in] Identifier of the application domain.
+
+`guidModule`  
+[in] Unique identifier of the module.
+
+`cMethods`  
+[in] Number of method tokens in the `rgMethodTokens` array.
+
+`rgMethodTokens`  
+[in] Array of method tokens.
+
+`pStreamLayout`  
+[out] A text stream that contains the variable layout.
+
+## Return Value
+If successful, returns `S_OK`; otherwise, returns an error code.
+
+## Example
+The following example shows how to implement this method for a **CDebugSymbolProvider** object that exposes the [IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md) interface.
+
+```cpp
+HRESULT CDebugSymbolProvider::GetLocalVariablelayout(
+    ULONG32 ulAppDomainID,
+    GUID guidModule,
+    ULONG32 cMethods,
+    _mdToken rgMethodTokens[],
+    IStream** ppStreamLayout)
+{
+    HRESULT hr = S_OK;
+
+    METHOD_ENTRY(CDebugSymbolProvider::GetLocalVariablelayout);
+
+    CComPtr<ISymUnmanagedReader> symReader;
+    IfFailRet(GetSymUnmanagedReader(ulAppDomainID, guidModule, (IUnknown **) &symReader));
+    CComPtr<IStream> stream;
+    IfFailRet(CreateStreamOnHGlobal(NULL, true, &stream));
+
+    for (ULONG32 iMethod = 0; iMethod < cMethods; iMethod += 1)
+    {
+        CComPtr<ISymUnmanagedMethod> method;
+        IfFailRet(symReader->GetMethod(rgMethodTokens[iMethod], &method));
+        CComPtr<ISymUnmanagedScope> rootScope;
+        IfFailRet(method->GetRootScope(&rootScope));
+
+        //
+        // Add the method's variables to the stream
+        //
+        IfFailRet(AddScopeToStream(rootScope, 0, stream));
+
+        // do end of method marker
+        ULONG32 depth = 0xFFFFFFFF;
+        ULONG cb = 0;
+        IfFailRet(stream->Write(&depth, sizeof(depth), &cb));
+    }
+
+    LARGE_INTEGER pos;
+    pos.QuadPart = 0;
+    IfFailRet(stream->Seek(pos, STREAM_SEEK_SET, 0));
+    *ppStreamLayout = stream.Detach();
+
+    METHOD_EXIT(CDebugSymbolProvider::GetLocalVariablelayout, hr);
+    return hr;
+}
+```
+
+## See Also
+[IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md)

--- a/docs/extensibility/debugger/reference/idebugcomplussymbolprovider-getlocalvariablelayout.md
+++ b/docs/extensibility/debugger/reference/idebugcomplussymbolprovider-getlocalvariablelayout.md
@@ -19,21 +19,21 @@ Retrieves the layout of local variables for a set of methods.
 
 ```cpp
 HRESULT GetLocalVariablelayout(
-   ULONG32   ulAppDomainID,
-   GUID      guidModule,
-   ULONG32   cMethods,
-   _mdToken  rgMethodTokens[],
-   IStream** pStreamLayout
+    ULONG32   ulAppDomainID,
+    GUID      guidModule,
+    ULONG32   cMethods,
+    _mdToken  rgMethodTokens[],
+    IStream** pStreamLayout
 );
 ```
 
 ```csharp
 int GetLocalVariablelayout(
-   uint        ulAppDomainID,
-   Guid        guidModule,
-   uint        cMethods,
-   int[]       rgMethodTokens,
-   out IStream pStreamLayout
+    uint        ulAppDomainID,
+    Guid        guidModule,
+    uint        cMethods,
+    int[]       rgMethodTokens,
+    out IStream pStreamLayout
 );
 ```
 


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.