### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/idebugcomplussymbolprovider-ishiddencode.md
+++ b/docs/extensibility/debugger/reference/idebugcomplussymbolprovider-ishiddencode.md
@@ -18,13 +18,13 @@ Determines if the code at the specified debugger address is hidden.
 
 ```cpp
 HRESULT IsHiddenCode(
-   IDebugAddress* pAddress
+    IDebugAddress* pAddress
 );
 ```
 
 ```csharp
 int IsHiddenCode(
-   IDebugAddress pAddress
+    IDebugAddress pAddress
 );
 ```
 

--- a/docs/extensibility/debugger/reference/idebugcomplussymbolprovider-ishiddencode.md
+++ b/docs/extensibility/debugger/reference/idebugcomplussymbolprovider-ishiddencode.md
@@ -2,86 +2,86 @@
 title: "IDebugComPlusSymbolProvider::IsHiddenCode | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "IDebugComPlusSymbolProvider::IsHiddenCode"
 ms.assetid: 1352c6ab-7b92-4a16-b2d2-6520b628830e
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # IDebugComPlusSymbolProvider::IsHiddenCode
-Determines if the code at the specified debugger address is hidden.  
-  
-## Syntax  
-  
-```cpp  
-HRESULT IsHiddenCode(  
-   IDebugAddress* pAddress  
-);  
-```  
-  
-```csharp  
-int IsHiddenCode(  
-   IDebugAddress pAddress  
-);  
-```  
-  
-#### Parameters  
- `pAddress`  
- [in] The debug address that is represented by an [IDebugAddress](../../../extensibility/debugger/reference/idebugaddress.md) interface.  
-  
-## Return Value  
- If the code is hidden, returns `S_OK`; otherwise, returns `S_FALSE`.  
-  
-## Example  
- The following example shows how to implement this method for a **CDebugSymbolProvider** object that exposes the [IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md) interface.  
-  
-```cpp  
-HRESULT CDebugSymbolProvider::IsHiddenCode(  
-    IDebugAddress* pAddress  
-)  
-{  
-    HRESULT hr = S_OK;  
-    CDEBUG_ADDRESS address;  
-    CComPtr<CModule> pModule;  
-  
-    ASSERT(IsValidObjectPtr(this, CDebugSymbolProvider));  
-    ASSERT(IsValidInterfacePtr(pAddress, IDebugAddress));  
-  
-    METHOD_ENTRY( CDebugSymbolProvider::IsHiddenCode );  
-  
-    IfFalseGo( pAddress, S_FALSE );  
-    IfFailGo( pAddress->GetAddress( &address ) );  
-  
-    ASSERT(address.addr.dwKind == ADDRESS_KIND_METADATA_METHOD);  
-    IfFalseGo( address.addr.dwKind == ADDRESS_KIND_METADATA_METHOD, S_FALSE );  
-  
-    IfFailGo( GetModule( address.GetModule(), &pModule) );  
-  
-    if (!pModule->IsHiddenCode( address.addr.addr.addrMethod.tokMethod,  
-                                address.addr.addr.addrMethod.dwVersion,  
-                                address.addr.addr.addrMethod.dwOffset ))  
-    {  
-  
-        // S_FALSE indicates this sequence point is not hidden  
-  
-        hr = S_FALSE;  
-    }  
-  
-Error:  
-  
-    METHOD_EXIT( CDebugSymbolProvider::IsHiddenCode, hr );  
-  
-    if (!SUCCEEDED(hr))  
-    {  
-        hr = S_FALSE;  
-    }  
-  
-    return hr;  
-}  
-```  
-  
-## See Also  
- [IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md)
+Determines if the code at the specified debugger address is hidden.
+
+## Syntax
+
+```cpp
+HRESULT IsHiddenCode(
+   IDebugAddress* pAddress
+);
+```
+
+```csharp
+int IsHiddenCode(
+   IDebugAddress pAddress
+);
+```
+
+#### Parameters
+`pAddress`  
+[in] The debug address that is represented by an [IDebugAddress](../../../extensibility/debugger/reference/idebugaddress.md) interface.
+
+## Return Value
+If the code is hidden, returns `S_OK`; otherwise, returns `S_FALSE`.
+
+## Example
+The following example shows how to implement this method for a **CDebugSymbolProvider** object that exposes the [IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md) interface.
+
+```cpp
+HRESULT CDebugSymbolProvider::IsHiddenCode(
+    IDebugAddress* pAddress
+)
+{
+    HRESULT hr = S_OK;
+    CDEBUG_ADDRESS address;
+    CComPtr<CModule> pModule;
+
+    ASSERT(IsValidObjectPtr(this, CDebugSymbolProvider));
+    ASSERT(IsValidInterfacePtr(pAddress, IDebugAddress));
+
+    METHOD_ENTRY( CDebugSymbolProvider::IsHiddenCode );
+
+    IfFalseGo( pAddress, S_FALSE );
+    IfFailGo( pAddress->GetAddress( &address ) );
+
+    ASSERT(address.addr.dwKind == ADDRESS_KIND_METADATA_METHOD);
+    IfFalseGo( address.addr.dwKind == ADDRESS_KIND_METADATA_METHOD, S_FALSE );
+
+    IfFailGo( GetModule( address.GetModule(), &pModule) );
+
+    if (!pModule->IsHiddenCode( address.addr.addr.addrMethod.tokMethod,
+                                address.addr.addr.addrMethod.dwVersion,
+                                address.addr.addr.addrMethod.dwOffset ))
+    {
+
+        // S_FALSE indicates this sequence point is not hidden
+
+        hr = S_FALSE;
+    }
+
+Error:
+
+    METHOD_EXIT( CDebugSymbolProvider::IsHiddenCode, hr );
+
+    if (!SUCCEEDED(hr))
+    {
+        hr = S_FALSE;
+    }
+
+    return hr;
+}
+```
+
+## See Also
+[IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md)


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.