### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/idebugcomplussymbolprovider-getsymattribute.md
+++ b/docs/extensibility/debugger/reference/idebugcomplussymbolprovider-getsymattribute.md
@@ -2,100 +2,100 @@
 title: "IDebugComPlusSymbolProvider::GetSymAttribute | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "IDebugComPlusSymbolProvider::GetSymAttribute"
   - "GetSymAttribute"
 ms.assetid: 6cbaac92-a60b-4165-a7f5-c34407770f3c
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # IDebugComPlusSymbolProvider::GetSymAttribute
-Retrieves the debug symbols with the given parent attribute for the specified module.  
-  
-## Syntax  
-  
-```cpp  
-HRESULT GetSymAttribute (  
-   ULONG32  ulAppDomainID,  
-   GUID     guidModule,  
-   _mdToken tokParent,  
-   LPOLESTR pstrName,  
-   ULONG32  cBuffer,  
-   ULONG32* pcBuffer,  
-   BYTE*    buffer  
-);  
-```  
-  
-```csharp  
-int GetSymAttribute (  
-   uint      ulAppDomainID,  
-   Guid      guidModule,  
-   int       tokParent,  
-   string    pstrName,  
-   uint      cBuffer,  
-   out uint  pcBuffer,  
-   out int[] buffer  
-);  
-```  
-  
-#### Parameters  
- `ulAppDomainID`  
- [in] Identifier of the application domain.  
-  
- `guidModule`  
- [in] Unique identifier of the module.  
-  
- `tokParent`  
- [in] Token for the parent attribute.  
-  
- `pstrName`  
- [in] Name of the module.  
-  
- `cBuffer`  
- [in] Number of bytes required for the output `buffer`.  
-  
- `pcBuffer`  
- [out] Length of the output `buffer`.  
-  
- `buffer`  
- [out] Array that contains the symbols.  
-  
-## Return Value  
- If successful, returns `S_OK`; otherwise, returns an error code.  
-  
-## Example  
- The following example shows how to implement this method for a **CDebugSymbolProvider** object that exposes the [IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md) interface.  
-  
-```cpp  
-HRESULT CDebugSymbolProvider::GetSymAttribute(  
-    ULONG32 ulAppDomainID,  
-    GUID guidModule,  
-    _mdToken tokParent,  
-    __in_z LPOLESTR pstrName,  
-    ULONG32 cBuffer,  
-    ULONG32 *pcBuffer,  
-    BYTE buffer[])  
-{  
-    HRESULT hr = S_OK;  
-    CComPtr<CModule> pModule;  
-    Module_ID idModule(ulAppDomainID, guidModule);  
-  
-    METHOD_ENTRY( CDebugSymbolProvider::GetSymAttribute );  
-  
-    IfFailGo( GetModule( idModule, &pModule) );  
-  
-    IfFailGo( pModule->GetSymAttribute( tokParent, pstrName, cBuffer, pcBuffer, buffer ) );  
-  
-Error:  
-  
-    METHOD_EXIT(CDebugSymbolProvider::GetSymAttribute, hr);  
-  
-    return hr;  
-}  
-```  
-  
-## See Also  
- [IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md)
+Retrieves the debug symbols with the given parent attribute for the specified module.
+
+## Syntax
+
+```cpp
+HRESULT GetSymAttribute (
+   ULONG32  ulAppDomainID,
+   GUID     guidModule,
+   _mdToken tokParent,
+   LPOLESTR pstrName,
+   ULONG32  cBuffer,
+   ULONG32* pcBuffer,
+   BYTE*    buffer
+);
+```
+
+```csharp
+int GetSymAttribute (
+   uint      ulAppDomainID,
+   Guid      guidModule,
+   int       tokParent,
+   string    pstrName,
+   uint      cBuffer,
+   out uint  pcBuffer,
+   out int[] buffer
+);
+```
+
+#### Parameters
+`ulAppDomainID`  
+[in] Identifier of the application domain.
+
+`guidModule`  
+[in] Unique identifier of the module.
+
+`tokParent`  
+[in] Token for the parent attribute.
+
+`pstrName`  
+[in] Name of the module.
+
+`cBuffer`  
+[in] Number of bytes required for the output `buffer`.
+
+`pcBuffer`  
+[out] Length of the output `buffer`.
+
+`buffer`  
+[out] Array that contains the symbols.
+
+## Return Value
+If successful, returns `S_OK`; otherwise, returns an error code.
+
+## Example
+The following example shows how to implement this method for a **CDebugSymbolProvider** object that exposes the [IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md) interface.
+
+```cpp
+HRESULT CDebugSymbolProvider::GetSymAttribute(
+    ULONG32 ulAppDomainID,
+    GUID guidModule,
+    _mdToken tokParent,
+    __in_z LPOLESTR pstrName,
+    ULONG32 cBuffer,
+    ULONG32 *pcBuffer,
+    BYTE buffer[])
+{
+    HRESULT hr = S_OK;
+    CComPtr<CModule> pModule;
+    Module_ID idModule(ulAppDomainID, guidModule);
+
+    METHOD_ENTRY( CDebugSymbolProvider::GetSymAttribute );
+
+    IfFailGo( GetModule( idModule, &pModule) );
+
+    IfFailGo( pModule->GetSymAttribute( tokParent, pstrName, cBuffer, pcBuffer, buffer ) );
+
+Error:
+
+    METHOD_EXIT(CDebugSymbolProvider::GetSymAttribute, hr);
+
+    return hr;
+}
+```
+
+## See Also
+[IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md)

--- a/docs/extensibility/debugger/reference/idebugcomplussymbolprovider-getsymattribute.md
+++ b/docs/extensibility/debugger/reference/idebugcomplussymbolprovider-getsymattribute.md
@@ -19,25 +19,25 @@ Retrieves the debug symbols with the given parent attribute for the specified mo
 
 ```cpp
 HRESULT GetSymAttribute (
-   ULONG32  ulAppDomainID,
-   GUID     guidModule,
-   _mdToken tokParent,
-   LPOLESTR pstrName,
-   ULONG32  cBuffer,
-   ULONG32* pcBuffer,
-   BYTE*    buffer
+    ULONG32  ulAppDomainID,
+    GUID     guidModule,
+    _mdToken tokParent,
+    LPOLESTR pstrName,
+    ULONG32  cBuffer,
+    ULONG32* pcBuffer,
+    BYTE*    buffer
 );
 ```
 
 ```csharp
 int GetSymAttribute (
-   uint      ulAppDomainID,
-   Guid      guidModule,
-   int       tokParent,
-   string    pstrName,
-   uint      cBuffer,
-   out uint  pcBuffer,
-   out int[] buffer
+    uint      ulAppDomainID,
+    Guid      guidModule,
+    int       tokParent,
+    string    pstrName,
+    uint      cBuffer,
+    out uint  pcBuffer,
+    out int[] buffer
 );
 ```
 


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.