### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/idebugdocumenttext2-gettext.md
+++ b/docs/extensibility/debugger/reference/idebugdocumenttext2-gettext.md
@@ -2,95 +2,95 @@
 title: "IDebugDocumentText2::GetText | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-f1_keywords: 
+f1_keywords:
   - "IDebugDocumentText2::GetText"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "IDebugDocumentText2::GetText"
 ms.assetid: f8c15a58-da77-473e-a721-7a094e306c63
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # IDebugDocumentText2::GetText
-Retrieves the text from the specified position in the document.  
-  
-## Syntax  
-  
-```cpp  
-HRESULT GetText(   
-   TEXT_POSITION pos,  
-   ULONG         cMaxChars,  
-   WCHAR*        pText,  
-   ULONG*        pcNumChars  
-);  
-```  
-  
-```csharp  
-int GetText(   
-   eumn_TEXT_POSITION pos,  
-   uint               cMaxChars,  
-   IntPtr             pText,  
-   out uint           pcNumChars  
-);  
-```  
-  
-#### Parameters  
- `pos`  
- [in] A [TEXT_POSITION](../../../extensibility/debugger/reference/text-position.md) structure that indicates the location of the text to be retrieved.  
-  
- `cMaxChars`  
- [in] The maximum number of characters of the text to be retrieved.  
-  
- `pText`  
- [in, out] A pointer to a buffer that is to be filled in with the desired text. This buffer must be able to contain at least `cMaxChars` number of wide characters.  
-  
- `pcNumChars`  
- [out] Returns the number of characters actually retrieved.  
-  
-## Return Value  
- If successful, returns `S_OK`; otherwise, returns an error code.  
-  
-## Example  
- This example shows how this method can be called from C#.  
-  
-```csharp  
-using System.Runtime.Interop.Services;  
-using Microsoft.VisualStudio;  
-using Microsoft.VisualStudio.Debugger.Interop;  
-  
-namespace Mynamespace  
-{  
-    class MyClass  
-    {  
-         string GetDocumentText(IDebugDocumentText2 pText, TEXT_POSITION pos)  
-        {  
-             string documentText = string.Empty;  
-             if (pText != null)  
-             {  
-                  uint numLines = 0;  
-                  uint numChars = 0;  
-                  int hr;  
-                  hr = pText.GetSize(ref numLines, ref numChars);  
-                  if (ErrorHandler.Succeeded(hr))  
-                  {  
-                       IntPtr buffer = Marshal.AllocCoTaskMem((int)numChars * sizeof(char));  
-                       uint actualChars = 0;  
-                       hr = pText.GetText(pos, numChars, buffer, out actualChars);  
-                       if (ErrorHandler.Succeeded(hr))  
-                       {  
-                            documentText = Marshal.PtrToStringUni(buffer, (int)actualChars);  
-                       }  
-                       Marshal.FreeCoTaskMem(buffer);  
-                  }  
-              }  
-              return documentText;  
-         }  
-    }  
-}  
-```  
-  
-## See Also  
- [IDebugDocumentText2](../../../extensibility/debugger/reference/idebugdocumenttext2.md)   
- [TEXT_POSITION](../../../extensibility/debugger/reference/text-position.md)
+Retrieves the text from the specified position in the document.
+
+## Syntax
+
+```cpp
+HRESULT GetText(
+   TEXT_POSITION pos,
+   ULONG         cMaxChars,
+   WCHAR*        pText,
+   ULONG*        pcNumChars
+);
+```
+
+```csharp
+int GetText(
+   eumn_TEXT_POSITION pos,
+   uint               cMaxChars,
+   IntPtr             pText,
+   out uint           pcNumChars
+);
+```
+
+#### Parameters
+`pos`  
+[in] A [TEXT_POSITION](../../../extensibility/debugger/reference/text-position.md) structure that indicates the location of the text to be retrieved.
+
+`cMaxChars`  
+[in] The maximum number of characters of the text to be retrieved.
+
+`pText`  
+[in, out] A pointer to a buffer that is to be filled in with the desired text. This buffer must be able to contain at least `cMaxChars` number of wide characters.
+
+`pcNumChars`  
+[out] Returns the number of characters actually retrieved.
+
+## Return Value
+If successful, returns `S_OK`; otherwise, returns an error code.
+
+## Example
+This example shows how this method can be called from C#.
+
+```csharp
+using System.Runtime.Interop.Services;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Debugger.Interop;
+
+namespace Mynamespace
+{
+    class MyClass
+    {
+         string GetDocumentText(IDebugDocumentText2 pText, TEXT_POSITION pos)
+        {
+             string documentText = string.Empty;
+             if (pText != null)
+             {
+                  uint numLines = 0;
+                  uint numChars = 0;
+                  int hr;
+                  hr = pText.GetSize(ref numLines, ref numChars);
+                  if (ErrorHandler.Succeeded(hr))
+                  {
+                       IntPtr buffer = Marshal.AllocCoTaskMem((int)numChars * sizeof(char));
+                       uint actualChars = 0;
+                       hr = pText.GetText(pos, numChars, buffer, out actualChars);
+                       if (ErrorHandler.Succeeded(hr))
+                       {
+                            documentText = Marshal.PtrToStringUni(buffer, (int)actualChars);
+                       }
+                       Marshal.FreeCoTaskMem(buffer);
+                  }
+              }
+              return documentText;
+         }
+    }
+}
+```
+
+## See Also
+[IDebugDocumentText2](../../../extensibility/debugger/reference/idebugdocumenttext2.md)  
+[TEXT_POSITION](../../../extensibility/debugger/reference/text-position.md)

