### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/idebugcomplussymbolprovider-isfunctionstale.md
+++ b/docs/extensibility/debugger/reference/idebugcomplussymbolprovider-isfunctionstale.md
@@ -2,85 +2,85 @@
 title: "IDebugComPlusSymbolProvider::IsFunctionStale | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "IDebugComPlusSymbolProvider::IsFunctionStale"
 ms.assetid: dcffc090-4ed8-47b2-ba51-bce1a6b6428d
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # IDebugComPlusSymbolProvider::IsFunctionStale
-Determines if the function at the specified debug address is considered stale.  
-  
-## Syntax  
-  
-```cpp  
-HRESULT IsFunctionStale(  
-   IDebugAddress* pAddress  
-);  
-```  
-  
-```csharp  
-int IsFunctionStale(  
-   IDebugAddress pAddress  
-);  
-```  
-  
-#### Parameters  
- `pAddress`  
- [in] The debug address that is represented by an [IDebugAddress](../../../extensibility/debugger/reference/idebugaddress.md) interface. This address must be a METHOD_ADDRESS.  
-  
-## Return Value  
- If the function is considered stale, returns `S_OK`. If the function is not stale, returns `S_FALSE`.  
-  
-## Example  
- The following example shows how to implement this method for a **CDebugSymbolProvider** object that exposes the [IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md) interface.  
-  
-```cpp  
-HRESULT CDebugSymbolProvider::IsFunctionStale(  
-    IDebugAddress* pAddress  
-)  
-{  
-    HRESULT hr = S_OK;  
-    CDEBUG_ADDRESS address;  
-    CComPtr<CModule> pModule;  
-  
-    ASSERT(IsValidObjectPtr(this, CDebugSymbolProvider));  
-    ASSERT(IsValidInterfacePtr(pAddress, IDebugAddress));  
-  
-    METHOD_ENTRY( CDebugSymbolProvider::IsFunctionStale );  
-  
-    IfFalseGo( pAddress, S_FALSE );  
-    IfFailGo( pAddress->GetAddress( &address ) );  
-  
-    ASSERT(address.addr.dwKind == ADDRESS_KIND_METADATA_METHOD);  
-    IfFalseGo( address.addr.dwKind == ADDRESS_KIND_METADATA_METHOD, S_FALSE );  
-  
-    IfFailGo( GetModule( address.GetModule(), &pModule) );  
-  
-    if (!pModule->IsFunctionStale( address.addr.addr.addrMethod.tokMethod,  
-                                   address.addr.addr.addrMethod.dwVersion ))  
-    {  
-  
-        // S_FALSE indicates the function is not stale  
-  
-        hr = S_FALSE;  
-    }  
-  
-Error:  
-  
-    METHOD_EXIT( CDebugSymbolProvider::IsFunctionStale, hr );  
-  
-    if (!SUCCEEDED(hr))  
-    {  
-        hr = S_FALSE;  
-    }  
-  
-    return hr;  
-}  
-```  
-  
-## See Also  
- [IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md)
+Determines if the function at the specified debug address is considered stale.
+
+## Syntax
+
+```cpp
+HRESULT IsFunctionStale(
+   IDebugAddress* pAddress
+);
+```
+
+```csharp
+int IsFunctionStale(
+   IDebugAddress pAddress
+);
+```
+
+#### Parameters
+`pAddress`  
+[in] The debug address that is represented by an [IDebugAddress](../../../extensibility/debugger/reference/idebugaddress.md) interface. This address must be a METHOD_ADDRESS.
+
+## Return Value
+If the function is considered stale, returns `S_OK`. If the function is not stale, returns `S_FALSE`.
+
+## Example
+The following example shows how to implement this method for a **CDebugSymbolProvider** object that exposes the [IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md) interface.
+
+```cpp
+HRESULT CDebugSymbolProvider::IsFunctionStale(
+    IDebugAddress* pAddress
+)
+{
+    HRESULT hr = S_OK;
+    CDEBUG_ADDRESS address;
+    CComPtr<CModule> pModule;
+
+    ASSERT(IsValidObjectPtr(this, CDebugSymbolProvider));
+    ASSERT(IsValidInterfacePtr(pAddress, IDebugAddress));
+
+    METHOD_ENTRY( CDebugSymbolProvider::IsFunctionStale );
+
+    IfFalseGo( pAddress, S_FALSE );
+    IfFailGo( pAddress->GetAddress( &address ) );
+
+    ASSERT(address.addr.dwKind == ADDRESS_KIND_METADATA_METHOD);
+    IfFalseGo( address.addr.dwKind == ADDRESS_KIND_METADATA_METHOD, S_FALSE );
+
+    IfFailGo( GetModule( address.GetModule(), &pModule) );
+
+    if (!pModule->IsFunctionStale( address.addr.addr.addrMethod.tokMethod,
+                                   address.addr.addr.addrMethod.dwVersion ))
+    {
+
+        // S_FALSE indicates the function is not stale
+
+        hr = S_FALSE;
+    }
+
+Error:
+
+    METHOD_EXIT( CDebugSymbolProvider::IsFunctionStale, hr );
+
+    if (!SUCCEEDED(hr))
+    {
+        hr = S_FALSE;
+    }
+
+    return hr;
+}
+```
+
+## See Also
+[IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md)

--- a/docs/extensibility/debugger/reference/idebugcomplussymbolprovider-isfunctionstale.md
+++ b/docs/extensibility/debugger/reference/idebugcomplussymbolprovider-isfunctionstale.md
@@ -18,13 +18,13 @@ Determines if the function at the specified debug address is considered stale.
 
 ```cpp
 HRESULT IsFunctionStale(
-   IDebugAddress* pAddress
+    IDebugAddress* pAddress
 );
 ```
 
 ```csharp
 int IsFunctionStale(
-   IDebugAddress pAddress
+    IDebugAddress pAddress
 );
 ```
 


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.