### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/idebugdocumentcontext2-getname.md
+++ b/docs/extensibility/debugger/reference/idebugdocumentcontext2-getname.md
@@ -2,89 +2,89 @@
 title: "IDebugDocumentContext2::GetName | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-f1_keywords: 
+f1_keywords:
   - "IDebugDocumentContext2::GetName"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "IDebugDocumentContext2::GetName"
 ms.assetid: 546c5b2e-f166-4edb-9e61-57d797ca98a1
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # IDebugDocumentContext2::GetName
-Gets the displayable name of the document that contains this document context.  
-  
-## Syntax  
-  
-```cpp  
-HRESULT GetName(   
-   GETNAME_TYPE gnType,  
-   BSTR*        pbstrFileName  
-);  
-```  
-  
-```csharp  
-int GetName(   
-   enum_GETNAME_TYPE  gnType,  
-   out string         pbstrFileName  
-);  
-```  
-  
-#### Parameters  
- `gnType`  
- [in] A value from the [GETNAME_TYPE](../../../extensibility/debugger/reference/getname-type.md) enumeration that specifies the type of name to return.  
-  
- `pbstrFileName`  
- [out] Returns the name of the file.  
-  
-## Return Value  
- If successful, returns `S_OK`; otherwise, returns an error code.  
-  
-## Remarks  
- This method typically forwards the call to the [GetName](../../../extensibility/debugger/reference/idebugdocument2-getname.md) method, unless the document context is written to store the document name itself (as the Example show).  
-  
-## Example  
- The following example shows how to implement this method for a simple `CDebugContext` object that exposes the [IDebugDocumentContext2](../../../extensibility/debugger/reference/idebugdocumentcontext2.md) interface.  
-  
-```cpp  
-HRESULT CDebugContext::GetName(GETNAME_TYPE gnType, BSTR* pbstrFileName)    
-{    
-   HRESULT hr;    
-  
-   // Check for a valid file name argument.    
-   if (pbstrFileName)    
-   {    
-      *pbstrFileName = NULL;    
-  
-      switch (gnType)    
-      {    
-         case GN_NAME:    
-         case GN_FILENAME:    
-         {    
-            // Copy the member file name into the local file name.    
-            *pbstrFileName = SysAllocString(m_sbstrFileName);    
-            // Check for successful copy.    
-            hr = (*pbstrFileName) ? S_OK : E_OUTOFMEMORY;    
-            break;    
-         }    
-         default:    
-         {    
-            hr = E_FAIL;    
-            break;    
-         }    
-      }    
-   }    
-   else    
-   {    
-      hr = E_INVALIDARG;    
-   }    
-  
-   return hr;    
-}    
-```  
-  
-## See Also  
- [IDebugDocumentContext2](../../../extensibility/debugger/reference/idebugdocumentcontext2.md)   
- [GETNAME_TYPE](../../../extensibility/debugger/reference/getname-type.md)
+Gets the displayable name of the document that contains this document context.
+
+## Syntax
+
+```cpp
+HRESULT GetName(
+   GETNAME_TYPE gnType,
+   BSTR*        pbstrFileName
+);
+```
+
+```csharp
+int GetName(
+   enum_GETNAME_TYPE  gnType,
+   out string         pbstrFileName
+);
+```
+
+#### Parameters
+`gnType`  
+[in] A value from the [GETNAME_TYPE](../../../extensibility/debugger/reference/getname-type.md) enumeration that specifies the type of name to return.
+
+`pbstrFileName`  
+[out] Returns the name of the file.
+
+## Return Value
+If successful, returns `S_OK`; otherwise, returns an error code.
+
+## Remarks
+This method typically forwards the call to the [GetName](../../../extensibility/debugger/reference/idebugdocument2-getname.md) method, unless the document context is written to store the document name itself (as the Example show).
+
+## Example
+The following example shows how to implement this method for a simple `CDebugContext` object that exposes the [IDebugDocumentContext2](../../../extensibility/debugger/reference/idebugdocumentcontext2.md) interface.
+
+```cpp
+HRESULT CDebugContext::GetName(GETNAME_TYPE gnType, BSTR* pbstrFileName)
+{
+   HRESULT hr;
+
+   // Check for a valid file name argument.
+   if (pbstrFileName)
+   {
+      *pbstrFileName = NULL;
+
+      switch (gnType)
+      {
+         case GN_NAME:
+         case GN_FILENAME:
+         {
+            // Copy the member file name into the local file name.
+            *pbstrFileName = SysAllocString(m_sbstrFileName);
+            // Check for successful copy.
+            hr = (*pbstrFileName) ? S_OK : E_OUTOFMEMORY;
+            break;
+         }
+         default:
+         {
+            hr = E_FAIL;
+            break;
+         }
+      }
+   }
+   else
+   {
+      hr = E_INVALIDARG;
+   }
+
+   return hr;
+}
+```
+
+## See Also
+[IDebugDocumentContext2](../../../extensibility/debugger/reference/idebugdocumentcontext2.md)  
+[GETNAME_TYPE](../../../extensibility/debugger/reference/getname-type.md)

--- a/docs/extensibility/debugger/reference/idebugdocumentcontext2-getname.md
+++ b/docs/extensibility/debugger/reference/idebugdocumentcontext2-getname.md
@@ -20,15 +20,15 @@ Gets the displayable name of the document that contains this document context.
 
 ```cpp
 HRESULT GetName(
-   GETNAME_TYPE gnType,
-   BSTR*        pbstrFileName
+    GETNAME_TYPE gnType,
+    BSTR*        pbstrFileName
 );
 ```
 
 ```csharp
 int GetName(
-   enum_GETNAME_TYPE  gnType,
-   out string         pbstrFileName
+    enum_GETNAME_TYPE  gnType,
+    out string         pbstrFileName
 );
 ```
 
@@ -51,37 +51,37 @@ The following example shows how to implement this method for a simple `CDebugCon
 ```cpp
 HRESULT CDebugContext::GetName(GETNAME_TYPE gnType, BSTR* pbstrFileName)
 {
-   HRESULT hr;
+    HRESULT hr;
 
-   // Check for a valid file name argument.
-   if (pbstrFileName)
-   {
-      *pbstrFileName = NULL;
+    // Check for a valid file name argument.
+    if (pbstrFileName)
+    {
+        *pbstrFileName = NULL;
 
-      switch (gnType)
-      {
-         case GN_NAME:
-         case GN_FILENAME:
-         {
-            // Copy the member file name into the local file name.
-            *pbstrFileName = SysAllocString(m_sbstrFileName);
-            // Check for successful copy.
-            hr = (*pbstrFileName) ? S_OK : E_OUTOFMEMORY;
-            break;
-         }
-         default:
-         {
-            hr = E_FAIL;
-            break;
-         }
-      }
-   }
-   else
-   {
-      hr = E_INVALIDARG;
-   }
+        switch (gnType)
+        {
+            case GN_NAME:
+            case GN_FILENAME:
+            {
+                // Copy the member file name into the local file name.
+                *pbstrFileName = SysAllocString(m_sbstrFileName);
+                // Check for successful copy.
+                hr = (*pbstrFileName) ? S_OK : E_OUTOFMEMORY;
+                break;
+            }
+            default:
+            {
+                hr = E_FAIL;
+                break;
+            }
+        }
+    }
+    else
+    {
+        hr = E_INVALIDARG;
+    }
 
-   return hr;
+    return hr;
 }
 ```
 


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.