### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/idebugcustomattributequery-iscustomattributedefined.md
+++ b/docs/extensibility/debugger/reference/idebugcustomattributequery-iscustomattributedefined.md
@@ -2,79 +2,79 @@
 title: "IDebugCustomAttributeQuery::IsCustomAttributeDefined | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "IDebugCustomAttributeQuery::IsCustomAttributeDefined"
   - "IsCustomAttributeDefined"
 ms.assetid: c7425db6-4347-4f69-8f88-337ddaa34fa6
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # IDebugCustomAttributeQuery::IsCustomAttributeDefined
-Determines if the specified custom attribute is defined.  
-  
-## Syntax  
-  
-```cpp  
-HRESULT IsCustomAttributeDefined(  
-   LPCOLESTR pszCustomAttributeName  
-);  
-```  
-  
-```csharp  
-int IsCustomAttributeDefined(  
-   string pszCustomAttributeName  
-);  
-```  
-  
-#### Parameters  
- `pszCustomAttributeName`  
- [in] Name of the custom attribute.  
-  
-## Return Value  
- If the custom attribute is defined, returns `S_OK`; otherwise, returns `S_FALSE`.  
-  
-## Example  
- The following example shows how to implement this method for a **CDebugClassFieldSymbol** object that exposes the [IDebugCustomAttributeQuery](../../../extensibility/debugger/reference/idebugcustomattributequery.md) interface.  
-  
-```cpp  
-HRESULT CDebugClassFieldSymbol::IsCustomAttributeDefined(  
-    LPCOLESTR pszCustomAttribute  
-)  
-{  
-    HRESULT hr = S_FALSE;  
-    CComPtr<IMetaDataImport> pMetadata;  
-    mdToken token = mdTokenNil;  
-    CComPtr<IDebugField> pField;  
-    CComPtr<IDebugCustomAttributeQuery> pCA;  
-  
-    ASSERT(IsValidWideStringPtr(pszCustomAttribute));  
-  
-    METHOD_ENTRY( CDebugClassFieldSymbol::IsCustomAttributeDefined );  
-  
-    IfFalseGo( pszCustomAttribute, E_INVALIDARG );  
-  
-    IfFailGo( m_spSH->GetMetadata( m_spAddress->GetModule(), &pMetadata ) );  
-  
-    IfFailGo( CDebugCustomAttribute::GetTokenFromAddress( m_spAddress, &token) );  
-    IfFailGo( pMetadata->GetCustomAttributeByName( token,  
-              pszCustomAttribute,  
-              NULL,  
-              NULL ) );  
-Error:  
-  
-    METHOD_EXIT( CDebugClassFieldSymbol::IsCustomAttributeDefined, hr );  
-  
-    if (hr != S_OK)  
-    {  
-        hr = S_FALSE;  
-    }  
-  
-    return hr;  
-}  
-```  
-  
-## See Also  
- [IDebugCustomAttributeQuery](../../../extensibility/debugger/reference/idebugcustomattributequery.md)
+Determines if the specified custom attribute is defined.
+
+## Syntax
+
+```cpp
+HRESULT IsCustomAttributeDefined(
+   LPCOLESTR pszCustomAttributeName
+);
+```
+
+```csharp
+int IsCustomAttributeDefined(
+   string pszCustomAttributeName
+);
+```
+
+#### Parameters
+`pszCustomAttributeName`  
+[in] Name of the custom attribute.
+
+## Return Value
+If the custom attribute is defined, returns `S_OK`; otherwise, returns `S_FALSE`.
+
+## Example
+The following example shows how to implement this method for a **CDebugClassFieldSymbol** object that exposes the [IDebugCustomAttributeQuery](../../../extensibility/debugger/reference/idebugcustomattributequery.md) interface.
+
+```cpp
+HRESULT CDebugClassFieldSymbol::IsCustomAttributeDefined(
+    LPCOLESTR pszCustomAttribute
+)
+{
+    HRESULT hr = S_FALSE;
+    CComPtr<IMetaDataImport> pMetadata;
+    mdToken token = mdTokenNil;
+    CComPtr<IDebugField> pField;
+    CComPtr<IDebugCustomAttributeQuery> pCA;
+
+    ASSERT(IsValidWideStringPtr(pszCustomAttribute));
+
+    METHOD_ENTRY( CDebugClassFieldSymbol::IsCustomAttributeDefined );
+
+    IfFalseGo( pszCustomAttribute, E_INVALIDARG );
+
+    IfFailGo( m_spSH->GetMetadata( m_spAddress->GetModule(), &pMetadata ) );
+
+    IfFailGo( CDebugCustomAttribute::GetTokenFromAddress( m_spAddress, &token) );
+    IfFailGo( pMetadata->GetCustomAttributeByName( token,
+              pszCustomAttribute,
+              NULL,
+              NULL ) );
+Error:
+
+    METHOD_EXIT( CDebugClassFieldSymbol::IsCustomAttributeDefined, hr );
+
+    if (hr != S_OK)
+    {
+        hr = S_FALSE;
+    }
+
+    return hr;
+}
+```
+
+## See Also
+[IDebugCustomAttributeQuery](../../../extensibility/debugger/reference/idebugcustomattributequery.md)

--- a/docs/extensibility/debugger/reference/idebugcustomattributequery-iscustomattributedefined.md
+++ b/docs/extensibility/debugger/reference/idebugcustomattributequery-iscustomattributedefined.md
@@ -19,13 +19,13 @@ Determines if the specified custom attribute is defined.
 
 ```cpp
 HRESULT IsCustomAttributeDefined(
-   LPCOLESTR pszCustomAttributeName
+    LPCOLESTR pszCustomAttributeName
 );
 ```
 
 ```csharp
 int IsCustomAttributeDefined(
-   string pszCustomAttributeName
+    string pszCustomAttributeName
 );
 ```
 


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.