### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/idebugengine2-getengineid.md
+++ b/docs/extensibility/debugger/reference/idebugengine2-getengineid.md
@@ -2,60 +2,60 @@
 title: "IDebugEngine2::GetEngineID | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-f1_keywords: 
+f1_keywords:
   - "IDebugEngine2::GetEngineID"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "IDebugEngine2::GetEngineID"
 ms.assetid: 0d5674c8-a9b9-4b72-8211-d2d68695775a
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # IDebugEngine2::GetEngineID
-Gets the GUID of the debug engine (DE).  
-  
-## Syntax  
-  
-```cpp  
-HRESULT GetEngineID(   
-   GUID* pguidEngine  
-);  
-```  
-  
-```csharp  
-int GetEngineID(   
-   out Guid pguidEngine  
-);  
-```  
-  
-#### Parameters  
- `pguidEngine`  
- [out] Returns the GUID of the DE.  
-  
-## Return Value  
- If successful, returns `S_OK`; otherwise, returns an error code.  
-  
-## Remarks  
- Some examples of typical GUIDs are `guidScriptEng`, `guidNativeEng`, or `guidSQLEng`. New debug engines will create their own GUID for identification.  
-  
-## Example  
- The following example shows how to implement this method for a simple `CEngine` object that implements the [IDebugEngine2](../../../extensibility/debugger/reference/idebugengine2.md) interface.  
-  
-```cpp  
-HRESULT CEngine::GetEngineId(GUID *pguidEngine){    
-   if (pguidEngine) {    
-      // Set pguidEngine to guidBatEng, as defined in the Batdbg.idl file.    
-      // Other languages would require their own guidDifferentEngine to be  
-      //defined in the Batdbg.idl file.    
-      *pguidEngine = guidBatEng;    
-      return NOERROR; // This is typically S_OK.    
-   } else {  
-      return E_INVALIDARG;    
-   }    
-}    
-```  
-  
-## See Also  
- [IDebugEngine2](../../../extensibility/debugger/reference/idebugengine2.md)
+Gets the GUID of the debug engine (DE).
+
+## Syntax
+
+```cpp
+HRESULT GetEngineID(
+   GUID* pguidEngine
+);
+```
+
+```csharp
+int GetEngineID(
+   out Guid pguidEngine
+);
+```
+
+#### Parameters
+`pguidEngine`  
+[out] Returns the GUID of the DE.
+
+## Return Value
+If successful, returns `S_OK`; otherwise, returns an error code.
+
+## Remarks
+Some examples of typical GUIDs are `guidScriptEng`, `guidNativeEng`, or `guidSQLEng`. New debug engines will create their own GUID for identification.
+
+## Example
+The following example shows how to implement this method for a simple `CEngine` object that implements the [IDebugEngine2](../../../extensibility/debugger/reference/idebugengine2.md) interface.
+
+```cpp
+HRESULT CEngine::GetEngineId(GUID *pguidEngine){
+   if (pguidEngine) {
+      // Set pguidEngine to guidBatEng, as defined in the Batdbg.idl file.
+      // Other languages would require their own guidDifferentEngine to be
+      //defined in the Batdbg.idl file.
+      *pguidEngine = guidBatEng;
+      return NOERROR; // This is typically S_OK.
+   } else {
+      return E_INVALIDARG;
+   }
+}
+```
+
+## See Also
+[IDebugEngine2](../../../extensibility/debugger/reference/idebugengine2.md)

--- a/docs/extensibility/debugger/reference/idebugengine2-getengineid.md
+++ b/docs/extensibility/debugger/reference/idebugengine2-getengineid.md
@@ -20,13 +20,13 @@ Gets the GUID of the debug engine (DE).
 
 ```cpp
 HRESULT GetEngineID(
-   GUID* pguidEngine
+    GUID* pguidEngine
 );
 ```
 
 ```csharp
 int GetEngineID(
-   out Guid pguidEngine
+    out Guid pguidEngine
 );
 ```
 
@@ -44,16 +44,16 @@ Some examples of typical GUIDs are `guidScriptEng`, `guidNativeEng`, or `guidSQL
 The following example shows how to implement this method for a simple `CEngine` object that implements the [IDebugEngine2](../../../extensibility/debugger/reference/idebugengine2.md) interface.
 
 ```cpp
-HRESULT CEngine::GetEngineId(GUID *pguidEngine){
-   if (pguidEngine) {
-      // Set pguidEngine to guidBatEng, as defined in the Batdbg.idl file.
-      // Other languages would require their own guidDifferentEngine to be
-      //defined in the Batdbg.idl file.
-      *pguidEngine = guidBatEng;
-      return NOERROR; // This is typically S_OK.
-   } else {
-      return E_INVALIDARG;
-   }
+HRESULT CEngine::GetEngineId(GUID *pguidEngine) {
+    if (pguidEngine) {
+        // Set pguidEngine to guidBatEng, as defined in the Batdbg.idl file.
+        // Other languages would require their own guidDifferentEngine to be
+        //defined in the Batdbg.idl file.
+        *pguidEngine = guidBatEng;
+        return NOERROR; // This is typically S_OK.
+    } else {
+        return E_INVALIDARG;
+    }
 }
 ```
 


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.