### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/idebugcomplussymbolprovider2-functionhaslineinfo.md
+++ b/docs/extensibility/debugger/reference/idebugcomplussymbolprovider2-functionhaslineinfo.md
@@ -2,79 +2,79 @@
 title: "IDebugComPlusSymbolProvider2::FunctionHasLineInfo | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "FunctionHasLineInfo"
   - "IDebugComPlusSymbolProvider2::FunctionHasLineInfo"
 ms.assetid: e1b508f1-6521-492f-b110-ab957744a037
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # IDebugComPlusSymbolProvider2::FunctionHasLineInfo
-Determines if the specified method has line information.  
-  
-## Syntax  
-  
-```cpp  
-HRESULT FunctionHasLineInfo(  
-   IDebugAddress* pAddress  
-);  
-```  
-  
-```csharp  
-int FunctionHasLineInfo(  
-   IDebugAddress pAddress  
-);  
-```  
-  
-#### Parameters  
- `pAddress`  
- [in] The debug address that is represented by an [IDebugAddress](../../../extensibility/debugger/reference/idebugaddress.md) interface. This address must be a METHOD_ADDRESS.  
-  
-## Return Value  
- If successful, returns `S_OK`; otherwise, returns `S_FALSE`.  
-  
-## Example  
- The following example shows how to implement this method for a **CDebugSymbolProvider** object that exposes the [IDebugComPlusSymbolProvider2](../../../extensibility/debugger/reference/idebugcomplussymbolprovider2.md) interface.  
-  
-```cpp  
-HRESULT CDebugSymbolProvider::FunctionHasLineInfo(  
-    IDebugAddress* pAddress  
-)  
-{  
-    HRESULT hr = S_OK;  
-    CDEBUG_ADDRESS address;  
-    CComPtr<CModule> pModule;  
-  
-    METHOD_ENTRY( CDebugSymbolProvider::LoadSymbol );  
-  
-    IfFalseGo( pAddress, E_INVALIDARG );  
-  
-    IfFailGo( pAddress->GetAddress( &address ) );  
-  
-    ASSERT(address.addr.dwKind == ADDRESS_KIND_METADATA_METHOD);  
-    IfFalseGo( address.addr.dwKind == ADDRESS_KIND_METADATA_METHOD, S_FALSE );  
-  
-    IfFailGo( GetModule( address.GetModule(), &pModule) );  
-  
-    if (!pModule->FunctionHasLineInfo( address.addr.addr.addrMethod.tokMethod,  
-                                       address.addr.addr.addrMethod.dwVersion))  
-    {  
-  
-        // S_FALSE indicates this method does not have line info  
-  
-        hr = S_FALSE;  
-    }  
-  
-Error:  
-  
-    METHOD_EXIT( CDebugSymbolProvider::LoadSymbol, hr );  
-  
-    return hr;  
-}  
-```  
-  
-## See Also  
- [IDebugComPlusSymbolProvider2](../../../extensibility/debugger/reference/idebugcomplussymbolprovider2.md)
+Determines if the specified method has line information.
+
+## Syntax
+
+```cpp
+HRESULT FunctionHasLineInfo(
+   IDebugAddress* pAddress
+);
+```
+
+```csharp
+int FunctionHasLineInfo(
+   IDebugAddress pAddress
+);
+```
+
+#### Parameters
+`pAddress`  
+[in] The debug address that is represented by an [IDebugAddress](../../../extensibility/debugger/reference/idebugaddress.md) interface. This address must be a METHOD_ADDRESS.
+
+## Return Value
+If successful, returns `S_OK`; otherwise, returns `S_FALSE`.
+
+## Example
+The following example shows how to implement this method for a **CDebugSymbolProvider** object that exposes the [IDebugComPlusSymbolProvider2](../../../extensibility/debugger/reference/idebugcomplussymbolprovider2.md) interface.
+
+```cpp
+HRESULT CDebugSymbolProvider::FunctionHasLineInfo(
+    IDebugAddress* pAddress
+)
+{
+    HRESULT hr = S_OK;
+    CDEBUG_ADDRESS address;
+    CComPtr<CModule> pModule;
+
+    METHOD_ENTRY( CDebugSymbolProvider::LoadSymbol );
+
+    IfFalseGo( pAddress, E_INVALIDARG );
+
+    IfFailGo( pAddress->GetAddress( &address ) );
+
+    ASSERT(address.addr.dwKind == ADDRESS_KIND_METADATA_METHOD);
+    IfFalseGo( address.addr.dwKind == ADDRESS_KIND_METADATA_METHOD, S_FALSE );
+
+    IfFailGo( GetModule( address.GetModule(), &pModule) );
+
+    if (!pModule->FunctionHasLineInfo( address.addr.addr.addrMethod.tokMethod,
+                                       address.addr.addr.addrMethod.dwVersion))
+    {
+
+        // S_FALSE indicates this method does not have line info
+
+        hr = S_FALSE;
+    }
+
+Error:
+
+    METHOD_EXIT( CDebugSymbolProvider::LoadSymbol, hr );
+
+    return hr;
+}
+```
+
+## See Also
+[IDebugComPlusSymbolProvider2](../../../extensibility/debugger/reference/idebugcomplussymbolprovider2.md)

--- a/docs/extensibility/debugger/reference/idebugcomplussymbolprovider2-functionhaslineinfo.md
+++ b/docs/extensibility/debugger/reference/idebugcomplussymbolprovider2-functionhaslineinfo.md
@@ -19,13 +19,13 @@ Determines if the specified method has line information.
 
 ```cpp
 HRESULT FunctionHasLineInfo(
-   IDebugAddress* pAddress
+    IDebugAddress* pAddress
 );
 ```
 
 ```csharp
 int FunctionHasLineInfo(
-   IDebugAddress pAddress
+    IDebugAddress pAddress
 );
 ```
 


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.