### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/idebugexpression2-evaluateasync.md
+++ b/docs/extensibility/debugger/reference/idebugexpression2-evaluateasync.md
@@ -20,15 +20,15 @@ This method evaluates the expression asynchronously.
 
 ```cpp
 HRESULT EvaluateAsync (
-   EVALFLAGS             dwFlags,
-   IDebugEventCallback2* pExprCallback
+    EVALFLAGS             dwFlags,
+    IDebugEventCallback2* pExprCallback
 );
 ```
 
 ```csharp
 int EvaluateAsync(
-   enum_EVALFLAGS       dwFlags,
-   IDebugEventCallback2 pExprCallback
+    enum_EVALFLAGS       dwFlags,
+    IDebugEventCallback2 pExprCallback
 );
 ```
 

--- a/docs/extensibility/debugger/reference/idebugexpression2-evaluateasync.md
+++ b/docs/extensibility/debugger/reference/idebugexpression2-evaluateasync.md
@@ -2,72 +2,72 @@
 title: "IDebugExpression2::EvaluateAsync | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-f1_keywords: 
+f1_keywords:
   - "IDebugExpression2::EvaluateAsync"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "IDebugExpression2::EvaluateAsync"
 ms.assetid: 848fe6cb-0759-42f2-890b-d2b551c527d6
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # IDebugExpression2::EvaluateAsync
-This method evaluates the expression asynchronously.  
-  
-## Syntax  
-  
-```cpp  
-HRESULT EvaluateAsync (   
-   EVALFLAGS             dwFlags,  
-   IDebugEventCallback2* pExprCallback  
-);  
-```  
-  
-```csharp  
-int EvaluateAsync(  
-   enum_EVALFLAGS       dwFlags,   
-   IDebugEventCallback2 pExprCallback  
-);  
-```  
-  
-#### Parameters  
- `dwFlags`  
- [in] A combination of flags from the [EVALFLAGS](../../../extensibility/debugger/reference/evalflags.md) enumeration that control expression evaluation.  
-  
- `pExprCallback`  
- [in] This parameter is always a null value.  
-  
-## Return Value  
- If successful, returns `S_OK`; otherwise returns an error code. A typical error code is:  
-  
-|Error|Description|  
-|-----------|-----------------|  
-|E_EVALUATE_BUSY_WITH_EVALUATION|Another expression is currently being evaluated, and simultaneous expression evaluation is not supported.|  
-  
-## Remarks  
- This method should return immediately after it has started the expression evaluation. When the expression is successfully evaluated, an [IDebugExpressionEvaluationCompleteEvent2](../../../extensibility/debugger/reference/idebugexpressionevaluationcompleteevent2.md) must be sent to the [IDebugEventCallback2](../../../extensibility/debugger/reference/idebugeventcallback2.md) event callback as supplied through [Attach](../../../extensibility/debugger/reference/idebugprogram2-attach.md) or [Attach](../../../extensibility/debugger/reference/idebugengine2-attach.md).  
-  
-## Example  
- The following example shows how to implement this method for a simple `CExpression` object that implements the [IDebugExpression2](../../../extensibility/debugger/reference/idebugexpression2.md) interface.  
-  
-```cpp  
-HRESULT CExpression::EvaluateAsync(EVALFLAGS dwFlags,  
-                                   IDebugEventCallback2* pExprCallback)  
-{  
-    // Set the aborted state to FALSE  
-    // in case the user tries to redo the evaluation after aborting.  
-    m_bAborted = FALSE;  
-    // Post the WM_EVAL_EXPR message in the message queue of the current thread.  
-    // This starts the expression evaluation on a background thread.  
-    PostThreadMessage(GetCurrentThreadId(), WM_EVAL_EXPR, 0, (LPARAM) this);  
-    return S_OK;  
-}  
-```  
-  
-## See Also  
- [IDebugExpression2](../../../extensibility/debugger/reference/idebugexpression2.md)   
- [IDebugExpressionEvaluationCompleteEvent2](../../../extensibility/debugger/reference/idebugexpressionevaluationcompleteevent2.md)   
- [EVALFLAGS](../../../extensibility/debugger/reference/evalflags.md)   
- [IDebugEventCallback2](../../../extensibility/debugger/reference/idebugeventcallback2.md)
+This method evaluates the expression asynchronously.
+
+## Syntax
+
+```cpp
+HRESULT EvaluateAsync (
+   EVALFLAGS             dwFlags,
+   IDebugEventCallback2* pExprCallback
+);
+```
+
+```csharp
+int EvaluateAsync(
+   enum_EVALFLAGS       dwFlags,
+   IDebugEventCallback2 pExprCallback
+);
+```
+
+#### Parameters
+`dwFlags`  
+[in] A combination of flags from the [EVALFLAGS](../../../extensibility/debugger/reference/evalflags.md) enumeration that control expression evaluation.
+
+`pExprCallback`  
+[in] This parameter is always a null value.
+
+## Return Value
+If successful, returns `S_OK`; otherwise returns an error code. A typical error code is:
+
+|Error|Description|
+|-----------|-----------------|
+|E_EVALUATE_BUSY_WITH_EVALUATION|Another expression is currently being evaluated, and simultaneous expression evaluation is not supported.|
+
+## Remarks
+This method should return immediately after it has started the expression evaluation. When the expression is successfully evaluated, an [IDebugExpressionEvaluationCompleteEvent2](../../../extensibility/debugger/reference/idebugexpressionevaluationcompleteevent2.md) must be sent to the [IDebugEventCallback2](../../../extensibility/debugger/reference/idebugeventcallback2.md) event callback as supplied through [Attach](../../../extensibility/debugger/reference/idebugprogram2-attach.md) or [Attach](../../../extensibility/debugger/reference/idebugengine2-attach.md).
+
+## Example
+The following example shows how to implement this method for a simple `CExpression` object that implements the [IDebugExpression2](../../../extensibility/debugger/reference/idebugexpression2.md) interface.
+
+```cpp
+HRESULT CExpression::EvaluateAsync(EVALFLAGS dwFlags,
+                                   IDebugEventCallback2* pExprCallback)
+{
+    // Set the aborted state to FALSE
+    // in case the user tries to redo the evaluation after aborting.
+    m_bAborted = FALSE;
+    // Post the WM_EVAL_EXPR message in the message queue of the current thread.
+    // This starts the expression evaluation on a background thread.
+    PostThreadMessage(GetCurrentThreadId(), WM_EVAL_EXPR, 0, (LPARAM) this);
+    return S_OK;
+}
+```
+
+## See Also
+[IDebugExpression2](../../../extensibility/debugger/reference/idebugexpression2.md)  
+[IDebugExpressionEvaluationCompleteEvent2](../../../extensibility/debugger/reference/idebugexpressionevaluationcompleteevent2.md)  
+[EVALFLAGS](../../../extensibility/debugger/reference/evalflags.md)  
+[IDebugEventCallback2](../../../extensibility/debugger/reference/idebugeventcallback2.md)


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.