### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/idebugcomplussymbolprovider-gettypefromaddress.md
+++ b/docs/extensibility/debugger/reference/idebugcomplussymbolprovider-gettypefromaddress.md
@@ -19,15 +19,15 @@ Retrieves to a symbol type given its debug address.
 
 ```cpp
 HRESULT GetTypeFromAddress(
-   IDebugAddress* pAddress,
-   IDebugField**  ppField
+    IDebugAddress* pAddress,
+    IDebugField**  ppField
 );
 ```
 
 ```csharp
 int GetTypeFromAddress(
-   IDebugAddress   pAddress,
-   out IDebugField ppField
+    IDebugAddress   pAddress,
+    out IDebugField ppField
 );
 ```
 

--- a/docs/extensibility/debugger/reference/idebugcomplussymbolprovider-gettypefromaddress.md
+++ b/docs/extensibility/debugger/reference/idebugcomplussymbolprovider-gettypefromaddress.md
@@ -2,112 +2,112 @@
 title: "IDebugComPlusSymbolProvider::GetTypeFromAddress | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "IDebugComPlusSymbolProvider::GetTypeFromAddress"
   - "GetTypeFromAddress"
 ms.assetid: 01f21ff9-e8a5-4e5f-9f7b-1b6de8b1432f
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # IDebugComPlusSymbolProvider::GetTypeFromAddress
-Retrieves to a symbol type given its debug address.  
-  
-## Syntax  
-  
-```cpp  
-HRESULT GetTypeFromAddress(  
-   IDebugAddress* pAddress,  
-   IDebugField**  ppField  
-);  
-```  
-  
-```csharp  
-int GetTypeFromAddress(  
-   IDebugAddress   pAddress,  
-   out IDebugField ppField  
-);  
-```  
-  
-#### Parameters  
- `pAddress`  
- [in] The debug address that is represented by an [IDebugAddress](../../../extensibility/debugger/reference/idebugaddress.md) interface.  
-  
- `ppField`  
- [out] Returns the array type as it is represented by an [IDebugClassField](../../../extensibility/debugger/reference/idebugclassfield.md) interface.  
-  
-## Return Value  
- If successful, returns `S_OK`; otherwise, returns an error code.  
-  
-## Example  
- The following example shows how to implement this method for a **CDebugSymbolProvider** object that exposes the [IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md) interface.  
-  
-```cpp  
-HRESULT CDebugSymbolProvider::GetTypeFromAddress(  
-    IDebugAddress *pAddress,  
-    IDebugField **ppField)  
-{  
-    HRESULT hr = E_FAIL;  
-    CDEBUG_ADDRESS da;  
-    CDebugGenericParamScope* pGenScope = NULL;  
-  
-    METHOD_ENTRY( CDebugDynamicFieldSymbol::GetTypeFromPrimitive );  
-  
-    ASSERT(IsValidObjectPtr(this, CDebugSymbolProvider));  
-    ASSERT(IsValidWritePtr(ppField, IDebugField*));  
-  
-    IfFailGo( pAddress->GetAddress(&da) );  
-  
-    switch ( da.addr.dwKind )  
-    {  
-        case ADDRESS_KIND_METADATA_LOCAL:  
-        case ADDRESS_KIND_METADATA_PARAM:  
-        case ADDRESS_KIND_METADATA_FIELD:  
-        case ADDRESS_KIND_METADATA_ARRAYELEM:  
-        case ADDRESS_KIND_METADATA_METHOD:  
-            {  
-                IfFailGo( this->CreateClassType(da.GetModule(), da.tokClass, ppField) );  
-                break;  
-            }  
-  
-        case ADDRESS_KIND_METADATA_RETVAL:  
-            {  
-                if ( da.addr.addr.addrRetVal.dwCorType )  
-                {  
-  
-                    IfNullGo( pGenScope = new CDebugGenericParamScope(da.GetModule(), da.tokClass, da.GetMethod()), E_OUTOFMEMORY );  
-                    IfFailGo( this->CreateType((const COR_SIGNATURE*)(&da.addr.addr.addrRetVal.rgSig),  
-                                               da.addr.addr.addrRetVal.dwSigSize,  
-                                               da.GetModule(),  
-                                               mdMethodDefNil,  
-                                               pGenScope,  
-                                               ppField) );  
-                }  
-                else  
-                {  
-                    IfFailGo( this->CreateClassType(da.GetModule(), da.tokClass, ppField) );  
-                }  
-  
-                break;  
-            }  
-  
-        default:  
-            {  
-                ASSERT(!"Address type not supported.");  
-            }  
-    }  
-  
-Error:  
-  
-    METHOD_EXIT( CDebugDynamicFieldSymbol::GetTypeFromPrimitive, hr );  
-  
-    RELEASE( pGenScope );  
-  
-    return hr;  
-}  
-```  
-  
-## See Also  
- [IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md)
+Retrieves to a symbol type given its debug address.
+
+## Syntax
+
+```cpp
+HRESULT GetTypeFromAddress(
+   IDebugAddress* pAddress,
+   IDebugField**  ppField
+);
+```
+
+```csharp
+int GetTypeFromAddress(
+   IDebugAddress   pAddress,
+   out IDebugField ppField
+);
+```
+
+#### Parameters
+`pAddress`  
+[in] The debug address that is represented by an [IDebugAddress](../../../extensibility/debugger/reference/idebugaddress.md) interface.
+
+`ppField`  
+[out] Returns the array type as it is represented by an [IDebugClassField](../../../extensibility/debugger/reference/idebugclassfield.md) interface.
+
+## Return Value
+If successful, returns `S_OK`; otherwise, returns an error code.
+
+## Example
+The following example shows how to implement this method for a **CDebugSymbolProvider** object that exposes the [IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md) interface.
+
+```cpp
+HRESULT CDebugSymbolProvider::GetTypeFromAddress(
+    IDebugAddress *pAddress,
+    IDebugField **ppField)
+{
+    HRESULT hr = E_FAIL;
+    CDEBUG_ADDRESS da;
+    CDebugGenericParamScope* pGenScope = NULL;
+
+    METHOD_ENTRY( CDebugDynamicFieldSymbol::GetTypeFromPrimitive );
+
+    ASSERT(IsValidObjectPtr(this, CDebugSymbolProvider));
+    ASSERT(IsValidWritePtr(ppField, IDebugField*));
+
+    IfFailGo( pAddress->GetAddress(&da) );
+
+    switch ( da.addr.dwKind )
+    {
+        case ADDRESS_KIND_METADATA_LOCAL:
+        case ADDRESS_KIND_METADATA_PARAM:
+        case ADDRESS_KIND_METADATA_FIELD:
+        case ADDRESS_KIND_METADATA_ARRAYELEM:
+        case ADDRESS_KIND_METADATA_METHOD:
+            {
+                IfFailGo( this->CreateClassType(da.GetModule(), da.tokClass, ppField) );
+                break;
+            }
+
+        case ADDRESS_KIND_METADATA_RETVAL:
+            {
+                if ( da.addr.addr.addrRetVal.dwCorType )
+                {
+
+                    IfNullGo( pGenScope = new CDebugGenericParamScope(da.GetModule(), da.tokClass, da.GetMethod()), E_OUTOFMEMORY );
+                    IfFailGo( this->CreateType((const COR_SIGNATURE*)(&da.addr.addr.addrRetVal.rgSig),
+                                               da.addr.addr.addrRetVal.dwSigSize,
+                                               da.GetModule(),
+                                               mdMethodDefNil,
+                                               pGenScope,
+                                               ppField) );
+                }
+                else
+                {
+                    IfFailGo( this->CreateClassType(da.GetModule(), da.tokClass, ppField) );
+                }
+
+                break;
+            }
+
+        default:
+            {
+                ASSERT(!"Address type not supported.");
+            }
+    }
+
+Error:
+
+    METHOD_EXIT( CDebugDynamicFieldSymbol::GetTypeFromPrimitive, hr );
+
+    RELEASE( pGenScope );
+
+    return hr;
+}
+```
+
+## See Also
+[IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md)


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.