### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/idebugcomplussymbolprovider-loadsymbolsfromstream.md
+++ b/docs/extensibility/debugger/reference/idebugcomplussymbolprovider-loadsymbolsfromstream.md
@@ -19,21 +19,21 @@ Loads debug symbols given the data stream.
 
 ```cpp
 HRESULT LoadSymbolsFromStream(
-   ULONG32   ulAppDomainID,
-   GUID      guidModule,
-   ULONGLONG baseAddress,
-   IUnknown* pUnkMetadataImport,
-   IStream*  pStream
+    ULONG32   ulAppDomainID,
+    GUID      guidModule,
+    ULONGLONG baseAddress,
+    IUnknown* pUnkMetadataImport,
+    IStream*  pStream
 );
 ```
 
 ```csharp
 int LoadSymbolsFromStream(
-   uint    ulAppDomainID,
-   Guid    guidModule,
-   ulong   baseAddress,
-   object  pUnkMetadataImport,
-   IStream pStream
+    uint    ulAppDomainID,
+    Guid    guidModule,
+    ulong   baseAddress,
+    object  pUnkMetadataImport,
+    IStream pStream
 );
 ```
 

--- a/docs/extensibility/debugger/reference/idebugcomplussymbolprovider-loadsymbolsfromstream.md
+++ b/docs/extensibility/debugger/reference/idebugcomplussymbolprovider-loadsymbolsfromstream.md
@@ -2,75 +2,75 @@
 title: "IDebugComPlusSymbolProvider::LoadSymbolsFromStream | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "IDebugComPlusSymbolProvider::LoadSymbolsFromStream"
   - "LoadSymbolsFromStream"
 ms.assetid: 1de272f0-24f4-4548-8b70-a205cddd4727
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # IDebugComPlusSymbolProvider::LoadSymbolsFromStream
-Loads debug symbols given the data stream.  
-  
-## Syntax  
-  
-```cpp  
-HRESULT LoadSymbolsFromStream(  
-   ULONG32   ulAppDomainID,  
-   GUID      guidModule,  
-   ULONGLONG baseAddress,  
-   IUnknown* pUnkMetadataImport,  
-   IStream*  pStream  
-);  
-```  
-  
-```csharp  
-int LoadSymbolsFromStream(  
-   uint    ulAppDomainID,  
-   Guid    guidModule,  
-   ulong   baseAddress,  
-   object  pUnkMetadataImport,  
-   IStream pStream  
-);  
-```  
-  
-#### Parameters  
- `ulAppDomainID`  
- [in] Identifier of the application domain.  
-  
- `guidModule`  
- [in] Unique identifier of the module.  
-  
- `baseAddress`  
- [in] Base memory address.  
-  
- `pUnkMetadataImport`  
- [in] Object that contains the symbol metadata.  
-  
- `pStream`  
- [in] Data stream that contains the symbols.  
-  
-## Return Value  
- If successful, returns `S_OK`; otherwise, returns an error code.  
-  
-## Example  
- The following example shows how to implement this method for a **CDebugSymbolProvider** object that exposes the [IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md) interface. The method calls the [LoadSymbolsFromStreamWithCorModule](../../../extensibility/debugger/reference/idebugcomplussymbolprovider2-loadsymbolsfromstreamwithcormodule.md) method.  
-  
-```cpp  
-HRESULT CDebugSymbolProvider::LoadSymbolsFromStream(  
-    ULONG32 ulAppDomainID,  
-    GUID guidModule,  
-    ULONGLONG baseOffset,  
-    IUnknown* pUnkMetadataImport,  
-    IStream* pStream  
-)  
-{  
-    return LoadSymbolsFromStreamWithCorModule (ulAppDomainID, guidModule, baseOffset, pUnkMetadataImport, NULL, pStream);  
-}  
-```  
-  
-## See Also  
- [IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md)
+Loads debug symbols given the data stream.
+
+## Syntax
+
+```cpp
+HRESULT LoadSymbolsFromStream(
+   ULONG32   ulAppDomainID,
+   GUID      guidModule,
+   ULONGLONG baseAddress,
+   IUnknown* pUnkMetadataImport,
+   IStream*  pStream
+);
+```
+
+```csharp
+int LoadSymbolsFromStream(
+   uint    ulAppDomainID,
+   Guid    guidModule,
+   ulong   baseAddress,
+   object  pUnkMetadataImport,
+   IStream pStream
+);
+```
+
+#### Parameters
+`ulAppDomainID`  
+[in] Identifier of the application domain.
+
+`guidModule`  
+[in] Unique identifier of the module.
+
+`baseAddress`  
+[in] Base memory address.
+
+`pUnkMetadataImport`  
+[in] Object that contains the symbol metadata.
+
+`pStream`  
+[in] Data stream that contains the symbols.
+
+## Return Value
+If successful, returns `S_OK`; otherwise, returns an error code.
+
+## Example
+The following example shows how to implement this method for a **CDebugSymbolProvider** object that exposes the [IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md) interface. The method calls the [LoadSymbolsFromStreamWithCorModule](../../../extensibility/debugger/reference/idebugcomplussymbolprovider2-loadsymbolsfromstreamwithcormodule.md) method.
+
+```cpp
+HRESULT CDebugSymbolProvider::LoadSymbolsFromStream(
+    ULONG32 ulAppDomainID,
+    GUID guidModule,
+    ULONGLONG baseOffset,
+    IUnknown* pUnkMetadataImport,
+    IStream* pStream
+)
+{
+    return LoadSymbolsFromStreamWithCorModule (ulAppDomainID, guidModule, baseOffset, pUnkMetadataImport, NULL, pStream);
+}
+```
+
+## See Also
+[IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md)


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.