### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/idebuggenericparamfield-getflags.md
+++ b/docs/extensibility/debugger/reference/idebuggenericparamfield-getflags.md
@@ -2,63 +2,63 @@
 title: "IDebugGenericParamField::GetFlags | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "GetFlags"
   - "IDebugGenericParamField::GetFlags"
 ms.assetid: adcbbca1-8960-4c88-86b0-8b9467056c97
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # IDebugGenericParamField::GetFlags
-Retrieves the flags for this generic parameter.  
-  
-## Syntax  
-  
-```cpp  
-HRESULT GetFlags(  
-   DWORD* pdwFlags  
-);  
-```  
-  
-```csharp  
-int GetFlags(  
-   ref uint pdwFlags  
-);  
-```  
-  
-#### Parameters  
- `pdwFlags`  
- [out] Returns the flags for this generic parameter.  
-  
-## Return Value  
- If successful, returns `S_OK`; otherwise, returns an error code.  
-  
-## Remarks  
- These flags contain information about various special constraints.  
-  
-## Example  
- The following example shows how to implement this method for a **CDebugGenericParamFieldType** object that exposes the [IDebugGenericParamField](../../../extensibility/debugger/reference/idebuggenericparamfield.md) interface.  
-  
-```cpp  
-HRESULT CDebugGenericParamFieldType::GetFlags(DWORD *pdwFlags)  
-{  
-    HRESULT hr = S_OK;  
-  
-    METHOD_ENTRY( CDebugGenericParamFieldType::GetFlags );  
-  
-    IfFalseGo( pdwFlags, E_INVALIDARG );  
-    IfFailGo( this->LoadProps() );  
-    *pdwFlags = m_dwFlags;  
-  
-Error:  
-  
-    METHOD_EXIT( CDebugGenericParamFieldType::GetFlags, hr );  
-    return hr;  
-}  
-```  
-  
-## See Also  
- [IDebugGenericParamField](../../../extensibility/debugger/reference/idebuggenericparamfield.md)
+Retrieves the flags for this generic parameter.
+
+## Syntax
+
+```cpp
+HRESULT GetFlags(
+   DWORD* pdwFlags
+);
+```
+
+```csharp
+int GetFlags(
+   ref uint pdwFlags
+);
+```
+
+#### Parameters
+`pdwFlags`  
+[out] Returns the flags for this generic parameter.
+
+## Return Value
+If successful, returns `S_OK`; otherwise, returns an error code.
+
+## Remarks
+These flags contain information about various special constraints.
+
+## Example
+The following example shows how to implement this method for a **CDebugGenericParamFieldType** object that exposes the [IDebugGenericParamField](../../../extensibility/debugger/reference/idebuggenericparamfield.md) interface.
+
+```cpp
+HRESULT CDebugGenericParamFieldType::GetFlags(DWORD *pdwFlags)
+{
+    HRESULT hr = S_OK;
+
+    METHOD_ENTRY( CDebugGenericParamFieldType::GetFlags );
+
+    IfFalseGo( pdwFlags, E_INVALIDARG );
+    IfFailGo( this->LoadProps() );
+    *pdwFlags = m_dwFlags;
+
+Error:
+
+    METHOD_EXIT( CDebugGenericParamFieldType::GetFlags, hr );
+    return hr;
+}
+```
+
+## See Also
+[IDebugGenericParamField](../../../extensibility/debugger/reference/idebuggenericparamfield.md)

--- a/docs/extensibility/debugger/reference/idebuggenericparamfield-getflags.md
+++ b/docs/extensibility/debugger/reference/idebuggenericparamfield-getflags.md
@@ -19,13 +19,13 @@ Retrieves the flags for this generic parameter.
 
 ```cpp
 HRESULT GetFlags(
-   DWORD* pdwFlags
+    DWORD* pdwFlags
 );
 ```
 
 ```csharp
 int GetFlags(
-   ref uint pdwFlags
+    ref uint pdwFlags
 );
 ```
 


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.