### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/idebugcomplussymbolprovider2-loadsymbolsfromstreamwithcormodule.md
+++ b/docs/extensibility/debugger/reference/idebugcomplussymbolprovider2-loadsymbolsfromstreamwithcormodule.md
@@ -2,137 +2,137 @@
 title: "IDebugComPlusSymbolProvider2::LoadSymbolsFromStreamWithCorModule | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "IDebugComPlusSymbolProvider2::LoadSymbolsFromStreamWithCorModule"
   - "LoadSymbolsFromStreamWithCorModule"
 ms.assetid: f79b894f-52c4-43c2-9a68-c71536451f6c
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # IDebugComPlusSymbolProvider2::LoadSymbolsFromStreamWithCorModule
-Load debug symbols from a data stream given the **ICorDebugModule** object.  
-  
-## Syntax  
-  
-```cpp  
-HRESULT LoadSymbolsFromStreamWithCorModule(  
-   ULONG32   ulAppDomainID,  
-   GUID      guidModule,  
-   ULONGLONG baseAddress,  
-   IUnknown* pUnkMetadataImport,  
-   IUnknown* pUnkCorDebugModule,  
-   IStream*  pStream  
-);  
-```  
-  
-```csharp  
-int LoadSymbolsFromStreamWithCorModule(  
-   uint    ulAppDomainID,  
-   Guid    guidModule,  
-   ulong   baseAddress,  
-   object  pUnkMetadataImport,  
-   object  pUnkCorDebugModule,  
-   IStream pStream  
-);  
-```  
-  
-#### Parameters  
- `ulAppDomainID`  
- [in] Identifier of the application domain.  
-  
- `guidModule`  
- [in] Unique identifier of the module.  
-  
- `baseAddress`  
- [in] Base memory address.  
-  
- `pUnkMetadataImport`  
- [in] Object that contains the symbol metadata.  
-  
- `pUnkCorDebugModule`  
- [in] Object that implements the [ICorDebugModule Interface](/dotnet/framework/unmanaged-api/debugging/icordebugmodule-interface).  
-  
- `pStream`  
- [in] Data stream that contains the debug symbols to load.  
-  
-## Return Value  
- If successful, returns `S_OK`; otherwise, returns an error code.  
-  
-## Example  
- The following example shows how to implement this method for a **CDebugSymbolProvider** object that exposes the [IDebugComPlusSymbolProvider2](../../../extensibility/debugger/reference/idebugcomplussymbolprovider2.md) interface.  
-  
-```cpp  
-HRESULT CDebugSymbolProvider::LoadSymbolsFromStreamWithCorModule(  
-    ULONG32 ulAppDomainID,  
-    GUID guidModule,  
-    ULONGLONG baseOffset,  
-    IUnknown* pUnkMetadataImport,  
-    IUnknown* pUnkCorDebugModule,  
-    IStream* pStream  
-)  
-{  
-    CAutoLock Lock(this);  
-  
-    HRESULT hr = S_OK;  
-    CComPtr<IMetaDataImport> pMetadata;  
-    CComPtr<ICorDebugModule> pCorModule;  
-  
-    CModule* pmodule = NULL;  
-    CModule* pmoduleNew = NULL;  
-    bool fAlreadyLoaded = false;  
-    Module_ID idModule(ulAppDomainID, guidModule);  
-    DWORD dwCurrentState = 0;  
-  
-    ASSERT(IsValidObjectPtr(this, CDebugSymbolProvider));  
-    ASSERT(IsValidInterfacePtr(pUnkMetadataImport, IUnknown));  
-  
-    METHOD_ENTRY( CDebugSymbolProvider::LoadSymbolsFromStream );  
-  
-    IfFalseGo( pUnkMetadataImport, E_INVALIDARG );  
-    IfFalseGo( pUnkCorDebugModule, E_INVALIDARG );  
-  
-    IfFailGo( pUnkMetadataImport->QueryInterface( IID_IMetaDataImport,  
-              (void**)&pMetadata) );  
-  
-    IfFailGo( pUnkCorDebugModule->QueryInterface( IID_ICorDebugModule,  
-              (void**)&pCorModule) );  
-  
-    ASSERT(guidModule != GUID_NULL);  
-  
-    fAlreadyLoaded = GetModule( idModule, &pmodule ) == S_OK;  
-  
-    IfNullGo( pmoduleNew = new CModule, E_OUTOFMEMORY );  
-  
-    dwCurrentState = m_pSymProvGroup ? m_pSymProvGroup->GetCurrentState() : 0;  
-  
-    IfFailGo( pmoduleNew->Create( idModule,  
-                                  dwCurrentState,  
-                                  pMetadata,  
-                                  pCorModule,  
-                                  pStream,  
-                                  baseOffset ) );  
-  
-    if (fAlreadyLoaded)  
-    {  
-        IfFailGo(pmoduleNew->AddEquivalentModulesFrom(pmodule));  
-        RemoveModule(pmodule);  
-    }  
-  
-    IfFailGo( AddModule( pmoduleNew ) );  
-  
-Error:  
-  
-    RELEASE (pmodule);  
-    RELEASE (pmoduleNew);  
-  
-    METHOD_EXIT( CDebugSymbolProvider::LoadSymbolsFromStream, hr );  
-  
-    return hr;  
-}  
-```  
-  
-## See Also  
- [IDebugComPlusSymbolProvider2](../../../extensibility/debugger/reference/idebugcomplussymbolprovider2.md)
+Load debug symbols from a data stream given the **ICorDebugModule** object.
+
+## Syntax
+
+```cpp
+HRESULT LoadSymbolsFromStreamWithCorModule(
+   ULONG32   ulAppDomainID,
+   GUID      guidModule,
+   ULONGLONG baseAddress,
+   IUnknown* pUnkMetadataImport,
+   IUnknown* pUnkCorDebugModule,
+   IStream*  pStream
+);
+```
+
+```csharp
+int LoadSymbolsFromStreamWithCorModule(
+   uint    ulAppDomainID,
+   Guid    guidModule,
+   ulong   baseAddress,
+   object  pUnkMetadataImport,
+   object  pUnkCorDebugModule,
+   IStream pStream
+);
+```
+
+#### Parameters
+`ulAppDomainID`  
+[in] Identifier of the application domain.
+
+`guidModule`  
+[in] Unique identifier of the module.
+
+`baseAddress`  
+[in] Base memory address.
+
+`pUnkMetadataImport`  
+[in] Object that contains the symbol metadata.
+
+`pUnkCorDebugModule`  
+[in] Object that implements the [ICorDebugModule Interface](/dotnet/framework/unmanaged-api/debugging/icordebugmodule-interface).
+
+`pStream`  
+[in] Data stream that contains the debug symbols to load.
+
+## Return Value
+If successful, returns `S_OK`; otherwise, returns an error code.
+
+## Example
+The following example shows how to implement this method for a **CDebugSymbolProvider** object that exposes the [IDebugComPlusSymbolProvider2](../../../extensibility/debugger/reference/idebugcomplussymbolprovider2.md) interface.
+
+```cpp
+HRESULT CDebugSymbolProvider::LoadSymbolsFromStreamWithCorModule(
+    ULONG32 ulAppDomainID,
+    GUID guidModule,
+    ULONGLONG baseOffset,
+    IUnknown* pUnkMetadataImport,
+    IUnknown* pUnkCorDebugModule,
+    IStream* pStream
+)
+{
+    CAutoLock Lock(this);
+
+    HRESULT hr = S_OK;
+    CComPtr<IMetaDataImport> pMetadata;
+    CComPtr<ICorDebugModule> pCorModule;
+
+    CModule* pmodule = NULL;
+    CModule* pmoduleNew = NULL;
+    bool fAlreadyLoaded = false;
+    Module_ID idModule(ulAppDomainID, guidModule);
+    DWORD dwCurrentState = 0;
+
+    ASSERT(IsValidObjectPtr(this, CDebugSymbolProvider));
+    ASSERT(IsValidInterfacePtr(pUnkMetadataImport, IUnknown));
+
+    METHOD_ENTRY( CDebugSymbolProvider::LoadSymbolsFromStream );
+
+    IfFalseGo( pUnkMetadataImport, E_INVALIDARG );
+    IfFalseGo( pUnkCorDebugModule, E_INVALIDARG );
+
+    IfFailGo( pUnkMetadataImport->QueryInterface( IID_IMetaDataImport,
+              (void**)&pMetadata) );
+
+    IfFailGo( pUnkCorDebugModule->QueryInterface( IID_ICorDebugModule,
+              (void**)&pCorModule) );
+
+    ASSERT(guidModule != GUID_NULL);
+
+    fAlreadyLoaded = GetModule( idModule, &pmodule ) == S_OK;
+
+    IfNullGo( pmoduleNew = new CModule, E_OUTOFMEMORY );
+
+    dwCurrentState = m_pSymProvGroup ? m_pSymProvGroup->GetCurrentState() : 0;
+
+    IfFailGo( pmoduleNew->Create( idModule,
+                                  dwCurrentState,
+                                  pMetadata,
+                                  pCorModule,
+                                  pStream,
+                                  baseOffset ) );
+
+    if (fAlreadyLoaded)
+    {
+        IfFailGo(pmoduleNew->AddEquivalentModulesFrom(pmodule));
+        RemoveModule(pmodule);
+    }
+
+    IfFailGo( AddModule( pmoduleNew ) );
+
+Error:
+
+    RELEASE (pmodule);
+    RELEASE (pmoduleNew);
+
+    METHOD_EXIT( CDebugSymbolProvider::LoadSymbolsFromStream, hr );
+
+    return hr;
+}
+```
+
+## See Also
+[IDebugComPlusSymbolProvider2](../../../extensibility/debugger/reference/idebugcomplussymbolprovider2.md)

