### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/idebugexpressionevaluator2-preloadmodules.md
+++ b/docs/extensibility/debugger/reference/idebugexpressionevaluator2-preloadmodules.md
@@ -2,71 +2,71 @@
 title: "IDebugExpressionEvaluator2::PreloadModules | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "IDebugExpressionEvaluator2::PreloadModules"
   - "PreloadModules"
 ms.assetid: bcf9b968-ee14-4a92-88ad-926268a44e03
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # IDebugExpressionEvaluator2::PreloadModules
-Preloads the modules designated by the specified symbol provider.  
-  
-## Syntax  
-  
-```cpp  
-HRESULT PreloadModules (  
-   IDebugSymbolProvider* pSym  
-);  
-```  
-  
-```csharp  
-int PreloadModules (  
-   IDebugSymbolProvider pSym  
-);  
-```  
-  
-#### Parameters  
- `pSym`  
- [in] Symbol provider for which the modules will be preloaded.  
-  
-## Return Value  
- If successful, returns `S_OK`; otherwise, returns an error code.  
-  
-## Remarks  
- This optional method is used when you do a hosting-process attach. It gives the EE a chance to 'warm up' as part of the attach.  
-  
-## Example  
- The following example shows how to implement this method for a **ExpressionEvaluatorPackage** object that exposes the [IDebugExpressionEvaluator2](../../../extensibility/debugger/reference/idebugexpressionevaluator2.md) interface.  
-  
-```cpp  
-STDMETHODIMP ExpressionEvaluatorPackage::PreloadModules  
-(  
-    IDebugSymbolProvider *pSym  
-)  
-{  
-    HRESULT hr = NOERROR;  
-    RuntimeMemberDescriptor  * prtMemberDesc;  
-    RuntimeClassDescriptor *prtClassDesc;  
-    CComPtr<IDebugClassField> pClassField;  
-    IfFalseGo(pSym,E_INVALIDARG);  
-  
-    prtMemberDesc = &(g_rgRTLangMembers[StandardModuleAttributeCtor]);  
-    prtClassDesc = &(g_rgRTLangClasses[prtMemberDesc->rtParent]);  
-    pSym->GetClassTypeByName(prtClassDesc->wszClassName, nmCaseSensitive, &pClassField);  
-  
-    pClassField = NULL;  
-    prtMemberDesc = &(g_rgRTLangMembers[LoadAssembly]);  
-    prtClassDesc = &(g_rgRTLangClasses[prtMemberDesc->rtParent]);  
-    pSym->GetClassTypeByName(prtClassDesc->wszClassName, nmCaseSensitive, &pClassField);  
-  
-Error:  
-    return hr;  
-}  
-```  
-  
-## See Also  
- [IDebugExpressionEvaluator2](../../../extensibility/debugger/reference/idebugexpressionevaluator2.md)
+Preloads the modules designated by the specified symbol provider.
+
+## Syntax
+
+```cpp
+HRESULT PreloadModules (
+   IDebugSymbolProvider* pSym
+);
+```
+
+```csharp
+int PreloadModules (
+   IDebugSymbolProvider pSym
+);
+```
+
+#### Parameters
+`pSym`  
+[in] Symbol provider for which the modules will be preloaded.
+
+## Return Value
+If successful, returns `S_OK`; otherwise, returns an error code.
+
+## Remarks
+This optional method is used when you do a hosting-process attach. It gives the EE a chance to 'warm up' as part of the attach.
+
+## Example
+The following example shows how to implement this method for a **ExpressionEvaluatorPackage** object that exposes the [IDebugExpressionEvaluator2](../../../extensibility/debugger/reference/idebugexpressionevaluator2.md) interface.
+
+```cpp
+STDMETHODIMP ExpressionEvaluatorPackage::PreloadModules
+(
+    IDebugSymbolProvider *pSym
+)
+{
+    HRESULT hr = NOERROR;
+    RuntimeMemberDescriptor  * prtMemberDesc;
+    RuntimeClassDescriptor *prtClassDesc;
+    CComPtr<IDebugClassField> pClassField;
+    IfFalseGo(pSym,E_INVALIDARG);
+
+    prtMemberDesc = &(g_rgRTLangMembers[StandardModuleAttributeCtor]);
+    prtClassDesc = &(g_rgRTLangClasses[prtMemberDesc->rtParent]);
+    pSym->GetClassTypeByName(prtClassDesc->wszClassName, nmCaseSensitive, &pClassField);
+
+    pClassField = NULL;
+    prtMemberDesc = &(g_rgRTLangMembers[LoadAssembly]);
+    prtClassDesc = &(g_rgRTLangClasses[prtMemberDesc->rtParent]);
+    pSym->GetClassTypeByName(prtClassDesc->wszClassName, nmCaseSensitive, &pClassField);
+
+Error:
+    return hr;
+}
+```
+
+## See Also
+[IDebugExpressionEvaluator2](../../../extensibility/debugger/reference/idebugexpressionevaluator2.md)

--- a/docs/extensibility/debugger/reference/idebugexpressionevaluator2-preloadmodules.md
+++ b/docs/extensibility/debugger/reference/idebugexpressionevaluator2-preloadmodules.md
@@ -19,13 +19,13 @@ Preloads the modules designated by the specified symbol provider.
 
 ```cpp
 HRESULT PreloadModules (
-   IDebugSymbolProvider* pSym
+    IDebugSymbolProvider* pSym
 );
 ```
 
 ```csharp
 int PreloadModules (
-   IDebugSymbolProvider pSym
+    IDebugSymbolProvider pSym
 );
 ```
 


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.