### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/idebugdocumentcontext2-getstatementrange.md
+++ b/docs/extensibility/debugger/reference/idebugdocumentcontext2-getstatementrange.md
@@ -20,15 +20,15 @@ Gets the file statement range of the document context.
 
 ```cpp
 HRESULT GetStatementRange(
-   TEXT_POSITION* pBegPosition,
-   TEXT_POSITION* pEndPosition
+    TEXT_POSITION* pBegPosition,
+    TEXT_POSITION* pEndPosition
 );
 ```
 
 ```csharp
 int GetStatementRange(
-   TEXT_POSITION[] pBegPosition,
-   TEXT_POSITION[] pEndPosition
+    TEXT_POSITION[] pBegPosition,
+    TEXT_POSITION[] pEndPosition
 );
 ```
 
@@ -54,28 +54,28 @@ The following example shows how to implement this method for a simple `CDebugCon
 HRESULT CDebugContext::GetStatementRange(TEXT_POSITION* pBegPosition,
                                          TEXT_POSITION* pEndPosition)
 {
-   HRESULT hr;
+    HRESULT hr;
 
-   // Check for a valid beginning position argument pointer.
-   if (pBegPosition)
-   {
-      // Copy the member TEXT_POSITION into the local pBegPosition.
-      memcpy(pBegPosition, &m_pos, sizeof (TEXT_POSITION));
+    // Check for a valid beginning position argument pointer.
+    if (pBegPosition)
+    {
+        // Copy the member TEXT_POSITION into the local pBegPosition.
+        memcpy(pBegPosition, &m_pos, sizeof (TEXT_POSITION));
 
-      // Check for a valid ending position argument pointer.
-     if (pEndPosition)
-      {
-         // Copy the member TEXT_POSITION into the local pEndPosition.
-         memcpy(pEndPosition, &m_pos, sizeof (TEXT_POSITION));
-      }
-      hr = S_OK;
-   }
-   else
-   {
-      hr = E_INVALIDARG;
-   }
+        // Check for a valid ending position argument pointer.
+        if (pEndPosition)
+        {
+            // Copy the member TEXT_POSITION into the local pEndPosition.
+            memcpy(pEndPosition, &m_pos, sizeof (TEXT_POSITION));
+        }
+        hr = S_OK;
+    }
+    else
+    {
+        hr = E_INVALIDARG;
+    }
 
-   return hr;
+    return hr;
 }
 ```
 

--- a/docs/extensibility/debugger/reference/idebugdocumentcontext2-getstatementrange.md
+++ b/docs/extensibility/debugger/reference/idebugdocumentcontext2-getstatementrange.md
@@ -2,84 +2,84 @@
 title: "IDebugDocumentContext2::GetStatementRange | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-f1_keywords: 
