### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/idebugcomplussymbolprovider-unloadsymbols.md
+++ b/docs/extensibility/debugger/reference/idebugcomplussymbolprovider-unloadsymbols.md
@@ -2,86 +2,86 @@
 title: "IDebugComPlusSymbolProvider::UnloadSymbols | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "UnloadSymbols"
   - "IDebugComPlusSymbolProvider::UnloadSymbols"
 ms.assetid: 53e3ddc1-ab47-4097-8fef-b26e5504b37a
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # IDebugComPlusSymbolProvider::UnloadSymbols
-Unloads the debug symbols for the specified module from memory.  
-  
-## Syntax  
-  
-```cpp  
-HRESULT UnloadSymbols(  
-   ULONG32 ulAppDomainID,  
-   GUID    guidModule  
-);  
-```  
-  
-```csharp  
-int UnloadSymbols(  
-   uint ulAppDomainID,  
-   Guid guidModule  
-);  
-```  
-  
-#### Parameters  
- `ulAppDomainID`  
- [in] Identifier of the application domain.  
-  
- `guidModule`  
- [in] Unique identifier of the module.  
-  
-## Return Value  
- If successful, returns `S_OK`; otherwise, returns an error code.  
-  
-## Example  
- The following example shows how to implement this method for a **CDebugSymbolProvider** object that exposes the [IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md) interface.  
-  
-```cpp  
-HRESULT CDebugSymbolProvider::UnloadSymbols(  
-    ULONG32 ulAppDomainID,  
-    GUID guidModule  
-)  
-{  
-    HRESULT hr = S_OK;  
-    CComPtr<CModule> pmodule;  
-    Module_ID idModule(ulAppDomainID, guidModule);  
-  
-    METHOD_ENTRY( CDebugSymbolProvider::UnloadSymbols );  
-  
-#if DEBUG  
-  
-    DebugVerifyModules();  
-#endif  
-  
-    IfFailGo( GetModule( idModule, &pmodule ) );  
-  
-#if DEBUG  
-  
-    DebugVerifyModules();  
-#endif  
-  
-    RemoveModule( pmodule );  
-    pmodule->Cleanup();  
-  
-Error:  
-#if DEBUG  
-  
-    DebugVerifyModules();  
-#endif  
-  
-    METHOD_EXIT( CDebugSymbolProvider::UnloadSymbols, hr );  
-  
-    return hr;  
-}  
-```  
-  
-## See Also  
- [IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md)
+Unloads the debug symbols for the specified module from memory.
+
+## Syntax
+
+```cpp
+HRESULT UnloadSymbols(
+   ULONG32 ulAppDomainID,
+   GUID    guidModule
+);
+```
+
+```csharp
+int UnloadSymbols(
+   uint ulAppDomainID,
+   Guid guidModule
+);
+```
+
+#### Parameters
+`ulAppDomainID`  
+[in] Identifier of the application domain.
+
+`guidModule`  
+[in] Unique identifier of the module.
+
+## Return Value
+If successful, returns `S_OK`; otherwise, returns an error code.
+
+## Example
+The following example shows how to implement this method for a **CDebugSymbolProvider** object that exposes the [IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md) interface.
+
+```cpp
+HRESULT CDebugSymbolProvider::UnloadSymbols(
+    ULONG32 ulAppDomainID,
+    GUID guidModule
+)
+{
+    HRESULT hr = S_OK;
+    CComPtr<CModule> pmodule;
+    Module_ID idModule(ulAppDomainID, guidModule);
+
+    METHOD_ENTRY( CDebugSymbolProvider::UnloadSymbols );
+
+#if DEBUG
+
+    DebugVerifyModules();
+#endif
+
+    IfFailGo( GetModule( idModule, &pmodule ) );
+
+#if DEBUG
+
+    DebugVerifyModules();
+#endif
+
+    RemoveModule( pmodule );
+    pmodule->Cleanup();
+
+Error:
+#if DEBUG
+
+    DebugVerifyModules();
+#endif
+
+    METHOD_EXIT( CDebugSymbolProvider::UnloadSymbols, hr );
+
+    return hr;
+}
+```
+
+## See Also
+[IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md)

--- a/docs/extensibility/debugger/reference/idebugcomplussymbolprovider-unloadsymbols.md
+++ b/docs/extensibility/debugger/reference/idebugcomplussymbolprovider-unloadsymbols.md
@@ -19,15 +19,15 @@ Unloads the debug symbols for the specified module from memory.
 
 ```cpp
 HRESULT UnloadSymbols(
-   ULONG32 ulAppDomainID,
-   GUID    guidModule
+    ULONG32 ulAppDomainID,
+    GUID    guidModule
 );
 ```
 
 ```csharp
 int UnloadSymbols(
-   uint ulAppDomainID,
-   Guid guidModule
+    uint ulAppDomainID,
+    Guid guidModule
 );
 ```
 


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.