--- a/docs/extensibility/debugger/reference/idebugdocumenttext2-gettext.md
+++ b/docs/extensibility/debugger/reference/idebugdocumenttext2-gettext.md
@@ -20,19 +20,19 @@ Retrieves the text from the specified position in the document.
 
 ```cpp
 HRESULT GetText(
-   TEXT_POSITION pos,
-   ULONG         cMaxChars,
-   WCHAR*        pText,
-   ULONG*        pcNumChars
+    TEXT_POSITION pos,
+    ULONG         cMaxChars,
+    WCHAR*        pText,
+    ULONG*        pcNumChars
 );
 ```
 
 ```csharp
 int GetText(
-   eumn_TEXT_POSITION pos,
-   uint               cMaxChars,
-   IntPtr             pText,
-   out uint           pcNumChars
+    eumn_TEXT_POSITION pos,
+    uint               cMaxChars,
+    IntPtr             pText,
+    out uint           pcNumChars
 );
 ```
 
@@ -64,29 +64,29 @@ namespace Mynamespace
 {
     class MyClass
     {
-         string GetDocumentText(IDebugDocumentText2 pText, TEXT_POSITION pos)
+        string GetDocumentText(IDebugDocumentText2 pText, TEXT_POSITION pos)
         {
-             string documentText = string.Empty;
-             if (pText != null)
-             {
-                  uint numLines = 0;
-                  uint numChars = 0;
-                  int hr;
-                  hr = pText.GetSize(ref numLines, ref numChars);
-                  if (ErrorHandler.Succeeded(hr))
-                  {
-                       IntPtr buffer = Marshal.AllocCoTaskMem((int)numChars * sizeof(char));
-                       uint actualChars = 0;
-                       hr = pText.GetText(pos, numChars, buffer, out actualChars);
-                       if (ErrorHandler.Succeeded(hr))
-                       {
-                            documentText = Marshal.PtrToStringUni(buffer, (int)actualChars);
-                       }
-                       Marshal.FreeCoTaskMem(buffer);
-                  }
-              }
-              return documentText;
-         }
+            string documentText = string.Empty;
+            if (pText != null)
+            {
+                uint numLines = 0;
+                uint numChars = 0;
+                int hr;
+                hr = pText.GetSize(ref numLines, ref numChars);
+                if (ErrorHandler.Succeeded(hr))
+                {
+                    IntPtr buffer = Marshal.AllocCoTaskMem((int)numChars * sizeof(char));
+                    uint actualChars = 0;
+                    hr = pText.GetText(pos, numChars, buffer, out actualChars);
+                    if (ErrorHandler.Succeeded(hr))
+                    {
+                        documentText = Marshal.PtrToStringUni(buffer, (int)actualChars);
+                    }
+                    Marshal.FreeCoTaskMem(buffer);
+                }
+            }
+            return documentText;
+        }
     }
 }
 ```


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.