### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/idebugcomplussymbolprovider-updatesymbols.md
+++ b/docs/extensibility/debugger/reference/idebugcomplussymbolprovider-updatesymbols.md
@@ -2,88 +2,88 @@
 title: "IDebugComPlusSymbolProvider::UpdateSymbols | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "UpdateSymbols"
   - "IDebugComPlusSymbolProvider::UpdateSymbols"
 ms.assetid: d530f6f1-4af2-454b-bab0-02478a8fe81e
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # IDebugComPlusSymbolProvider::UpdateSymbols
-Updates the debug symbols in memory with those from the specified data stream.  
-  
-## Syntax  
-  
-```cpp  
-HRESULT UpdateSymbols (  
-   ULONG32  ulAppDomainID,  
-   GUID     guidModule,  
-   IStream* pUpdateStream  
-);  
-```  
-  
-```csharp  
-int UpdateSymbols (  
-   uint    ulAppDomainID,  
-   Guid    guidModule,  
-   IStream pUpdateStream  
-);  
-```  
-  
-#### Parameters  
- `ulAppDomainID`  
- [in] Identifier of the application domain.  
-  
- `guidModule`  
- [in] Unique identifier of the module.  
-  
- `pUpdateStream`  
- [in] Data stream that contains the updated debug symbols.  
-  
-## Example  
- The following example shows how to implement this method for a **CDebugSymbolProvider** object that exposes the [IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md) interface.  
-  
-```cpp  
-HRESULT CDebugSymbolProvider::UpdateSymbols(  
-    ULONG32 ulAppDomainID,  
-    GUID guidModule,  
-    IStream* pUpdateStream  
-)  
-{  
-    ASSERT(!"Use UpdateSymbols2 on IDebugENCSymbolProvider2");  
-    return E_NOTIMPL;  
-}  
-  
-HRESULT CDebugSymbolProvider::UpdateSymbols2(  
-    ULONG32 ulAppDomainID,  
-    GUID guidModule,  
-    IStream* pUpdateStream,  
-    LINEDELTA* pDeltaLines,  
-    ULONG cDeltaLines  
-)  
-{  
-    HRESULT hr = S_OK;  
-    CComPtr<CModule> pModule;  
-    Module_ID idModule(ulAppDomainID, guidModule);  
-  
-    METHOD_ENTRY( CDebugSymbolProvider::UpdateSymbols );  
-  
-    IfFailGo( GetModule( idModule, &pModule ) );  
-    IfFailGo( pModule->UpdateSymbols( pUpdateStream, pDeltaLines, cDeltaLines ) );  
-  
-Error:  
-  
-    METHOD_EXIT( CDebugSymbolProvider::UpdateSymbols, hr );  
-  
-    return hr;  
-}  
-```  
-  
-## Return Value  
- If successful, returns `S_OK`; otherwise, returns an error code.  
-  
-## See Also  
- [IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md)
+Updates the debug symbols in memory with those from the specified data stream.
+
+## Syntax
+
+```cpp
+HRESULT UpdateSymbols (
+   ULONG32  ulAppDomainID,
+   GUID     guidModule,
+   IStream* pUpdateStream
+);
+```
+
+```csharp
+int UpdateSymbols (
+   uint    ulAppDomainID,
+   Guid    guidModule,
+   IStream pUpdateStream
+);
+```
+
+#### Parameters
+`ulAppDomainID`  
+[in] Identifier of the application domain.
+
+`guidModule`  
+[in] Unique identifier of the module.
+
+`pUpdateStream`  
+[in] Data stream that contains the updated debug symbols.
+
+## Example
+The following example shows how to implement this method for a **CDebugSymbolProvider** object that exposes the [IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md) interface.
+
+```cpp
+HRESULT CDebugSymbolProvider::UpdateSymbols(
+    ULONG32 ulAppDomainID,
+    GUID guidModule,
+    IStream* pUpdateStream
+)
+{
+    ASSERT(!"Use UpdateSymbols2 on IDebugENCSymbolProvider2");
+    return E_NOTIMPL;
+}
+
+HRESULT CDebugSymbolProvider::UpdateSymbols2(
+    ULONG32 ulAppDomainID,
+    GUID guidModule,
+    IStream* pUpdateStream,
+    LINEDELTA* pDeltaLines,
+    ULONG cDeltaLines
+)
+{
+    HRESULT hr = S_OK;
+    CComPtr<CModule> pModule;
+    Module_ID idModule(ulAppDomainID, guidModule);
+
+    METHOD_ENTRY( CDebugSymbolProvider::UpdateSymbols );
+
+    IfFailGo( GetModule( idModule, &pModule ) );
+    IfFailGo( pModule->UpdateSymbols( pUpdateStream, pDeltaLines, cDeltaLines ) );
+
+Error:
+
+    METHOD_EXIT( CDebugSymbolProvider::UpdateSymbols, hr );
+
+    return hr;
+}
+```
+
+## Return Value
+If successful, returns `S_OK`; otherwise, returns an error code.
+
+## See Also
+[IDebugComPlusSymbolProvider](../../../extensibility/debugger/reference/idebugcomplussymbolprovider.md)

--- a/docs/extensibility/debugger/reference/idebugcomplussymbolprovider-updatesymbols.md
+++ b/docs/extensibility/debugger/reference/idebugcomplussymbolprovider-updatesymbols.md
@@ -19,17 +19,17 @@ Updates the debug symbols in memory with those from the specified data stream.
 
 ```cpp
 HRESULT UpdateSymbols (
-   ULONG32  ulAppDomainID,
-   GUID     guidModule,
-   IStream* pUpdateStream
+    ULONG32  ulAppDomainID,
+    GUID     guidModule,
+    IStream* pUpdateStream
 );
 ```
 
 ```csharp
 int UpdateSymbols (
-   uint    ulAppDomainID,
-   Guid    guidModule,
-   IStream pUpdateStream
+    uint    ulAppDomainID,
+    Guid    guidModule,
+    IStream pUpdateStream
 );
 ```
 


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.