### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/idebugexpressionevaluator3-parse2.md
+++ b/docs/extensibility/debugger/reference/idebugexpressionevaluator3-parse2.md
@@ -2,131 +2,131 @@
 title: "IDebugExpressionEvaluator3::Parse2 | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "IDebugExpressionEvaluator3::Parse2"
 ms.assetid: 78099628-d600-4f76-b7c8-ee07c864af1e
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # IDebugExpressionEvaluator3::Parse2
-Converts an expression string to a parsed expression given the symbol provider and the address of the evaluating frame.  
-  
-## Syntax  
-  
-```cpp  
-HRESULT Parse2 (  
-   LPCOLESTR                upstrExpression,  
-   PARSEFLAGS               dwFlags,  
-   UINT                     nRadix,  
-   IDebugSymbolProvider*    pSymbolProvider,  
-   IDebugAddress*           pAddress,  
-   BSTR*                    pbstrError,  
-   UINT*                    pichError,  
-   IDebugParsedExpression** ppParsedExpression  
-);  
-```  
-  
-```csharp  
-HRESULT Parse2 (  
-   string                     upstrExpression,  
-   enum_PARSEFLAGS            dwFlags,  
-   uint                       nRadix,  
-   IDebugSymbolProvider       pSymbolProvider,  
-   IDebugAddress              pAddress,  
-   out string                 pbstrError,  
-   out uint                   pichError,  
-   out IDebugParsedExpression ppParsedExpression  
-);  
-```  
-  
-#### Parameters  
- `upstrExpression`  
- [in] The expression string to be parsed.  
-  
- `dwFlags`  
- [in] A collection of [PARSEFLAGS](../../../extensibility/debugger/reference/parseflags.md) constants that determine how the expression is to be parsed.  
-  
- `nRadix`  
- [in] Radix to be used to interpret any numerical information.  
-  
- `pSymbolProvider`  
- [in] Interface of the symbol provider.  
-  
- `pAddress`  
- [in] Address of the evaluating frame.  
-  
- `pbstrError`  
- [out] Returns the error as human-readable text.  
-  
- `pichError`  
- [out] Returns the character position of the start of the error in the expression string.  
-  
- `ppParsedExpression`  
- [out] Returns the parsed expression in an [IDebugParsedExpression](../../../extensibility/debugger/reference/idebugparsedexpression.md) object.  
-  
-## Return Value  
- If successful, returns `S_OK`; otherwise, returns an error code.  
-  
-## Remarks  
- This method produces a parsed expression, not an actual value. A parsed expression is ready to be evaluated, that is, converted to a value.  
-  
-## Example  
- The following example shows how to implement this method for a **CEE** object that exposes the [IDebugExpressionEvaluator3](../../../extensibility/debugger/reference/idebugexpressionevaluator3.md) interface.  
-  
-```cpp  
-HRESULT CEE::Parse2 ( LPCOLESTR in_szExprText,  
-  PARSEFLAGS in_FLAGS,  
-  UINT in_RADIX,  
-  IDebugSymbolProvider *pSymbolProvider,  
-  IDebugAddress *pAddress,  
-  BSTR* out_pbstrError,  
-  UINT* inout_pichError,  
-  IDebugParsedExpression** out_ppParsedExpression )  
-{  
-    // precondition  
-    REQUIRE( NULL != in_szExprText );  
-    //REQUIRE( NULL != out_pbstrError );  
-    REQUIRE( NULL != inout_pichError );  
-    REQUIRE( NULL != out_ppParsedExpression );  
-  
-    if (NULL == in_szExprText)  
-        return E_INVALIDARG;  
-  
-    if (NULL == inout_pichError)  
-        return E_POINTER;  
-  
-    if (NULL == out_ppParsedExpression)  
-        return E_POINTER;  
-  
-    if (out_pbstrError)  
-        *out_pbstrError = NULL;  
-  
-    *out_ppParsedExpression = NULL;  
-  
-    INVARIANT( this );  
-  
-    if (!this->ClassInvariant())  
-        return E_UNEXPECTED;  
-  
-    // function body  
-    EEDomain::fParseExpression DomainVal =  
-    {  
-        this,                   // CEE*  
-        in_szExprText,          // LPCOLESTR  
-        in_FLAGS,               // EVALFLAGS  
-        in_RADIX,               // RADIX  
-        out_pbstrError      ,   // BSTR*  
-        inout_pichError,        // UINT*  
-        pSymbolProvider,  
-        out_ppParsedExpression  // Output  
-    };  
-  
-    return (*m_LanguageSpecificUseCases.pfParseExpression)(DomainVal);  
-}  
-```  
-  
-## See Also  
- [IDebugExpressionEvaluator3](../../../extensibility/debugger/reference/idebugexpressionevaluator3.md)
+Converts an expression string to a parsed expression given the symbol provider and the address of the evaluating frame.
+
+## Syntax
+
+```cpp
+HRESULT Parse2 (
+   LPCOLESTR                upstrExpression,
+   PARSEFLAGS               dwFlags,
+   UINT                     nRadix,
+   IDebugSymbolProvider*    pSymbolProvider,
+   IDebugAddress*           pAddress,
+   BSTR*                    pbstrError,
+   UINT*                    pichError,
+   IDebugParsedExpression** ppParsedExpression
+);
+```
+
+```csharp
+HRESULT Parse2 (
+   string                     upstrExpression,
+   enum_PARSEFLAGS            dwFlags,
+   uint                       nRadix,
+   IDebugSymbolProvider       pSymbolProvider,
+   IDebugAddress              pAddress,
+   out string                 pbstrError,
+   out uint                   pichError,
+   out IDebugParsedExpression ppParsedExpression
+);
+```
+
+#### Parameters
+`upstrExpression`  
+[in] The expression string to be parsed.
+
+`dwFlags`  
+[in] A collection of [PARSEFLAGS](../../../extensibility/debugger/reference/parseflags.md) constants that determine how the expression is to be parsed.
+
+`nRadix`  
+[in] Radix to be used to interpret any numerical information.
+
+`pSymbolProvider`  
+[in] Interface of the symbol provider.
+
+`pAddress`  
+[in] Address of the evaluating frame.
+
+`pbstrError`  
+[out] Returns the error as human-readable text.
+
+`pichError`  
+[out] Returns the character position of the start of the error in the expression string.
+
+`ppParsedExpression`  
+[out] Returns the parsed expression in an [IDebugParsedExpression](../../../extensibility/debugger/reference/idebugparsedexpression.md) object.
+
+## Return Value
+If successful, returns `S_OK`; otherwise, returns an error code.
+
+## Remarks
+This method produces a parsed expression, not an actual value. A parsed expression is ready to be evaluated, that is, converted to a value.
+
+## Example
+The following example shows how to implement this method for a **CEE** object that exposes the [IDebugExpressionEvaluator3](../../../extensibility/debugger/reference/idebugexpressionevaluator3.md) interface.
+
+```cpp
+HRESULT CEE::Parse2 ( LPCOLESTR in_szExprText,
+  PARSEFLAGS in_FLAGS,
+  UINT in_RADIX,
+  IDebugSymbolProvider *pSymbolProvider,
+  IDebugAddress *pAddress,
+  BSTR* out_pbstrError,
+  UINT* inout_pichError,
+  IDebugParsedExpression** out_ppParsedExpression )
+{
+    // precondition
+    REQUIRE( NULL != in_szExprText );
+    //REQUIRE( NULL != out_pbstrError );
+    REQUIRE( NULL != inout_pichError );
+    REQUIRE( NULL != out_ppParsedExpression );
+
+    if (NULL == in_szExprText)
+        return E_INVALIDARG;
+
+    if (NULL == inout_pichError)
+        return E_POINTER;
+
+    if (NULL == out_ppParsedExpression)
+        return E_POINTER;
+
+    if (out_pbstrError)
+        *out_pbstrError = NULL;
+
+    *out_ppParsedExpression = NULL;
+
+    INVARIANT( this );
+
+    if (!this->ClassInvariant())
+        return E_UNEXPECTED;
+
+    // function body
+    EEDomain::fParseExpression DomainVal =
+    {
+        this,                   // CEE*
+        in_szExprText,          // LPCOLESTR
+        in_FLAGS,               // EVALFLAGS
+        in_RADIX,               // RADIX
+        out_pbstrError      ,   // BSTR*
+        inout_pichError,        // UINT*
+        pSymbolProvider,
+        out_ppParsedExpression  // Output
+    };
+
+    return (*m_LanguageSpecificUseCases.pfParseExpression)(DomainVal);
+}
+```
+
+## See Also
+[IDebugExpressionEvaluator3](../../../extensibility/debugger/reference/idebugexpressionevaluator3.md)

