### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/idebugcomplussymbolprovider-getsymunmanagedreader.md
+++ b/docs/extensibility/debugger/reference/idebugcomplussymbolprovider-getsymunmanagedreader.md
@@ -2,75 +2,75 @@
 title: "IDebugComPlusSymbolProvider::GetSymUnmanagedReader | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "IDebugComPlusSymbolProvider::GetSymUnmanagedReader"
   - "GetSymUnmanagedReader"
 ms.assetid: 8f1c1627-217f-4405-8141-7a2eb80310a5
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # IDebugComPlusSymbolProvider::GetSymUnmanagedReader
-Retrieves the symbol reader to be used by unmanaged code.  
-  
-## Syntax  
-  
-```cpp  
-HRESULT GetSymUnmanagedReader(  
-   ULONG32    ulAppDomainID,  
-   GUID       guidModule,  
-   IUnknown** ppSymUnmanagedReader  
-);  
-```  
-  
-```csharp  
-int GetSymUnmanagedReader(  
-   uint       ulAppDomainID,  
-   Guid       guidModule,  
-   out object ppSymUnmanagedReader  
-);  
-```  
-  
-#### Parameters  
- `ulAppDomainID`  
- [in] Identifier of the application domain.  
-  
- `guidModule`  
- [in] Unique identifier of the module.  
-  
- `ppSymUnmanagedReader`  
- [out] Returns the object that represents the symbol reader.  
-  
-## Return Value  
- If successful, returns `S_OK`; otherwise, returns an error code.  
-  
-## Example  
- The following example shows how to implement this method for a **CDebugSymbolProvider** object that exposes the [IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md) interface.  
-  
-```cpp  
-HRESULT CDebugSymbolProvider::GetSymUnmanagedReader(  
-    ULONG32 ulAppDomainID,  
-    GUID guidModule,  
-    IUnknown ** ppSymUnmanagedReader  
-)  
-{  
-    HRESULT hr = S_OK;  
-    CComPtr<CModule> pModule;  
-    Module_ID idModule(ulAppDomainID, guidModule);  
-  
-    METHOD_ENTRY( CDebugSymbolProvider::GetSymUnmanagedReader );  
-  
-    IfFailGo( GetModule( idModule, &pModule ) );  
-    IfFailGo( pModule->GetSymReader((ISymUnmanagedReader**) ppSymUnmanagedReader) );  
-  
-Error:  
-  
-    METHOD_EXIT( CDebugSymbolProvider::GetSymUnmanagedReader, hr );  
-    return hr;  
-}  
-```  
-  
-## See Also  
- [IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md)
+Retrieves the symbol reader to be used by unmanaged code.
+
+## Syntax
+
+```cpp
+HRESULT GetSymUnmanagedReader(
+   ULONG32    ulAppDomainID,
+   GUID       guidModule,
+   IUnknown** ppSymUnmanagedReader
+);
+```
+
+```csharp
+int GetSymUnmanagedReader(
+   uint       ulAppDomainID,
+   Guid       guidModule,
+   out object ppSymUnmanagedReader
+);
+```
+
+#### Parameters
+`ulAppDomainID`  
+[in] Identifier of the application domain.
+
+`guidModule`  
+[in] Unique identifier of the module.
+
+`ppSymUnmanagedReader`  
+[out] Returns the object that represents the symbol reader.
+
+## Return Value
+If successful, returns `S_OK`; otherwise, returns an error code.
+
+## Example
+The following example shows how to implement this method for a **CDebugSymbolProvider** object that exposes the [IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md) interface.
+
+```cpp
+HRESULT CDebugSymbolProvider::GetSymUnmanagedReader(
+    ULONG32 ulAppDomainID,
+    GUID guidModule,
+    IUnknown ** ppSymUnmanagedReader
+)
+{
+    HRESULT hr = S_OK;
+    CComPtr<CModule> pModule;
+    Module_ID idModule(ulAppDomainID, guidModule);
+
+    METHOD_ENTRY( CDebugSymbolProvider::GetSymUnmanagedReader );
+
+    IfFailGo( GetModule( idModule, &pModule ) );
+    IfFailGo( pModule->GetSymReader((ISymUnmanagedReader**) ppSymUnmanagedReader) );
+
+Error:
+
+    METHOD_EXIT( CDebugSymbolProvider::GetSymUnmanagedReader, hr );
+    return hr;
+}
+```
+
+## See Also
+[IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md)

--- a/docs/extensibility/debugger/reference/idebugcomplussymbolprovider-getsymunmanagedreader.md
+++ b/docs/extensibility/debugger/reference/idebugcomplussymbolprovider-getsymunmanagedreader.md
@@ -19,17 +19,17 @@ Retrieves the symbol reader to be used by unmanaged code.
 
 ```cpp
 HRESULT GetSymUnmanagedReader(
-   ULONG32    ulAppDomainID,
-   GUID       guidModule,
-   IUnknown** ppSymUnmanagedReader
+    ULONG32    ulAppDomainID,
+    GUID       guidModule,
+    IUnknown** ppSymUnmanagedReader
 );
 ```
 
 ```csharp
 int GetSymUnmanagedReader(
-   uint       ulAppDomainID,
-   Guid       guidModule,
-   out object ppSymUnmanagedReader
+    uint       ulAppDomainID,
+    Guid       guidModule,
+    out object ppSymUnmanagedReader
 );
 ```
 


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.