### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/idebuggenericparamfield-getconstraints.md
+++ b/docs/extensibility/debugger/reference/idebuggenericparamfield-getconstraints.md
@@ -2,145 +2,145 @@
 title: "IDebugGenericParamField::GetConstraints | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "IDebugGenericParamField::GetConstraints"
   - "GetConstraints"
 ms.assetid: 86a78b5a-ee0f-4999-a0ba-919d3dc7d969
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # IDebugGenericParamField::GetConstraints
-Retrieves the constraints that are associated with this generic parameter.  
-  
-## Syntax  
-  
-```cpp  
-HRESULT GetConstraints(  
-   ULONG32       cConstraints,  
-   IDebugField** ppConstraints,  
-   ULONG32*      pcConstraints  
-);  
-```  
-  
-```csharp  
-int GetConstraints(  
-   uint              cConstraints,  
-   out IDebugField[] ppConstraints,  
-   ref uint          pcConstraints  
-);  
-```  
-  
-#### Parameters  
- `cConstraints`  
- [in] Number of constraints.  
-  
- `ppConstraints`  
- [out] Returns an array that contains the constraints associated with this field.  
-  
- `pcConstraints`  
- [in, out] Number of constraints in the `ppConstraints` array.  
-  
-## Return Value  
- If successful, returns `S_OK`; otherwise, returns an error code.  
-  
-## Example  
- The following example shows how to implement this method for a **CDebugGenericParamFieldType** object that exposes the [IDebugGenericParamField](../../../extensibility/debugger/reference/idebuggenericparamfield.md) interface.  
-  
-```cpp  
-HRESULT CDebugGenericParamFieldType::GetConstraints(  
-    ULONG32 cConstraints,  
-    IDebugField** ppConstraints,  
-    ULONG32* pcConstraints)  
-{  
-    HRESULT hr = S_OK;  
-    CComPtr<IMetaDataImport> pMetadata;  
-    CComPtr<IMetaDataImport2> pMetadata2;  
-    mdGenericParamConstraint* rgParamConsts = NULL;  
-    HCORENUM hEnum = 0;  
-    ULONG cConst = 0;  
-    ULONG iConst;  
-    ULONG iConstOut = 0;  
-  
-    METHOD_ENTRY( CDebugGenericParamFieldType::GetConstraints );  
-  
-    IfFalseGo(ppConstraints && pcConstraints, E_INVALIDARG );  
-    *pcConstraints = 0;  
-  
-    IfNullGo( rgParamConsts = new mdGenericParamConstraint[cConstraints], E_OUTOFMEMORY);  
-  
-    IfFailGo( m_spSH->GetMetadata( m_idModule, &pMetadata ) );  
-    IfFailGo( pMetadata->QueryInterface(IID_IMetaDataImport2, (void**)&pMetadata2) );  
-    IfFailGo( pMetadata2->EnumGenericParamConstraints( &hEnum,  
-              m_tokParam,  
-              rgParamConsts,  
-              cConstraints,  
-              &cConst) );  
-    pMetadata->CloseEnum(hEnum);  
-    hEnum = NULL;  
-  
-    for (iConst = 0; iConst < cConst; iConst++)  
-    {  
-        mdToken tokConst;  
-  
-        IfFailGo( pMetadata2->GetGenericParamConstraintProps( rgParamConsts[iConst],  
-                  NULL,  
-                  &tokConst ) );  
-        switch (TypeFromToken(tokConst))  
-        {  
-            case mdtTypeRef:  
-                {  
-                    Module_ID mid;  
-                    mdTypeDef tokClass;  
-  
-                    IfFailGo( CDebugClassFieldType::GetClassToken(m_spSH, m_idModule, tokConst, &mid, &tokClass) );  
-                    IfFailGo( m_spSH->CreateClassType( mid, tokClass, ppConstraints + iConstOut ) );  
-                    iConstOut++;  
-                    break;  
-                }  
-            case mdtTypeDef:  
-                {  
-                    IfFailGo( m_spSH->CreateClassType( m_idModule, tokConst, ppConstraints + iConstOut ) );  
-                    iConstOut++;  
-                    break;  
-                }  
-            case mdtTypeSpec:  
-                {  
-                    PCCOR_SIGNATURE pvSig;  
-                    ULONG cbSig;  
-                    DWORD cb = 0;  
-                    DWORD dwElementType;  
-  
-                    IfFailGo( pMetadata2->GetTypeSpecFromToken( tokConst, &pvSig, &cbSig) );  
-  
-                    cb += CorSigUncompressData(&(pvSig[cb]), &dwElementType);  
-  
-                    IfFailGo( m_spSH->CreateType( pvSig, cbSig, m_idModule, mdMethodDefNil, m_pGenScope, ppConstraints + iConstOut ) );  
-  
-                    iConstOut++;  
-  
-                    break;  
-                }  
-            default:  
-                {  
-                    ASSERT(!"Bad constraint token");  
-                }  
-        }  
-    }  
-  
-    *pcConstraints = iConstOut;  
-  
-Error:  
-  
-    METHOD_EXIT( CDebugGenericParamFieldType::GetConstraints, hr );  
-  
-    DELETERG(rgParamConsts);  
-  
-    return hr;  
-}  
-```  
-  
-## See Also  
- [IDebugGenericParamField](../../../extensibility/debugger/reference/idebuggenericparamfield.md)
+Retrieves the constraints that are associated with this generic parameter.
+
+## Syntax
+
+```cpp
+HRESULT GetConstraints(
+   ULONG32       cConstraints,
+   IDebugField** ppConstraints,
+   ULONG32*      pcConstraints
+);
+```
+
+```csharp
+int GetConstraints(
+   uint              cConstraints,
+   out IDebugField[] ppConstraints,
+   ref uint          pcConstraints
+);
+```
+
+#### Parameters
+`cConstraints`  
+[in] Number of constraints.
+
+`ppConstraints`  
+[out] Returns an array that contains the constraints associated with this field.
+
+`pcConstraints`  
+[in, out] Number of constraints in the `ppConstraints` array.
+
+## Return Value
+If successful, returns `S_OK`; otherwise, returns an error code.
+
+## Example
+The following example shows how to implement this method for a **CDebugGenericParamFieldType** object that exposes the [IDebugGenericParamField](../../../extensibility/debugger/reference/idebuggenericparamfield.md) interface.
+
+```cpp
+HRESULT CDebugGenericParamFieldType::GetConstraints(
+    ULONG32 cConstraints,
+    IDebugField** ppConstraints,
+    ULONG32* pcConstraints)
+{
+    HRESULT hr = S_OK;
+    CComPtr<IMetaDataImport> pMetadata;
+    CComPtr<IMetaDataImport2> pMetadata2;
+    mdGenericParamConstraint* rgParamConsts = NULL;
+    HCORENUM hEnum = 0;
+    ULONG cConst = 0;
+    ULONG iConst;
+    ULONG iConstOut = 0;
+
+    METHOD_ENTRY( CDebugGenericParamFieldType::GetConstraints );
+
+    IfFalseGo(ppConstraints && pcConstraints, E_INVALIDARG );
+    *pcConstraints = 0;
+
+    IfNullGo( rgParamConsts = new mdGenericParamConstraint[cConstraints], E_OUTOFMEMORY);
+
+    IfFailGo( m_spSH->GetMetadata( m_idModule, &pMetadata ) );
+    IfFailGo( pMetadata->QueryInterface(IID_IMetaDataImport2, (void**)&pMetadata2) );
+    IfFailGo( pMetadata2->EnumGenericParamConstraints( &hEnum,
+              m_tokParam,
+              rgParamConsts,
+              cConstraints,
+              &cConst) );
+    pMetadata->CloseEnum(hEnum);
+    hEnum = NULL;
+
+    for (iConst = 0; iConst < cConst; iConst++)
+    {
+        mdToken tokConst;
+
+        IfFailGo( pMetadata2->GetGenericParamConstraintProps( rgParamConsts[iConst],
+                  NULL,
+                  &tokConst ) );
+        switch (TypeFromToken(tokConst))
+        {
+            case mdtTypeRef:
+                {
+                    Module_ID mid;
+                    mdTypeDef tokClass;
+
+                    IfFailGo( CDebugClassFieldType::GetClassToken(m_spSH, m_idModule, tokConst, &mid, &tokClass) );
+                    IfFailGo( m_spSH->CreateClassType( mid, tokClass, ppConstraints + iConstOut ) );
+                    iConstOut++;
+                    break;
+                }
+            case mdtTypeDef:
+                {
+                    IfFailGo( m_spSH->CreateClassType( m_idModule, tokConst, ppConstraints + iConstOut ) );
+                    iConstOut++;
+                    break;
+                }
+            case mdtTypeSpec:
+                {
+                    PCCOR_SIGNATURE pvSig;
+                    ULONG cbSig;
+                    DWORD cb = 0;
+                    DWORD dwElementType;
+
+                    IfFailGo( pMetadata2->GetTypeSpecFromToken( tokConst, &pvSig, &cbSig) );
+
+                    cb += CorSigUncompressData(&(pvSig[cb]), &dwElementType);
+
+                    IfFailGo( m_spSH->CreateType( pvSig, cbSig, m_idModule, mdMethodDefNil, m_pGenScope, ppConstraints + iConstOut ) );
+
+                    iConstOut++;
+
+                    break;
+                }
+            default:
+                {
+                    ASSERT(!"Bad constraint token");
+                }
+        }
+    }
+
+    *pcConstraints = iConstOut;
+
+Error:
+
+    METHOD_EXIT( CDebugGenericParamFieldType::GetConstraints, hr );
+
+    DELETERG(rgParamConsts);
+
+    return hr;
+}
+```
+
+## See Also
+[IDebugGenericParamField](../../../extensibility/debugger/reference/idebuggenericparamfield.md)

--- a/docs/extensibility/debugger/reference/idebuggenericparamfield-getconstraints.md
+++ b/docs/extensibility/debugger/reference/idebuggenericparamfield-getconstraints.md
@@ -19,17 +19,17 @@ Retrieves the constraints that are associated with this generic parameter.
 
 ```cpp
 HRESULT GetConstraints(
-   ULONG32       cConstraints,
-   IDebugField** ppConstraints,
-   ULONG32*      pcConstraints
+    ULONG32       cConstraints,
+    IDebugField** ppConstraints,
+    ULONG32*      pcConstraints
 );
 ```
 
 ```csharp
 int GetConstraints(
-   uint              cConstraints,
-   out IDebugField[] ppConstraints,
-   ref uint          pcConstraints
+    uint              cConstraints,
+    out IDebugField[] ppConstraints,
+    ref uint          pcConstraints
 );
 ```
 


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.