--- a/docs/extensibility/debugger/reference/idebugexpressionevaluator3-parse2.md
+++ b/docs/extensibility/debugger/reference/idebugexpressionevaluator3-parse2.md
@@ -18,27 +18,27 @@ Converts an expression string to a parsed expression given the symbol provider a
 
 ```cpp
 HRESULT Parse2 (
-   LPCOLESTR                upstrExpression,
-   PARSEFLAGS               dwFlags,
-   UINT                     nRadix,
-   IDebugSymbolProvider*    pSymbolProvider,
-   IDebugAddress*           pAddress,
-   BSTR*                    pbstrError,
-   UINT*                    pichError,
-   IDebugParsedExpression** ppParsedExpression
+    LPCOLESTR                upstrExpression,
+    PARSEFLAGS               dwFlags,
+    UINT                     nRadix,
+    IDebugSymbolProvider*    pSymbolProvider,
+    IDebugAddress*           pAddress,
+    BSTR*                    pbstrError,
+    UINT*                    pichError,
+    IDebugParsedExpression** ppParsedExpression
 );
 ```
 
 ```csharp
 HRESULT Parse2 (
-   string                     upstrExpression,
-   enum_PARSEFLAGS            dwFlags,
-   uint                       nRadix,
-   IDebugSymbolProvider       pSymbolProvider,
-   IDebugAddress              pAddress,
-   out string                 pbstrError,
-   out uint                   pichError,
-   out IDebugParsedExpression ppParsedExpression
+    string                     upstrExpression,
+    enum_PARSEFLAGS            dwFlags,
+    uint                       nRadix,
+    IDebugSymbolProvider       pSymbolProvider,
+    IDebugAddress              pAddress,
+    out string                 pbstrError,
+    out uint                   pichError,
+    out IDebugParsedExpression ppParsedExpression
 );
 ```
 
@@ -118,7 +118,7 @@ HRESULT CEE::Parse2 ( LPCOLESTR in_szExprText,
         in_szExprText,          // LPCOLESTR
         in_FLAGS,               // EVALFLAGS
         in_RADIX,               // RADIX
-        out_pbstrError      ,   // BSTR*
+        out_pbstrError,         // BSTR*
         inout_pichError,        // UINT*
         pSymbolProvider,
         out_ppParsedExpression  // Output


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.