+f1_keywords:
   - "IDebugDocumentContext2::GetStatementRange"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "IDebugDocumentContext2::GetStatementRange"
 ms.assetid: bc94851a-0ec4-47ea-99c7-0a585e54e726
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # IDebugDocumentContext2::GetStatementRange
-Gets the file statement range of the document context.  
-  
-## Syntax  
-  
-```cpp  
-HRESULT GetStatementRange(   
-   TEXT_POSITION* pBegPosition,  
-   TEXT_POSITION* pEndPosition  
-);  
-```  
-  
-```csharp  
-int GetStatementRange(   
-   TEXT_POSITION[] pBegPosition,  
-   TEXT_POSITION[] pEndPosition  
-);  
-```  
-  
-#### Parameters  
- `pBegPosition`  
- [in, out] A [TEXT_POSITION](../../../extensibility/debugger/reference/text-position.md) structure that is filled in with the starting position. Set this argument to a null value if this information is not needed.  
-  
- `pEndPosition`  
- [in, out] A [TEXT_POSITION](../../../extensibility/debugger/reference/text-position.md) structure that is filled in with the ending position. Set this argument to a null value if this information is not needed.  
-  
-## Return Value  
- If successful, returns `S_OK`; otherwise, returns an error code.  
-  
-## Remarks  
- A statement range is the range of the lines that contributed the code to which this document context refers.  
-  
- To obtain the range of source code (including comments) within this document context, call the [GetSourceRange](../../../extensibility/debugger/reference/idebugdocumentcontext2-getsourcerange.md) method.  
-  
-## Example  
- The following example shows how to implement this method for a simple `CDebugContext` object that exposes the [IDebugDocumentContext2](../../../extensibility/debugger/reference/idebugdocumentcontext2.md) interface. This example fills in the ending position only if the beginning position is not a null value.  
-  
-```cpp  
-HRESULT CDebugContext::GetStatementRange(TEXT_POSITION* pBegPosition,  
-                                         TEXT_POSITION* pEndPosition)    
-{    
-   HRESULT hr;    
-  
-   // Check for a valid beginning position argument pointer.    
-   if (pBegPosition)    
-   {    
-      // Copy the member TEXT_POSITION into the local pBegPosition.    
-      memcpy(pBegPosition, &m_pos, sizeof (TEXT_POSITION));    
-  
-      // Check for a valid ending position argument pointer.   
-     if (pEndPosition)    
-      {    
-         // Copy the member TEXT_POSITION into the local pEndPosition.    
-         memcpy(pEndPosition, &m_pos, sizeof (TEXT_POSITION));    
-      }    
-      hr = S_OK;    
-   }    
-   else    
-   {    
-      hr = E_INVALIDARG;    
-   }    
-  
-   return hr;    
-}    
-```  
-  
-## See Also  
- [IDebugDocumentContext2](../../../extensibility/debugger/reference/idebugdocumentcontext2.md)   
- [GetSourceRange](../../../extensibility/debugger/reference/idebugdocumentcontext2-getsourcerange.md)   
- [TEXT_POSITION](../../../extensibility/debugger/reference/text-position.md)
+Gets the file statement range of the document context.
+
+## Syntax
+
+```cpp
+HRESULT GetStatementRange(
+   TEXT_POSITION* pBegPosition,
+   TEXT_POSITION* pEndPosition
+);
+```
+
+```csharp
+int GetStatementRange(
+   TEXT_POSITION[] pBegPosition,
+   TEXT_POSITION[] pEndPosition
+);
+```
+
+#### Parameters
+`pBegPosition`  
+[in, out] A [TEXT_POSITION](../../../extensibility/debugger/reference/text-position.md) structure that is filled in with the starting position. Set this argument to a null value if this information is not needed.
+
+`pEndPosition`  
+[in, out] A [TEXT_POSITION](../../../extensibility/debugger/reference/text-position.md) structure that is filled in with the ending position. Set this argument to a null value if this information is not needed.
+
+## Return Value
+If successful, returns `S_OK`; otherwise, returns an error code.
+
+## Remarks
+A statement range is the range of the lines that contributed the code to which this document context refers.
+
+To obtain the range of source code (including comments) within this document context, call the [GetSourceRange](../../../extensibility/debugger/reference/idebugdocumentcontext2-getsourcerange.md) method.
+
+## Example
+The following example shows how to implement this method for a simple `CDebugContext` object that exposes the [IDebugDocumentContext2](../../../extensibility/debugger/reference/idebugdocumentcontext2.md) interface. This example fills in the ending position only if the beginning position is not a null value.
+
+```cpp
+HRESULT CDebugContext::GetStatementRange(TEXT_POSITION* pBegPosition,
+                                         TEXT_POSITION* pEndPosition)
+{
+   HRESULT hr;
+
+   // Check for a valid beginning position argument pointer.
+   if (pBegPosition)
+   {
+      // Copy the member TEXT_POSITION into the local pBegPosition.
+      memcpy(pBegPosition, &m_pos, sizeof (TEXT_POSITION));
+
+      // Check for a valid ending position argument pointer.
+     if (pEndPosition)
+      {
+         // Copy the member TEXT_POSITION into the local pEndPosition.
+         memcpy(pEndPosition, &m_pos, sizeof (TEXT_POSITION));
+      }
+      hr = S_OK;
+   }
+   else
+   {
+      hr = E_INVALIDARG;
+   }
+
+   return hr;
+}
+```
+
+## See Also
+[IDebugDocumentContext2](../../../extensibility/debugger/reference/idebugdocumentcontext2.md)  
+[GetSourceRange](../../../extensibility/debugger/reference/idebugdocumentcontext2-getsourcerange.md)  
+[TEXT_POSITION](../../../extensibility/debugger/reference/text-position.md)


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.