### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/idebugdocumentcontext2-enumcodecontexts.md
+++ b/docs/extensibility/debugger/reference/idebugdocumentcontext2-enumcodecontexts.md
@@ -2,103 +2,103 @@
 title: "IDebugDocumentContext2::EnumCodeContexts | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-f1_keywords: 
+f1_keywords:
   - "IDebugDocumentContext2::EnumCodeContexts"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "IDebugDocumentContext2::EnumCodeContexts"
 ms.assetid: 627af69c-5cce-4e1d-8233-5f4d8dbc62e5
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # IDebugDocumentContext2::EnumCodeContexts
-Retrieves a list of all code contexts associated with this document context.  
-  
-## Syntax  
-  
-```cpp  
-HRESULT EnumCodeContexts(   
-   IEnumDebugCodeContexts2** ppEnumCodeCxts  
-);  
-```  
-  
-```csharp  
-int EnumCodeContexts(   
-   out IEnumDebugCodeContexts2 ppEnumCodeCxts  
-);  
-```  
-  
-#### Parameters  
- `ppEnumCodeCxts`  
- [out] Returns an [IEnumDebugCodeContexts2](../../../extensibility/debugger/reference/ienumdebugcodecontexts2.md) object that contains a list of code contexts.  
-  
-## Return Value  
- If successful, returns `S_OK`; otherwise, returns an error code.  
-  
-## Remarks  
- A single document context can generate multiple code contexts when the document is using templates or include files.  
-  
-## Example  
- The following example shows how to implement this method for a simple `CDebugContext` object that exposes the [IDebugDocumentContext2](../../../extensibility/debugger/reference/idebugdocumentcontext2.md) interface.  
-  
-```cpp  
-HRESULT CDebugContext::EnumCodeContexts(IEnumDebugCodeContexts2 **ppEnumCodeCxts)    
-{    
-   HRESULT hr;    
-  
-   // Check for a valid IEnumDebugCodeContexts2 interface pointer.    
-   if (ppEnumCodeCxts)    
-   {    
-      *ppEnumCodeCxts = NULL;    
-  
-      // Create a CEnumDebugCodeContexts object.    
-      CComObject<CEnumDebugCodeContexts>* pEnum;    
-      hr = CComObject<CEnumDebugCodeContexts>::CreateInstance(&pEnum);    
-      assert(hr == S_OK);    
-      if (hr == S_OK)    
-      {    
-         // Get an IID_IDebugCodeContext2 interface.    
-         CComPtr<IDebugCodeContext2> spCodeCxt;    
-         hr = QueryInterface(IID_IDebugCodeContext2,  
-                             (void**)&spCodeCxt);  
-         assert(hr == S_OK);    
-         if (hr == S_OK)    
-         {    
-            // Initialize the code context enumerator with the    
-            // IDebugCodeContext2 information.  
-            IDebugCodeContext2* rgpCodeContext[] = { spCodeCxt.p };    
-            hr = pEnum->Init(rgpCodeContext,  
-                             &(rgpCodeContext[1]),  
-                             NULL,  
-                             AtlFlagCopy);  
-            assert(hr == S_OK);    
-            if (hr == S_OK)    
-            {    
-               // Set the passed IEnumDebugCodeContexts2 pointer equal to the pointer  
-               // value of the created CEnumDebugCodeContexts object.  
-               hr = pEnum->QueryInterface(ppEnumCodeCxts);    
-               assert(hr == S_OK);    
-            }    
-         }    
-  
-         // Otherwise, delete the CEnumDebugCodeContexts object.    
-         if (FAILED(hr))    
-         {    
-            delete pEnum;    
-         }    
-      }    
-   }    
-   else    
-   {    
-      hr = E_INVALIDARG;    
-   }    
-  
-   return hr;    
-}    
-```  
-  
-## See Also  
- [IDebugDocumentContext2](../../../extensibility/debugger/reference/idebugdocumentcontext2.md)   
- [IEnumDebugCodeContexts2](../../../extensibility/debugger/reference/ienumdebugcodecontexts2.md)
+Retrieves a list of all code contexts associated with this document context.
+
+## Syntax
+
+```cpp
+HRESULT EnumCodeContexts(
+   IEnumDebugCodeContexts2** ppEnumCodeCxts
+);
+```
+
+```csharp
+int EnumCodeContexts(
+   out IEnumDebugCodeContexts2 ppEnumCodeCxts
+);
+```
+
+#### Parameters
+`ppEnumCodeCxts`  
+[out] Returns an [IEnumDebugCodeContexts2](../../../extensibility/debugger/reference/ienumdebugcodecontexts2.md) object that contains a list of code contexts.
+
+## Return Value
+If successful, returns `S_OK`; otherwise, returns an error code.
+
+## Remarks
+A single document context can generate multiple code contexts when the document is using templates or include files.
+
+## Example
+The following example shows how to implement this method for a simple `CDebugContext` object that exposes the [IDebugDocumentContext2](../../../extensibility/debugger/reference/idebugdocumentcontext2.md) interface.
+
+```cpp
+HRESULT CDebugContext::EnumCodeContexts(IEnumDebugCodeContexts2 **ppEnumCodeCxts)
+{
+   HRESULT hr;
+
+   // Check for a valid IEnumDebugCodeContexts2 interface pointer.
+   if (ppEnumCodeCxts)
+   {
+      *ppEnumCodeCxts = NULL;
+
+      // Create a CEnumDebugCodeContexts object.
+      CComObject<CEnumDebugCodeContexts>* pEnum;
+      hr = CComObject<CEnumDebugCodeContexts>::CreateInstance(&pEnum);
+      assert(hr == S_OK);
+      if (hr == S_OK)
+      {
+         // Get an IID_IDebugCodeContext2 interface.
+         CComPtr<IDebugCodeContext2> spCodeCxt;
+         hr = QueryInterface(IID_IDebugCodeContext2,
+                             (void**)&spCodeCxt);
+         assert(hr == S_OK);
+         if (hr == S_OK)
+         {
+            // Initialize the code context enumerator with the
+            // IDebugCodeContext2 information.
+            IDebugCodeContext2* rgpCodeContext[] = { spCodeCxt.p };
+            hr = pEnum->Init(rgpCodeContext,
+                             &(rgpCodeContext[1]),
+                             NULL,
+                             AtlFlagCopy);
+            assert(hr == S_OK);
+            if (hr == S_OK)
+            {
+               // Set the passed IEnumDebugCodeContexts2 pointer equal to the pointer
+               // value of the created CEnumDebugCodeContexts object.
+               hr = pEnum->QueryInterface(ppEnumCodeCxts);
+               assert(hr == S_OK);
+            }
+         }
+
+         // Otherwise, delete the CEnumDebugCodeContexts object.
+         if (FAILED(hr))
+         {
+            delete pEnum;
+         }
+      }
+   }
+   else
+   {
+      hr = E_INVALIDARG;
+   }
+
+   return hr;
+}
+```
+
+## See Also
+[IDebugDocumentContext2](../../../extensibility/debugger/reference/idebugdocumentcontext2.md)  
+[IEnumDebugCodeContexts2](../../../extensibility/debugger/reference/ienumdebugcodecontexts2.md)

