### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/idebugcustomattributequery-getcustomattributebyname.md
+++ b/docs/extensibility/debugger/reference/idebugcustomattributequery-getcustomattributebyname.md
@@ -2,87 +2,87 @@
 title: "IDebugCustomAttributeQuery::GetCustomAttributeByName | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "IDebugCustomAttributeQuery::GetCustomAttributeByName"
   - "GetCustomAttributeByName"
 ms.assetid: 6779727c-d10a-4abe-9acd-d0a1eb0737e7
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # IDebugCustomAttributeQuery::GetCustomAttributeByName
-Retrieves a custom attribute given its name.  
-  
-## Syntax  
-  
-```cpp  
-HRESULT GetCustomAttributeByName(  
-   LPCOLESTR pszCustomAttributeName,  
-   BYTE*     ppBlob,  
-   DWORD*    pdwLen  
-);  
-```  
-  
-```csharp  
-int GetCustomAttributeByName(  
-   string    pszCustomAttributeName,  
-   ref int[] ppBlob,  
-   out uint  pdwLen  
-);  
-```  
-  
-#### Parameters  
- `pszCustomAttributeName`  
- [in] Name of the custom attribute.  
-  
- `ppBlob`  
- [in,out] Array of bytes that contain the custom attribute data.  
-  
- `pdwLen`  
- [out] Length in bytes of the `ppBlob` parameter.  
-  
-## Return Value  
- If successful, returns `S_OK`. If custom attribute does not exist, returns `S_FALSE`. Otherwise, returns an error code.  
-  
-## Example  
- The following example shows how to implement this method for a **CDebugClassFieldSymbol** object that exposes the [IDebugCustomAttributeQuery](../../../extensibility/debugger/reference/idebugcustomattributequery.md) interface.  
-  
-```cpp  
-HRESULT CDebugClassFieldSymbol::GetCustomAttributeByName(  
-    LPCOLESTR pszCustomAttributeName,  
-    BYTE *pBlob,  
-    DWORD *pdwLen  
-)  
-{  
-    HRESULT hr = S_FALSE;  
-    CComPtr<IMetaDataImport> pMetadata;  
-    mdToken token = mdTokenNil;  
-    CComPtr<IDebugField> pField;  
-    CComPtr<IDebugCustomAttributeQuery> pCA;  
-  
-    ASSERT(IsValidWideStringPtr(pszCustomAttributeName));  
-    ASSERT(IsValidWritePtr(pdwLen, ULONG*));  
-  
-    METHOD_ENTRY( CDebugClassFieldSymbol::GetCustomAttributeByName );  
-  
-    IfFalseGo( pszCustomAttributeName && pdwLen, E_INVALIDARG );  
-  
-    IfFailGo( m_spSH->GetMetadata( m_spAddress->GetModule(), &pMetadata ) );  
-  
-    IfFailGo( CDebugCustomAttribute::GetTokenFromAddress( m_spAddress, &token) );  
-    IfFailGo( CDebugCustomAttribute::GetCustomAttributeByName( pMetadata,  
-              token,  
-              pszCustomAttributeName,  
-              pBlob,  
-              pdwLen ) );  
-Error:  
-  
-    METHOD_EXIT( CDebugClassFieldSymbol::GetCustomAttributeByName, hr );  
-    return hr;  
-}  
-```  
-  
-## See Also  
- [IDebugCustomAttributeQuery](../../../extensibility/debugger/reference/idebugcustomattributequery.md)
+Retrieves a custom attribute given its name.
+
+## Syntax
+
+```cpp
+HRESULT GetCustomAttributeByName(
+   LPCOLESTR pszCustomAttributeName,
+   BYTE*     ppBlob,
+   DWORD*    pdwLen
+);
+```
+
+```csharp
+int GetCustomAttributeByName(
+   string    pszCustomAttributeName,
+   ref int[] ppBlob,
+   out uint  pdwLen
+);
+```
+
+#### Parameters
+`pszCustomAttributeName`  
+[in] Name of the custom attribute.
+
+`ppBlob`  
+[in,out] Array of bytes that contain the custom attribute data.
+
+`pdwLen`  
+[out] Length in bytes of the `ppBlob` parameter.
+
+## Return Value
+If successful, returns `S_OK`. If custom attribute does not exist, returns `S_FALSE`. Otherwise, returns an error code.
+
+## Example
+The following example shows how to implement this method for a **CDebugClassFieldSymbol** object that exposes the [IDebugCustomAttributeQuery](../../../extensibility/debugger/reference/idebugcustomattributequery.md) interface.
+
+```cpp
+HRESULT CDebugClassFieldSymbol::GetCustomAttributeByName(
+    LPCOLESTR pszCustomAttributeName,
+    BYTE *pBlob,
+    DWORD *pdwLen
+)
+{
+    HRESULT hr = S_FALSE;
+    CComPtr<IMetaDataImport> pMetadata;
+    mdToken token = mdTokenNil;
+    CComPtr<IDebugField> pField;
+    CComPtr<IDebugCustomAttributeQuery> pCA;
+
+    ASSERT(IsValidWideStringPtr(pszCustomAttributeName));
+    ASSERT(IsValidWritePtr(pdwLen, ULONG*));
+
+    METHOD_ENTRY( CDebugClassFieldSymbol::GetCustomAttributeByName );
+
+    IfFalseGo( pszCustomAttributeName && pdwLen, E_INVALIDARG );
+
+    IfFailGo( m_spSH->GetMetadata( m_spAddress->GetModule(), &pMetadata ) );
+
+    IfFailGo( CDebugCustomAttribute::GetTokenFromAddress( m_spAddress, &token) );
+    IfFailGo( CDebugCustomAttribute::GetCustomAttributeByName( pMetadata,
+              token,
+              pszCustomAttributeName,
+              pBlob,
+              pdwLen ) );
+Error:
+
+    METHOD_EXIT( CDebugClassFieldSymbol::GetCustomAttributeByName, hr );
+    return hr;
+}
+```
+
+## See Also
+[IDebugCustomAttributeQuery](../../../extensibility/debugger/reference/idebugcustomattributequery.md)

--- a/docs/extensibility/debugger/reference/idebugcustomattributequery-getcustomattributebyname.md
+++ b/docs/extensibility/debugger/reference/idebugcustomattributequery-getcustomattributebyname.md
@@ -19,17 +19,17 @@ Retrieves a custom attribute given its name.
 
 ```cpp
 HRESULT GetCustomAttributeByName(
-   LPCOLESTR pszCustomAttributeName,
-   BYTE*     ppBlob,
-   DWORD*    pdwLen
+    LPCOLESTR pszCustomAttributeName,
+    BYTE*     ppBlob,
+    DWORD*    pdwLen
 );
 ```
 
 ```csharp
 int GetCustomAttributeByName(
-   string    pszCustomAttributeName,
-   ref int[] ppBlob,
-   out uint  pdwLen
+    string    pszCustomAttributeName,
+    ref int[] ppBlob,
+    out uint  pdwLen
 );
 ```
 


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.