### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/idebuggenericparamfield-constraintcount.md
+++ b/docs/extensibility/debugger/reference/idebuggenericparamfield-constraintcount.md
@@ -2,75 +2,75 @@
 title: "IDebugGenericParamField::ConstraintCount | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "ConstraintCount"
   - "IDebugGenericParamField::ConstraintCount"
 ms.assetid: 76bef0cb-8a3c-4ce5-87cc-1809de229f33
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # IDebugGenericParamField::ConstraintCount
-Returns the number of constraints that are associated with this generic parameter.  
-  
-## Syntax  
-  
-```cpp  
-HRESULT ConstraintCount(  
-   ULONG32* pcConst  
-);  
-```  
-  
-```csharp  
-int ConstraintCount(  
-   ref uint pcConst  
-);  
-```  
-  
-#### Parameters  
- `pcConst`  
- [in, out] Number of constraints that are associated with this field.  
-  
-## Return Value  
- If successful, returns `S_OK`; otherwise, returns an error code.  
-  
-## Example  
- The following example shows how to implement this method for a **CDebugGenericParamFieldType** object that exposes the [IDebugGenericParamField](../../../extensibility/debugger/reference/idebuggenericparamfield.md) interface.  
-  
-```cpp  
-HRESULT CDebugGenericParamFieldType::ConstraintCount(ULONG32* pcConst)  
-{  
-    HRESULT hr = S_OK;  
-    CComPtr<IMetaDataImport> pMetadata;  
-    CComPtr<IMetaDataImport2> pMetadata2;  
-    HCORENUM hEnum = 0;  
-    ULONG cConst = 0;  
-  
-    METHOD_ENTRY( CDebugGenericParamFieldType::ConstraintCount );  
-  
-    IfFalseGo(pcConst, E_INVALIDARG );  
-    *pcConst = 0;  
-    IfFailGo( m_spSH->GetMetadata( m_idModule, &pMetadata ) );  
-    IfFailGo( pMetadata->QueryInterface(IID_IMetaDataImport2, (void**)&pMetadata2) );  
-    IfFailGo( pMetadata2->EnumGenericParamConstraints( &hEnum,  
-              m_tokParam,  
-              NULL,  
-              0,  
-              &cConst) );  
-    IfFailGo( pMetadata->CountEnum(hEnum, &cConst) );  
-    pMetadata->CloseEnum(hEnum);  
-    hEnum = NULL;  
-  
-    *pcConst = cConst;  
-  
-Error:  
-  
-    METHOD_EXIT( CDebugGenericParamFieldType::ConstraintCount, hr );  
-    return hr;  
-}  
-```  
-  
-## See Also  
- [IDebugGenericParamField](../../../extensibility/debugger/reference/idebuggenericparamfield.md)
+Returns the number of constraints that are associated with this generic parameter.
+
+## Syntax
+
+```cpp
+HRESULT ConstraintCount(
+   ULONG32* pcConst
+);
+```
+
+```csharp
+int ConstraintCount(
+   ref uint pcConst
+);
+```
+
+#### Parameters
+`pcConst`  
+[in, out] Number of constraints that are associated with this field.
+
+## Return Value
+If successful, returns `S_OK`; otherwise, returns an error code.
+
+## Example
+The following example shows how to implement this method for a **CDebugGenericParamFieldType** object that exposes the [IDebugGenericParamField](../../../extensibility/debugger/reference/idebuggenericparamfield.md) interface.
+
+```cpp
+HRESULT CDebugGenericParamFieldType::ConstraintCount(ULONG32* pcConst)
+{
+    HRESULT hr = S_OK;
+    CComPtr<IMetaDataImport> pMetadata;
+    CComPtr<IMetaDataImport2> pMetadata2;
+    HCORENUM hEnum = 0;
+    ULONG cConst = 0;
+
+    METHOD_ENTRY( CDebugGenericParamFieldType::ConstraintCount );
+
+    IfFalseGo(pcConst, E_INVALIDARG );
+    *pcConst = 0;
+    IfFailGo( m_spSH->GetMetadata( m_idModule, &pMetadata ) );
+    IfFailGo( pMetadata->QueryInterface(IID_IMetaDataImport2, (void**)&pMetadata2) );
+    IfFailGo( pMetadata2->EnumGenericParamConstraints( &hEnum,
+              m_tokParam,
+              NULL,
+              0,
+              &cConst) );
+    IfFailGo( pMetadata->CountEnum(hEnum, &cConst) );
+    pMetadata->CloseEnum(hEnum);
+    hEnum = NULL;
+
+    *pcConst = cConst;
+
+Error:
+
+    METHOD_EXIT( CDebugGenericParamFieldType::ConstraintCount, hr );
+    return hr;
+}
+```
+
+## See Also
+[IDebugGenericParamField](../../../extensibility/debugger/reference/idebuggenericparamfield.md)

--- a/docs/extensibility/debugger/reference/idebuggenericparamfield-constraintcount.md
+++ b/docs/extensibility/debugger/reference/idebuggenericparamfield-constraintcount.md
@@ -19,13 +19,13 @@ Returns the number of constraints that are associated with this generic paramete
 
 ```cpp
 HRESULT ConstraintCount(
-   ULONG32* pcConst
+    ULONG32* pcConst
 );
 ```
 
 ```csharp
 int ConstraintCount(
-   ref uint pcConst
+    ref uint pcConst
 );
 ```
 


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.