### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/idebugcomplussymbolprovider2-gettypefromtoken.md
+++ b/docs/extensibility/debugger/reference/idebugcomplussymbolprovider2-gettypefromtoken.md
@@ -2,83 +2,83 @@
 title: "IDebugComPlusSymbolProvider2::GetTypeFromToken | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "IDebugComPlusSymbolProvider2::GetTypeFromToken"
   - "GetTypeFromToken"
 ms.assetid: 4452bc5d-0225-40e0-a467-c472a5c7c4ee
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # IDebugComPlusSymbolProvider2::GetTypeFromToken
-Retrieves a type given its token.  
-  
-## Syntax  
-  
-```cpp  
-HRESULT GetTypeFromToken(  
-   ULONG32       appDomain,  
-   GUID          guidModule,  
-   DWORD         tdToken,  
-   IDebugField** ppField  
-);  
-```  
-  
-```csharp  
-int GetTypeFromToken(  
-   uint            appDomain,  
-   Guid            guidModule,  
-   uint            tdToken,  
-   out IDebugField ppField  
-);  
-```  
-  
-#### Parameters  
- `appDomain`  
- [in] Identifier of the application domain.  
-  
- `guidModule`  
- [in] Unique identifier of the module.  
-  
- `tdToken`  
- [in] Token of the type to be retrieved.  
-  
- `ppField`  
- [out] Returns the type that is represented by the [IDebugField](../../../extensibility/debugger/reference/idebugfield.md).  
-  
-## Return Value  
- If successful, returns `S_OK`; otherwise, returns an error code.  
-  
-## Example  
- The following example shows how to implement this method for a **CDebugSymbolProvider** object that exposes the [IDebugComPlusSymbolProvider2](../../../extensibility/debugger/reference/idebugcomplussymbolprovider2.md) interface.  
-  
-```cpp  
-HRESULT CDebugSymbolProvider::GetTypeFromToken(  
-    ULONG32 ulAppDomainID,  
-    GUID guidModule,  
-    DWORD tdToken,  
-    IDebugField **ppField)  
-{  
-    HRESULT hr = E_FAIL;  
-  
-    METHOD_ENTRY( CDebugDynamicFieldSymbol::GetTypeFromToken );  
-  
-    ASSERT(IsValidObjectPtr(this, CDebugSymbolProvider));  
-    ASSERT(IsValidWritePtr(ppField, IDebugField*));  
-  
-    Module_ID idModule(ulAppDomainID, guidModule);  
-  
-    IfFailGo( this->CreateClassType(idModule, tdToken, ppField) );  
-  
-Error:  
-  
-    METHOD_EXIT( CDebugDynamicFieldSymbol::GetTypeFromToken, hr );  
-  
-    return hr;  
-}  
-```  
-  
-## See Also  
- [IDebugComPlusSymbolProvider2](../../../extensibility/debugger/reference/idebugcomplussymbolprovider2.md)
+Retrieves a type given its token.
+
+## Syntax
+
+```cpp
+HRESULT GetTypeFromToken(
+   ULONG32       appDomain,
+   GUID          guidModule,
+   DWORD         tdToken,
+   IDebugField** ppField
+);
+```
+
+```csharp
+int GetTypeFromToken(
+   uint            appDomain,
+   Guid            guidModule,
+   uint            tdToken,
+   out IDebugField ppField
+);
+```
+
+#### Parameters
+`appDomain`  
+[in] Identifier of the application domain.
+
+`guidModule`  
+[in] Unique identifier of the module.
+
+`tdToken`  
+[in] Token of the type to be retrieved.
+
+`ppField`  
+[out] Returns the type that is represented by the [IDebugField](../../../extensibility/debugger/reference/idebugfield.md).
+
+## Return Value
+If successful, returns `S_OK`; otherwise, returns an error code.
+
+## Example
+The following example shows how to implement this method for a **CDebugSymbolProvider** object that exposes the [IDebugComPlusSymbolProvider2](../../../extensibility/debugger/reference/idebugcomplussymbolprovider2.md) interface.
+
+```cpp
+HRESULT CDebugSymbolProvider::GetTypeFromToken(
+    ULONG32 ulAppDomainID,
+    GUID guidModule,
+    DWORD tdToken,
+    IDebugField **ppField)
+{
+    HRESULT hr = E_FAIL;
+
+    METHOD_ENTRY( CDebugDynamicFieldSymbol::GetTypeFromToken );
+
+    ASSERT(IsValidObjectPtr(this, CDebugSymbolProvider));
+    ASSERT(IsValidWritePtr(ppField, IDebugField*));
+
+    Module_ID idModule(ulAppDomainID, guidModule);
+
+    IfFailGo( this->CreateClassType(idModule, tdToken, ppField) );
+
+Error:
+
+    METHOD_EXIT( CDebugDynamicFieldSymbol::GetTypeFromToken, hr );
+
+    return hr;
+}
+```
+
+## See Also
+[IDebugComPlusSymbolProvider2](../../../extensibility/debugger/reference/idebugcomplussymbolprovider2.md)

--- a/docs/extensibility/debugger/reference/idebugcomplussymbolprovider2-gettypefromtoken.md
+++ b/docs/extensibility/debugger/reference/idebugcomplussymbolprovider2-gettypefromtoken.md
@@ -19,19 +19,19 @@ Retrieves a type given its token.
 
 ```cpp
 HRESULT GetTypeFromToken(
-   ULONG32       appDomain,
-   GUID          guidModule,
-   DWORD         tdToken,
-   IDebugField** ppField
+    ULONG32       appDomain,
+    GUID          guidModule,
+    DWORD         tdToken,
+    IDebugField** ppField
 );
 ```
 
 ```csharp
 int GetTypeFromToken(
-   uint            appDomain,
-   Guid            guidModule,
-   uint            tdToken,
-   out IDebugField ppField
+    uint            appDomain,
+    Guid            guidModule,
+    uint            tdToken,
+    out IDebugField ppField
 );
 ```
 


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.