### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/idebugcomplussymbolprovider-replacesymbols.md
+++ b/docs/extensibility/debugger/reference/idebugcomplussymbolprovider-replacesymbols.md
@@ -2,75 +2,75 @@
 title: "IDebugComPlusSymbolProvider::ReplaceSymbols | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "ReplaceSymbols"
   - "IDebugComPlusSymbolProvider::ReplaceSymbols"
 ms.assetid: 82fbc8db-c4b1-432f-bec9-1a9dc09570be
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # IDebugComPlusSymbolProvider::ReplaceSymbols
-Replaces the current debug symbols with those in the specified data stream.  
-  
-## Syntax  
-  
-```cpp  
-HRESULT ReplaceSymbols(  
-   ULONG32  ulAppDomainID,  
-   GUID     guidModule,  
-   IStream* pStream  
-);  
-```  
-  
-```csharp  
-int ReplaceSymbols(  
-   uint    ulAppDomainID,  
-   Guid    guidModule,  
-   IStream pStream  
-);  
-```  
-  
-#### Parameters  
- `ulAppDomainID`  
- [in] Identifier of the application domain.  
-  
- `guidModule`  
- [in] Unique identifier of the module.  
-  
- `pStream`  
- [in] Data stream that contains the new symbols.  
-  
-## Return Value  
- If successful, returns `S_OK`; otherwise, returns an error code.  
-  
-## Example  
- The following example shows how to implement this method for a **CDebugSymbolProvider** object that exposes the [IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md) interface.  
-  
-```cpp  
-HRESULT CDebugSymbolProvider::ReplaceSymbols(  
-    ULONG32 ulAppDomainID,  
-    GUID guidModule,  
-    IStream* pStream  
-)  
-{  
-    HRESULT hr = S_OK;  
-    CComPtr<CModule> pModule;  
-    Module_ID idModule(ulAppDomainID, guidModule);  
-  
-    METHOD_ENTRY( CDebugSymbolProvider::ReplaceSymbols );  
-  
-    IfFailGo( GetModule( idModule, &pModule ) );  
-    IfFailGo( pModule->ReplaceSymbols( pStream ) );  
-  
-Error:  
-  
-    METHOD_EXIT( CDebugSymbolProvider::ReplaceSymbols, hr );  
-    return hr;  
-}  
-```  
-  
-## See Also  
+Replaces the current debug symbols with those in the specified data stream.
+
+## Syntax
+
+```cpp
+HRESULT ReplaceSymbols(
+   ULONG32  ulAppDomainID,
+   GUID     guidModule,
+   IStream* pStream
+);
+```
+
+```csharp
+int ReplaceSymbols(
+   uint    ulAppDomainID,
+   Guid    guidModule,
+   IStream pStream
+);
+```
+
+#### Parameters
+ `ulAppDomainID`
+ [in] Identifier of the application domain.
+
+ `guidModule`
+ [in] Unique identifier of the module.
+
+ `pStream`
+ [in] Data stream that contains the new symbols.
+
+## Return Value
+ If successful, returns `S_OK`; otherwise, returns an error code.
+
+## Example
+ The following example shows how to implement this method for a **CDebugSymbolProvider** object that exposes the [IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md) interface.
+
+```cpp
+HRESULT CDebugSymbolProvider::ReplaceSymbols(
+    ULONG32 ulAppDomainID,
+    GUID guidModule,
+    IStream* pStream
+)
+{
+    HRESULT hr = S_OK;
+    CComPtr<CModule> pModule;
+    Module_ID idModule(ulAppDomainID, guidModule);
+
+    METHOD_ENTRY( CDebugSymbolProvider::ReplaceSymbols );
+
+    IfFailGo( GetModule( idModule, &pModule ) );
+    IfFailGo( pModule->ReplaceSymbols( pStream ) );
+
+Error:
+
+    METHOD_EXIT( CDebugSymbolProvider::ReplaceSymbols, hr );
+    return hr;
+}
+```
+
+## See Also
  [IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md)

--- a/docs/extensibility/debugger/reference/idebugcomplussymbolprovider-replacesymbols.md
+++ b/docs/extensibility/debugger/reference/idebugcomplussymbolprovider-replacesymbols.md
@@ -19,35 +19,35 @@ Replaces the current debug symbols with those in the specified data stream.
 
 ```cpp
 HRESULT ReplaceSymbols(
-   ULONG32  ulAppDomainID,
-   GUID     guidModule,
-   IStream* pStream
+    ULONG32  ulAppDomainID,
+    GUID     guidModule,
+    IStream* pStream
 );
 ```
 
 ```csharp
 int ReplaceSymbols(
-   uint    ulAppDomainID,
-   Guid    guidModule,
-   IStream pStream
+    uint    ulAppDomainID,
+    Guid    guidModule,
+    IStream pStream
 );
 ```
 
 #### Parameters
- `ulAppDomainID`
- [in] Identifier of the application domain.
+`ulAppDomainID`  
+[in] Identifier of the application domain.
 
- `guidModule`
- [in] Unique identifier of the module.
+`guidModule`  
+[in] Unique identifier of the module.
 
- `pStream`
- [in] Data stream that contains the new symbols.
+`pStream`  
+[in] Data stream that contains the new symbols.
 
 ## Return Value
- If successful, returns `S_OK`; otherwise, returns an error code.
+If successful, returns `S_OK`; otherwise, returns an error code.
 
 ## Example
- The following example shows how to implement this method for a **CDebugSymbolProvider** object that exposes the [IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md) interface.
+The following example shows how to implement this method for a **CDebugSymbolProvider** object that exposes the [IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md) interface.
 
 ```cpp
 HRESULT CDebugSymbolProvider::ReplaceSymbols(
@@ -73,4 +73,4 @@ Error:
 ```
 
 ## See Also
- [IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md)
+[IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md)


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.