### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/idebugcomplussymbolprovider2-loadsymbolsfromcallback.md
+++ b/docs/extensibility/debugger/reference/idebugcomplussymbolprovider2-loadsymbolsfromcallback.md
@@ -19,25 +19,25 @@ Loads debug symbols using the specified callback method.
 
 ```cpp
 HRESULT LoadSymbolsFromCallback(
-   ULONG32   ulAppDomainID,
-   GUID      guidModule,
-   IUnknown* pUnkMetadataImport,
-   IUnknown* pUnkCorDebugModule,
-   BSTR      bstrModuleName,
-   BSTR      bstrSymSearchPath,
-   IUnknown* pCallback
+    ULONG32   ulAppDomainID,
+    GUID      guidModule,
+    IUnknown* pUnkMetadataImport,
+    IUnknown* pUnkCorDebugModule,
+    BSTR      bstrModuleName,
+    BSTR      bstrSymSearchPath,
+    IUnknown* pCallback
 );
 ```
 
 ```csharp
 int LoadSymbolsFromCallback(
-   uint   ulAppDomainID,
-   Guid   guidModule,
-   object pUnkMetadataImport,
-   object pUnkCorDebugModule,
-   string bstrModuleName,
-   string bstrSymSearchPath,
-   object pCallback
+    uint   ulAppDomainID,
+    Guid   guidModule,
+    object pUnkMetadataImport,
+    object pUnkCorDebugModule,
+    string bstrModuleName,
+    string bstrSymSearchPath,
+    object pCallback
 );
 ```
 

