### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/idebugcomplussymbolprovider2-isaddresssequencepoint.md
+++ b/docs/extensibility/debugger/reference/idebugcomplussymbolprovider2-isaddresssequencepoint.md
@@ -19,13 +19,13 @@ Determines if the specified debug address is a sequence point.
 
 ```cpp
 HRESULT IsAddressSequencePoint(
-   IDebugAddress* pAddress
+    IDebugAddress* pAddress
 );
 ```
 
 ```csharp
 int IsAddressSequencePoint(
-   IDebugAddress pAddress
+    IDebugAddress pAddress
 );
 ```
 

--- a/docs/extensibility/debugger/reference/idebugcomplussymbolprovider2-isaddresssequencepoint.md
+++ b/docs/extensibility/debugger/reference/idebugcomplussymbolprovider2-isaddresssequencepoint.md
@@ -2,80 +2,80 @@
 title: "IDebugComPlusSymbolProvider2::IsAddressSequencePoint | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "IDebugComPlusSymbolProvider2::IsAddressSequencePoint"
   - "IsAddressSequencePoint"
 ms.assetid: 89b27c57-5295-428b-8229-a402500d8cd3
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # IDebugComPlusSymbolProvider2::IsAddressSequencePoint
-Determines if the specified debug address is a sequence point.  
-  
-## Syntax  
-  
-```cpp  
-HRESULT IsAddressSequencePoint(  
-   IDebugAddress* pAddress  
-);  
-```  
-  
-```csharp  
-int IsAddressSequencePoint(  
-   IDebugAddress pAddress  
-);  
-```  
-  
-#### Parameters  
- `pAddress`  
- [in] Debug address that is represented by the [IDebugAddress](../../../extensibility/debugger/reference/idebugaddress.md) interface.  
-  
-## Return Value  
- If the debug address is a sequence point, returns `S_OK`; otherwise, returns `S_FALSE`.  
-  
-## Example  
- The following example shows how to implement this method for a **CDebugSymbolProvider** object that exposes the [IDebugComPlusSymbolProvider2](../../../extensibility/debugger/reference/idebugcomplussymbolprovider2.md) interface.  
-  
-```cpp  
-HRESULT CDebugSymbolProvider::IsAddressSequencePoint(  
-    IDebugAddress* pAddress  
-)  
-{  
-    HRESULT hr = S_OK;  
-    CDEBUG_ADDRESS address;  
-    CComPtr<CModule> pModule;  
-  
-    METHOD_ENTRY( CDebugSymbolProvider::LoadSymbol );  
-  
-    IfFalseGo( pAddress, E_INVALIDARG );  
-  
-    IfFailGo( pAddress->GetAddress( &address ) );  
-  
-    ASSERT(address.addr.dwKind == ADDRESS_KIND_METADATA_METHOD);  
-    IfFalseGo( address.addr.dwKind == ADDRESS_KIND_METADATA_METHOD, S_FALSE );  
-  
-    IfFailGo( GetModule( address.GetModule(), &pModule) );  
-  
-    if (!pModule->IsSequencePoint( address.addr.addr.addrMethod.tokMethod,  
-                                   address.addr.addr.addrMethod.dwVersion,  
-                                   address.addr.addr.addrMethod.dwOffset ))  
-    {  
-  
-        // S_FALSE indicates this is not a sequence point  
-  
-        hr = S_FALSE;  
-    }  
-  
-Error:  
-  
-    METHOD_EXIT( CDebugSymbolProvider::LoadSymbol, hr );  
-  
-    return hr;  
-}  
-```  
-  
-## See Also  
- [IDebugComPlusSymbolProvider2](../../../extensibility/debugger/reference/idebugcomplussymbolprovider2.md)
+Determines if the specified debug address is a sequence point.
+
+## Syntax
+
+```cpp
+HRESULT IsAddressSequencePoint(
+   IDebugAddress* pAddress
+);
+```
+
+```csharp
+int IsAddressSequencePoint(
+   IDebugAddress pAddress
+);
+```
+
+#### Parameters
+`pAddress`  
+[in] Debug address that is represented by the [IDebugAddress](../../../extensibility/debugger/reference/idebugaddress.md) interface.
+
+## Return Value
+If the debug address is a sequence point, returns `S_OK`; otherwise, returns `S_FALSE`.
+
+## Example
+The following example shows how to implement this method for a **CDebugSymbolProvider** object that exposes the [IDebugComPlusSymbolProvider2](../../../extensibility/debugger/reference/idebugcomplussymbolprovider2.md) interface.
+
+```cpp
+HRESULT CDebugSymbolProvider::IsAddressSequencePoint(
+    IDebugAddress* pAddress
+)
+{
+    HRESULT hr = S_OK;
+    CDEBUG_ADDRESS address;
+    CComPtr<CModule> pModule;
+
+    METHOD_ENTRY( CDebugSymbolProvider::LoadSymbol );
+
+    IfFalseGo( pAddress, E_INVALIDARG );
+
+    IfFailGo( pAddress->GetAddress( &address ) );
+
+    ASSERT(address.addr.dwKind == ADDRESS_KIND_METADATA_METHOD);
+    IfFalseGo( address.addr.dwKind == ADDRESS_KIND_METADATA_METHOD, S_FALSE );
+
+    IfFailGo( GetModule( address.GetModule(), &pModule) );
+
+    if (!pModule->IsSequencePoint( address.addr.addr.addrMethod.tokMethod,
+                                   address.addr.addr.addrMethod.dwVersion,
+                                   address.addr.addr.addrMethod.dwOffset ))
+    {
+
+        // S_FALSE indicates this is not a sequence point
+
+        hr = S_FALSE;
+    }
+
+Error:
+
+    METHOD_EXIT( CDebugSymbolProvider::LoadSymbol, hr );
+
+    return hr;
+}
+```
+
+## See Also
+[IDebugComPlusSymbolProvider2](../../../extensibility/debugger/reference/idebugcomplussymbolprovider2.md)


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.