### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/idebugcomplussymbolprovider-getnamefromtoken.md
+++ b/docs/extensibility/debugger/reference/idebugcomplussymbolprovider-getnamefromtoken.md
@@ -19,17 +19,17 @@ Returns the name associated with the specified token given its metadata object.
 
 ```cpp
 HRESULT GetNameFromToken (
-   IUnknown* pMetadataImport,
-   DWORD     dwToken,
-   BSTR*     pbstrName
+    IUnknown* pMetadataImport,
+    DWORD     dwToken,
+    BSTR*     pbstrName
 );
 ```
 
 ```csharp
 int GetNameFromToken (
-   object     pMetadataImport,
-   uint       dwToken,
-   out string pbstrName
+    object     pMetadataImport,
+    uint       dwToken,
+    out string pbstrName
 );
 ```
 

--- a/docs/extensibility/debugger/reference/idebugcomplussymbolprovider-getnamefromtoken.md
+++ b/docs/extensibility/debugger/reference/idebugcomplussymbolprovider-getnamefromtoken.md
@@ -2,116 +2,116 @@
 title: "IDebugComPlusSymbolProvider::GetNameFromToken | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "IDebugComPlusSymbolProvider::GetNameFromToken"
   - "GetNameFromToken"
 ms.assetid: 6e8cf468-5fd1-4655-93ed-88828d6068b7
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # IDebugComPlusSymbolProvider::GetNameFromToken
-Returns the name associated with the specified token given its metadata object.  
-  
-## Syntax  
-  
-```cpp  
-HRESULT GetNameFromToken (  
-   IUnknown* pMetadataImport,  
-   DWORD     dwToken,  
-   BSTR*     pbstrName  
-);  
-```  
-  
-```csharp  
-int GetNameFromToken (  
-   object     pMetadataImport,  
-   uint       dwToken,  
-   out string pbstrName  
-);  
-```  
-  
-#### Parameters  
- `pMetadataImport`  
- [in] Object that contains the metadata information.  
-  
- `dwToken`  
- [in] Token to be named.  
-  
- `pbstrName`  
- [out] Name that corresponds to the token.  
-  
-## Return Value  
- If successful, returns `S_OK`; otherwise, returns an error code.  
-  
-## Example  
- The following example shows how to implement this method for a **CDebugSymbolProvider** object that exposes the [IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md) interface.  
-  
-```cpp  
-HRESULT CDebugSymbolProvider::GetNameFromToken(  
-    IUnknown* pMetadataImport,  
-    DWORD dwToken,  
-    BSTR* pbstrName  
-)  
-{  
-    HRESULT hr = S_OK;  
-    CComPtr<IMetaDataImport> pMetaData;  
-  
-    ASSERT(IsValidObjectPtr(this, CDebugSymbolProvider));  
-    ASSERT(IsValidInterfacePtr(pMetadataImport, IUnknown));  
-  
-    METHOD_ENTRY(CDebugSymbolProvider::GetNameFromToken);  
-  
-    IfFalseGo( pMetadataImport && pbstrName, E_INVALIDARG );  
-  
-    *pbstrName = NULL;  
-    IfFailGo( pMetadataImport->QueryInterface( IID_IMetaDataImport,  
-              (void**) &pMetaData ) );  
-  
-    switch ( TypeFromToken(dwToken) )  
-    {  
-        case mdtModule:  
-            IfFailGo( GetModuleName( pMetaData, dwToken, pbstrName) );  
-            break;  
-  
-        case mdtTypeDef:  
-            IfFailGo( GetTypeName( pMetaData, dwToken, pbstrName) );  
-            break;  
-  
-        case mdtFieldDef:  
-            IfFailGo( GetFieldName( pMetaData, dwToken, pbstrName) );  
-            break;  
-  
-        case mdtMethodDef:  
-            IfFailGo( GetMethodName( pMetaData, dwToken, pbstrName) );  
-            break;  
-  
-        case mdtEvent:  
-            IfFailGo( GetEventName( pMetaData, dwToken, pbstrName) );  
-            break;  
-  
-        case mdtProperty:  
-            IfFailGo( GetPropertyName( pMetaData, dwToken, pbstrName) );  
-            break;  
-  
-        case mdtAssembly:  
-            IfFailGo( GetAssemblyName( pMetaData, dwToken, pbstrName) );  
-            break;  
-  
-        default:  
-            ASSERT(!"Unsupported token passed to GetNameFromToken");  
-            hr = E_FAIL;  
-            break;  
-    }  
-  
-Error:  
-  
-    METHOD_EXIT(CDebugSymbolProvider::GetNameFromToken, hr);  
-    return hr;  
-}  
-```  
-  
-## See Also  
- [IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md)
+Returns the name associated with the specified token given its metadata object.
+
+## Syntax
+
+```cpp
+HRESULT GetNameFromToken (
+   IUnknown* pMetadataImport,
+   DWORD     dwToken,
+   BSTR*     pbstrName
+);
+```
+
+```csharp
+int GetNameFromToken (
+   object     pMetadataImport,
+   uint       dwToken,
+   out string pbstrName
+);
+```
+
+#### Parameters
+`pMetadataImport`  
+[in] Object that contains the metadata information.
+
+`dwToken`  
+[in] Token to be named.
+
+`pbstrName`  
+[out] Name that corresponds to the token.
+
+## Return Value
+If successful, returns `S_OK`; otherwise, returns an error code.
+
+## Example
+The following example shows how to implement this method for a **CDebugSymbolProvider** object that exposes the [IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md) interface.
+
+```cpp
+HRESULT CDebugSymbolProvider::GetNameFromToken(
+    IUnknown* pMetadataImport,
+    DWORD dwToken,
+    BSTR* pbstrName
+)
+{
+    HRESULT hr = S_OK;
+    CComPtr<IMetaDataImport> pMetaData;
+
+    ASSERT(IsValidObjectPtr(this, CDebugSymbolProvider));
+    ASSERT(IsValidInterfacePtr(pMetadataImport, IUnknown));
+
+    METHOD_ENTRY(CDebugSymbolProvider::GetNameFromToken);
+
+    IfFalseGo( pMetadataImport && pbstrName, E_INVALIDARG );
+
+    *pbstrName = NULL;
+    IfFailGo( pMetadataImport->QueryInterface( IID_IMetaDataImport,
+              (void**) &pMetaData ) );
+
+    switch ( TypeFromToken(dwToken) )
+    {
+        case mdtModule:
+            IfFailGo( GetModuleName( pMetaData, dwToken, pbstrName) );
+            break;
+
+        case mdtTypeDef:
+            IfFailGo( GetTypeName( pMetaData, dwToken, pbstrName) );
+            break;
+
+        case mdtFieldDef:
+            IfFailGo( GetFieldName( pMetaData, dwToken, pbstrName) );
+            break;
+
+        case mdtMethodDef:
+            IfFailGo( GetMethodName( pMetaData, dwToken, pbstrName) );
+            break;
+
+        case mdtEvent:
+            IfFailGo( GetEventName( pMetaData, dwToken, pbstrName) );
+            break;
+
+        case mdtProperty:
+            IfFailGo( GetPropertyName( pMetaData, dwToken, pbstrName) );
+            break;
+
+        case mdtAssembly:
+            IfFailGo( GetAssemblyName( pMetaData, dwToken, pbstrName) );
+            break;
+
+        default:
+            ASSERT(!"Unsupported token passed to GetNameFromToken");
+            hr = E_FAIL;
+            break;
+    }
+
+Error:
+
+    METHOD_EXIT(CDebugSymbolProvider::GetNameFromToken, hr);
+    return hr;
+}
+```
+
+## See Also
+[IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md)


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.