--- a/docs/extensibility/debugger/reference/idebugcomplussymbolprovider2-loadsymbolsfromstreamwithcormodule.md
+++ b/docs/extensibility/debugger/reference/idebugcomplussymbolprovider2-loadsymbolsfromstreamwithcormodule.md
@@ -19,23 +19,23 @@ Load debug symbols from a data stream given the **ICorDebugModule** object.
 
 ```cpp
 HRESULT LoadSymbolsFromStreamWithCorModule(
-   ULONG32   ulAppDomainID,
-   GUID      guidModule,
-   ULONGLONG baseAddress,
-   IUnknown* pUnkMetadataImport,
-   IUnknown* pUnkCorDebugModule,
-   IStream*  pStream
+    ULONG32   ulAppDomainID,
+    GUID      guidModule,
+    ULONGLONG baseAddress,
+    IUnknown* pUnkMetadataImport,
+    IUnknown* pUnkCorDebugModule,
+    IStream*  pStream
 );
 ```
 
 ```csharp
 int LoadSymbolsFromStreamWithCorModule(
-   uint    ulAppDomainID,
-   Guid    guidModule,
-   ulong   baseAddress,
-   object  pUnkMetadataImport,
-   object  pUnkCorDebugModule,
-   IStream pStream
+    uint    ulAppDomainID,
+    Guid    guidModule,
+    ulong   baseAddress,
+    object  pUnkMetadataImport,
+    object  pUnkCorDebugModule,
+    IStream pStream
 );
 ```
 


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.