--- a/docs/extensibility/debugger/reference/idebugdocumentcontext2-enumcodecontexts.md
+++ b/docs/extensibility/debugger/reference/idebugdocumentcontext2-enumcodecontexts.md
@@ -20,13 +20,13 @@ Retrieves a list of all code contexts associated with this document context.
 
 ```cpp
 HRESULT EnumCodeContexts(
-   IEnumDebugCodeContexts2** ppEnumCodeCxts
+    IEnumDebugCodeContexts2** ppEnumCodeCxts
 );
 ```
 
 ```csharp
 int EnumCodeContexts(
-   out IEnumDebugCodeContexts2 ppEnumCodeCxts
+    out IEnumDebugCodeContexts2 ppEnumCodeCxts
 );
 ```
 
@@ -46,56 +46,56 @@ The following example shows how to implement this method for a simple `CDebugCon
 ```cpp
 HRESULT CDebugContext::EnumCodeContexts(IEnumDebugCodeContexts2 **ppEnumCodeCxts)
 {
-   HRESULT hr;
+    HRESULT hr;
 
-   // Check for a valid IEnumDebugCodeContexts2 interface pointer.
-   if (ppEnumCodeCxts)
-   {
-      *ppEnumCodeCxts = NULL;
+    // Check for a valid IEnumDebugCodeContexts2 interface pointer.
+    if (ppEnumCodeCxts)
+    {
+        *ppEnumCodeCxts = NULL;
 
-      // Create a CEnumDebugCodeContexts object.
-      CComObject<CEnumDebugCodeContexts>* pEnum;
-      hr = CComObject<CEnumDebugCodeContexts>::CreateInstance(&pEnum);
-      assert(hr == S_OK);
-      if (hr == S_OK)
-      {
-         // Get an IID_IDebugCodeContext2 interface.
-         CComPtr<IDebugCodeContext2> spCodeCxt;
-         hr = QueryInterface(IID_IDebugCodeContext2,
-                             (void**)&spCodeCxt);
-         assert(hr == S_OK);
-         if (hr == S_OK)
-         {
-            // Initialize the code context enumerator with the
-            // IDebugCodeContext2 information.
-            IDebugCodeContext2* rgpCodeContext[] = { spCodeCxt.p };
-            hr = pEnum->Init(rgpCodeContext,
-                             &(rgpCodeContext[1]),
-                             NULL,
-                             AtlFlagCopy);
+        // Create a CEnumDebugCodeContexts object.
+        CComObject<CEnumDebugCodeContexts>* pEnum;
+        hr = CComObject<CEnumDebugCodeContexts>::CreateInstance(&pEnum);
+        assert(hr == S_OK);
+        if (hr == S_OK)
+        {
+            // Get an IID_IDebugCodeContext2 interface.
+            CComPtr<IDebugCodeContext2> spCodeCxt;
+            hr = QueryInterface(IID_IDebugCodeContext2,
+                                (void**)&spCodeCxt);
             assert(hr == S_OK);
             if (hr == S_OK)
             {
-               // Set the passed IEnumDebugCodeContexts2 pointer equal to the pointer
-               // value of the created CEnumDebugCodeContexts object.
-               hr = pEnum->QueryInterface(ppEnumCodeCxts);
-               assert(hr == S_OK);
+                // Initialize the code context enumerator with the
+                // IDebugCodeContext2 information.
+                IDebugCodeContext2* rgpCodeContext[] = { spCodeCxt.p };
+                hr = pEnum->Init(rgpCodeContext,
+                                 &(rgpCodeContext[1]),
+                                 NULL,
+                                 AtlFlagCopy);
+                assert(hr == S_OK);
+                if (hr == S_OK)
+                {
+                // Set the passed IEnumDebugCodeContexts2 pointer equal to the pointer
+                // value of the created CEnumDebugCodeContexts object.
+                hr = pEnum->QueryInterface(ppEnumCodeCxts);
+                assert(hr == S_OK);
+                }
             }
-         }
 
-         // Otherwise, delete the CEnumDebugCodeContexts object.
-         if (FAILED(hr))
-         {
-            delete pEnum;
-         }
-      }
-   }
-   else
-   {
-      hr = E_INVALIDARG;
-   }
+            // Otherwise, delete the CEnumDebugCodeContexts object.
+            if (FAILED(hr))
+            {
+                delete pEnum;
+            }
+        }
+    }
+    else
+    {
+        hr = E_INVALIDARG;
+    }
 
-   return hr;
+    return hr;
 }
 ```
 


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.