### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/idebugerrorbreakpointresolution2-getbreakpointtype.md
+++ b/docs/extensibility/debugger/reference/idebugerrorbreakpointresolution2-getbreakpointtype.md
@@ -2,78 +2,78 @@
 title: "IDebugErrorBreakpointResolution2::GetBreakpointType | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-f1_keywords: 
+f1_keywords:
   - "IDebugErrorBreakpointResolution2::GetBreakpointType"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "IDebugErrorBreakpointResolution2::GetBreakpointType"
 ms.assetid: 0bdb1152-4752-4464-ae7c-6d666dc293b7
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # IDebugErrorBreakpointResolution2::GetBreakpointType
-Gets the breakpoint type.  
-  
-## Syntax  
-  
-```cpp  
-HRESULT GetBreakpointType(   
-   BP_TYPE* pBPType  
-);  
-```  
-  
-```csharp  
-int GetBreakpointType(   
-   out enum_BP_TYPE pBPType  
-);  
-```  
-  
-#### Parameters  
- `pBPType`  
- [out] Returns a value from the [BP_TYPE](../../../extensibility/debugger/reference/bp-type.md) enumeration that describes the type of breakpoint.  
-  
-## Return Value  
- If successful, returns `S_OK`; otherwise, returns an error code.  
-  
-## Remarks  
- This method returns the type of the breakpoint that failed to bind, thus requiring an error breakpoint event.  
-  
-## Example  
- The following example shows how to implement this method for a simple `CDebugErrorBreakpointResolution` object that exposes the [IDebugErrorBreakpointResolution2](../../../extensibility/debugger/reference/idebugerrorbreakpointresolution2.md) interface.  
-  
-```  
-HRESULT CDebugErrorBreakpointResolution::GetBreakpointType(BP_TYPE* pBPType)    
-{    
-   HRESULT hr;    
-  
-   if (pBPType)    
-   {    
-      // Set default BP_TYPE.    
-      *pBPType = BPT_NONE;    
-  
-      // Check if the BPERESI_BPRESLOCATION flag is set in BPERESI_FIELDS.    
-      if (IsFlagSet(m_bpErrorResolutionInfo.dwFields, BPERESI_BPRESLOCATION))    
-      {    
-         // Set the new BP_TYPE.    
-         *pBPType = m_bpErrorResolutionInfo.bpResLocation.bpType;    
-         hr = S_OK;    
-      }    
-      else    
-      {    
-         hr = E_FAIL;    
-      }    
-   }    
-   else    
-   {    
-      hr = E_INVALIDARG;    
-   }    
-  
-   return hr;    
-}    
-```  
-  
-## See Also  
- [IDebugErrorBreakpointResolution2](../../../extensibility/debugger/reference/idebugerrorbreakpointresolution2.md)   
- [BP_TYPE](../../../extensibility/debugger/reference/bp-type.md)
+Gets the breakpoint type.
+
+## Syntax
+
+```cpp
+HRESULT GetBreakpointType(
+   BP_TYPE* pBPType
+);
+```
+
+```csharp
+int GetBreakpointType(
+   out enum_BP_TYPE pBPType
+);
+```
+
+#### Parameters
+`pBPType`  
+[out] Returns a value from the [BP_TYPE](../../../extensibility/debugger/reference/bp-type.md) enumeration that describes the type of breakpoint.
+
+## Return Value
+If successful, returns `S_OK`; otherwise, returns an error code.
+
+## Remarks
+This method returns the type of the breakpoint that failed to bind, thus requiring an error breakpoint event.
+
+## Example
+The following example shows how to implement this method for a simple `CDebugErrorBreakpointResolution` object that exposes the [IDebugErrorBreakpointResolution2](../../../extensibility/debugger/reference/idebugerrorbreakpointresolution2.md) interface.
+
+```
+HRESULT CDebugErrorBreakpointResolution::GetBreakpointType(BP_TYPE* pBPType)
+{
+   HRESULT hr;
+
+   if (pBPType)
+   {
+      // Set default BP_TYPE.
+      *pBPType = BPT_NONE;
+
+      // Check if the BPERESI_BPRESLOCATION flag is set in BPERESI_FIELDS.
+      if (IsFlagSet(m_bpErrorResolutionInfo.dwFields, BPERESI_BPRESLOCATION))
+      {
+         // Set the new BP_TYPE.
+         *pBPType = m_bpErrorResolutionInfo.bpResLocation.bpType;
+         hr = S_OK;
+      }
+      else
+      {
+         hr = E_FAIL;
+      }
+   }
+   else
+   {
+      hr = E_INVALIDARG;
+   }
+
+   return hr;
+}
+```
+
+## See Also
+[IDebugErrorBreakpointResolution2](../../../extensibility/debugger/reference/idebugerrorbreakpointresolution2.md)  
+[BP_TYPE](../../../extensibility/debugger/reference/bp-type.md)

--- a/docs/extensibility/debugger/reference/idebugerrorbreakpointresolution2-getbreakpointtype.md
+++ b/docs/extensibility/debugger/reference/idebugerrorbreakpointresolution2-getbreakpointtype.md
@@ -20,13 +20,13 @@ Gets the breakpoint type.
 
 ```cpp
 HRESULT GetBreakpointType(
-   BP_TYPE* pBPType
+    BP_TYPE* pBPType
 );
 ```
 
 ```csharp
 int GetBreakpointType(
-   out enum_BP_TYPE pBPType
+    out enum_BP_TYPE pBPType
 );
 ```
 
@@ -46,31 +46,31 @@ The following example shows how to implement this method for a simple `CDebugErr
 ```
 HRESULT CDebugErrorBreakpointResolution::GetBreakpointType(BP_TYPE* pBPType)
 {
-   HRESULT hr;
+    HRESULT hr;
 
-   if (pBPType)
-   {
-      // Set default BP_TYPE.
-      *pBPType = BPT_NONE;
+    if (pBPType)
+    {
+        // Set default BP_TYPE.
+        *pBPType = BPT_NONE;
 
-      // Check if the BPERESI_BPRESLOCATION flag is set in BPERESI_FIELDS.
-      if (IsFlagSet(m_bpErrorResolutionInfo.dwFields, BPERESI_BPRESLOCATION))
-      {
-         // Set the new BP_TYPE.
-         *pBPType = m_bpErrorResolutionInfo.bpResLocation.bpType;
-         hr = S_OK;
-      }
-      else
-      {
-         hr = E_FAIL;
-      }
-   }
-   else
-   {
-      hr = E_INVALIDARG;
-   }
+        // Check if the BPERESI_BPRESLOCATION flag is set in BPERESI_FIELDS.
+        if (IsFlagSet(m_bpErrorResolutionInfo.dwFields, BPERESI_BPRESLOCATION))
+        {
+            // Set the new BP_TYPE.
+            *pBPType = m_bpErrorResolutionInfo.bpResLocation.bpType;
+            hr = S_OK;
+        }
+        else
+        {
+            hr = E_FAIL;
+        }
+    }
+    else
+    {
+        hr = E_INVALIDARG;
+    }
 
-   return hr;
+    return hr;
 }
 ```
 


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.