--- a/docs/extensibility/debugger/reference/idebugcomplussymbolprovider2-loadsymbolsfromcallback.md
+++ b/docs/extensibility/debugger/reference/idebugcomplussymbolprovider2-loadsymbolsfromcallback.md
@@ -2,163 +2,163 @@
 title: "IDebugComPlusSymbolProvider2::LoadSymbolsFromCallback | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "LoadSymbolsFromCallback"
   - "IDebugComPlusSymbolProvider2::LoadSymbolsFromCallback"
 ms.assetid: 905315ba-8e9b-4889-b9da-98e1441950ad
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # IDebugComPlusSymbolProvider2::LoadSymbolsFromCallback
-Loads debug symbols using the specified callback method.  
-  
-## Syntax  
-  
-```cpp  
-HRESULT LoadSymbolsFromCallback(  
-   ULONG32   ulAppDomainID,  
-   GUID      guidModule,  
-   IUnknown* pUnkMetadataImport,  
-   IUnknown* pUnkCorDebugModule,  
-   BSTR      bstrModuleName,  
-   BSTR      bstrSymSearchPath,  
-   IUnknown* pCallback  
-);  
-```  
-  
-```csharp  
-int LoadSymbolsFromCallback(  
-   uint   ulAppDomainID,  
-   Guid   guidModule,  
-   object pUnkMetadataImport,  
-   object pUnkCorDebugModule,  
-   string bstrModuleName,  
-   string bstrSymSearchPath,  
-   object pCallback  
-);  
-```  
-  
-#### Parameters  
- `ulAppDomainID`  
- [in] Identifier of the application domain.  
-  
- `guidModule`  
- [in] Unique identifier of the module.  
-  
- `pUnkMetadataImport`  
- [in] Object that contains the symbol metadata.  
-  
- `pUnkCorDebugModule`  
- [in] Object that implements the [ICorDebugModule Interface](/dotnet/framework/unmanaged-api/debugging/icordebugmodule-interface).  
-  
- `bstrModuleName`  
- [in] Name of the module.  
-  
- `bstrSymSearchPath`  
- [in] Path to search for the symbol file.  
-  
- `pCallback`  
- [in] Object that represents the callback method.  
-  
-## Return Value  
- If successful, returns `S_OK`; otherwise, returns an error code.  
-  
-## Example  
- The following example shows how to implement this method for a **CDebugSymbolProvider** object that exposes the [IDebugComPlusSymbolProvider2](../../../extensibility/debugger/reference/idebugcomplussymbolprovider2.md) interface.  
-  
-```cpp  
-HRESULT CDebugSymbolProvider::LoadSymbolsFromCallback(  
-    ULONG32 ulAppDomainID,  
-    GUID guidModule,  
-    IUnknown *pMetadataImport,  
-    IUnknown * _pCorModule,  
-    BSTR bstrModule,  
-    BSTR bstrSearchPath,  
-    IUnknown *pCallback)  
-{  
-    EMIT_TICK_COUNT("Entry -- Loading symbols for the following target:");  
-    USES_CONVERSION;  
-    EmitTickCount(W2A(bstrModule));  
-  
-    CAutoLock Lock(this);  
-  
-    HRESULT hr = S_OK;  
-    CComPtr<IMetaDataImport> pMetadata;  
-    CComPtr<ICorDebugModule> pCorModule;  
-  
-    CModule* pmodule = NULL;  
-    CModule* pmoduleNew = NULL;  
-    bool fAlreadyLoaded = false;  
-    Module_ID idModule(ulAppDomainID, guidModule);  
-    bool fSymbolsLoaded = false;  
-    DWORD dwCurrentState = 0;  
-  
-    ASSERT(IsValidObjectPtr(this, CDebugSymbolProvider));  
-    ASSERT(IsValidInterfacePtr(pMetadataImport, IUnknown));  
-  
-    METHOD_ENTRY( CDebugSymbolProvider::LoadSymbol );  
-  
-    IfFalseGo( pMetadataImport, E_INVALIDARG );  
-    IfFalseGo( _pCorModule, E_INVALIDARG );  
-  
-    IfFailGo( pMetadataImport->QueryInterface( IID_IMetaDataImport,  
-              (void**)&pMetadata) );  
-  
-    IfFailGo( _pCorModule->QueryInterface( IID_ICorDebugModule,  
-                                           (void**)&pCorModule) );  
-  
-    ASSERT(guidModule != GUID_NULL);  
-  
-    fAlreadyLoaded = GetModule( idModule, &pmodule ) == S_OK;  
-  
-    IfNullGo( pmoduleNew = new CModule, E_OUTOFMEMORY );  
-  
-    //  
-    //  We are now allowing modules to be created that do not have SymReaders.  
-    //  It is likely there are a number of corner cases being ignored  
-    //  that will require knowledge of the hr result below.  
-    //  
-    dwCurrentState = m_pSymProvGroup ? m_pSymProvGroup->GetCurrentState() : 0;  
-    HRESULT hrLoad = pmoduleNew->Create( idModule,  
-                                         dwCurrentState,  
-                                         pMetadata,  
-                                         pCorModule,  
-                                         bstrModule,  
-                                         bstrSearchPath,  
-                                         pCallback );  
-  
-    if (hrLoad == S_OK)  
-    {  
-        fSymbolsLoaded = true;  
-    }  
-  
-    // Remove the old module  
-    if (fAlreadyLoaded)  
-    {  
-        IfFailGo(pmoduleNew->AddEquivalentModulesFrom(pmodule));  
-        RemoveModule( pmodule );  
-    }  
-  
-    IfFailGo( AddModule( pmoduleNew ) );  
-  
-Error:  
-  
-    RELEASE (pmodule);  
-    RELEASE (pmoduleNew);  
-  
-    if (SUCCEEDED(hr) && !fSymbolsLoaded)  
-    {  
-        hr = hrLoad;  
-    }  
-  
-    METHOD_EXIT( CDebugSymbolProvider::LoadSymbol, hr );  
-    EMIT_TICK_COUNT("Exit");  
-    return hr;  
-}  
-```  
-  
-## See Also  
- [IDebugComPlusSymbolProvider2](../../../extensibility/debugger/reference/idebugcomplussymbolprovider2.md)
+Loads debug symbols using the specified callback method.
+
+## Syntax
+
+```cpp
+HRESULT LoadSymbolsFromCallback(
+   ULONG32   ulAppDomainID,
+   GUID      guidModule,
+   IUnknown* pUnkMetadataImport,
+   IUnknown* pUnkCorDebugModule,
+   BSTR      bstrModuleName,
+   BSTR      bstrSymSearchPath,
+   IUnknown* pCallback
+);
+```
+
+```csharp
+int LoadSymbolsFromCallback(
+   uint   ulAppDomainID,
+   Guid   guidModule,
+   object pUnkMetadataImport,
+   object pUnkCorDebugModule,
+   string bstrModuleName,
+   string bstrSymSearchPath,
+   object pCallback
+);
+```
+
+#### Parameters
+`ulAppDomainID`  
+[in] Identifier of the application domain.
+
+`guidModule`  
+[in] Unique identifier of the module.
+
+`pUnkMetadataImport`  
+[in] Object that contains the symbol metadata.
+
+`pUnkCorDebugModule`  
+[in] Object that implements the [ICorDebugModule Interface](/dotnet/framework/unmanaged-api/debugging/icordebugmodule-interface).
+
+`bstrModuleName`  
+[in] Name of the module.
+
+`bstrSymSearchPath`  
+[in] Path to search for the symbol file.
+
+`pCallback`  
+[in] Object that represents the callback method.
+
+## Return Value
+If successful, returns `S_OK`; otherwise, returns an error code.
+
+## Example
+The following example shows how to implement this method for a **CDebugSymbolProvider** object that exposes the [IDebugComPlusSymbolProvider2](../../../extensibility/debugger/reference/idebugcomplussymbolprovider2.md) interface.
+
+```cpp
+HRESULT CDebugSymbolProvider::LoadSymbolsFromCallback(
+    ULONG32 ulAppDomainID,
+    GUID guidModule,
+    IUnknown *pMetadataImport,
+    IUnknown * _pCorModule,
+    BSTR bstrModule,
+    BSTR bstrSearchPath,
+    IUnknown *pCallback)
+{
+    EMIT_TICK_COUNT("Entry -- Loading symbols for the following target:");
+    USES_CONVERSION;
+    EmitTickCount(W2A(bstrModule));
+
+    CAutoLock Lock(this);
+
+    HRESULT hr = S_OK;
+    CComPtr<IMetaDataImport> pMetadata;
+    CComPtr<ICorDebugModule> pCorModule;
+
+    CModule* pmodule = NULL;
+    CModule* pmoduleNew = NULL;
+    bool fAlreadyLoaded = false;
+    Module_ID idModule(ulAppDomainID, guidModule);
+    bool fSymbolsLoaded = false;
+    DWORD dwCurrentState = 0;
+
+    ASSERT(IsValidObjectPtr(this, CDebugSymbolProvider));
+    ASSERT(IsValidInterfacePtr(pMetadataImport, IUnknown));
+
+    METHOD_ENTRY( CDebugSymbolProvider::LoadSymbol );
+
+    IfFalseGo( pMetadataImport, E_INVALIDARG );
+    IfFalseGo( _pCorModule, E_INVALIDARG );
+
+    IfFailGo( pMetadataImport->QueryInterface( IID_IMetaDataImport,
+              (void**)&pMetadata) );
+
+    IfFailGo( _pCorModule->QueryInterface( IID_ICorDebugModule,
+                                           (void**)&pCorModule) );
+
+    ASSERT(guidModule != GUID_NULL);
+
+    fAlreadyLoaded = GetModule( idModule, &pmodule ) == S_OK;
+
+    IfNullGo( pmoduleNew = new CModule, E_OUTOFMEMORY );
+
+    //
+    // We are now allowing modules to be created that do not have SymReaders.
+    // It is likely there are a number of corner cases being ignored
+    // that will require knowledge of the hr result below.
+    //
+    dwCurrentState = m_pSymProvGroup ? m_pSymProvGroup->GetCurrentState() : 0;
+    HRESULT hrLoad = pmoduleNew->Create( idModule,
+                                         dwCurrentState,
+                                         pMetadata,
+                                         pCorModule,
+                                         bstrModule,
+                                         bstrSearchPath,
+                                         pCallback );
+
+    if (hrLoad == S_OK)
+    {
+        fSymbolsLoaded = true;
+    }
+
+    // Remove the old module
+    if (fAlreadyLoaded)
+    {
+        IfFailGo(pmoduleNew->AddEquivalentModulesFrom(pmodule));
+        RemoveModule( pmodule );
+    }
+
+    IfFailGo( AddModule( pmoduleNew ) );
+
+Error:
+
+    RELEASE (pmodule);
+    RELEASE (pmoduleNew);
+
+    if (SUCCEEDED(hr) && !fSymbolsLoaded)
+    {
+        hr = hrLoad;
+    }
+
+    METHOD_EXIT( CDebugSymbolProvider::LoadSymbol, hr );
+    EMIT_TICK_COUNT("Exit");
+    return hr;
+}
+```
+
+## See Also
+[IDebugComPlusSymbolProvider2](../../../extensibility/debugger/reference/idebugcomplussymbolprovider2.md)


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.