### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/idebuggenericparamfield-getindex.md
+++ b/docs/extensibility/debugger/reference/idebuggenericparamfield-getindex.md
@@ -2,62 +2,62 @@
 title: "IDebugGenericParamField::GetIndex | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "IDebugGenericParamField::GetIndex"
 ms.assetid: 8e0bdb26-1247-44d9-8d80-ec6e35187fb4
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # IDebugGenericParamField::GetIndex
-Retrieves the index of this generic parameter.  
-  
-## Syntax  
-  
-```cpp  
-HRESULT GetIndex(  
-   DWORD* pIndex  
-);  
-```  
-  
-```csharp  
-int GetIndex(  
-   out uint pIndex  
-);  
-```  
-  
-#### Parameters  
- `pIndex`  
- [out] Index value of this generic parameter.  
-  
-## Return Value  
- If successful, returns `S_OK`; otherwise, returns an error code.  
-  
-## Remarks  
- For example, for Dictionary(K,V), K is index 0, V is index 1.  
-  
-## Example  
- The following example shows how to implement this method for a **CDebugGenericParamFieldType** object that exposes the [IDebugGenericParamField](../../../extensibility/debugger/reference/idebuggenericparamfield.md) interface.  
-  
-```cpp  
-HRESULT CDebugGenericParamFieldType::GetIndex(DWORD* pIndex)  
-{  
-    HRESULT hr = S_OK;  
-  
-    METHOD_ENTRY( CDebugGenericParamFieldType::GetIndex );  
-  
-    IfFalseGo(pIndex, E_INVALIDARG );  
-    IfFailGo( this->LoadProps() );  
-    *pIndex = m_index;  
-  
-Error:  
-  
-    METHOD_EXIT( CDebugGenericParamFieldType::GetIndex, hr );  
-    return hr;  
-}  
-```  
-  
-## See Also  
- [IDebugGenericParamField](../../../extensibility/debugger/reference/idebuggenericparamfield.md)
+Retrieves the index of this generic parameter.
+
+## Syntax
+
+```cpp
+HRESULT GetIndex(
+   DWORD* pIndex
+);
+```
+
+```csharp
+int GetIndex(
+   out uint pIndex
+);
+```
+
+#### Parameters
+`pIndex`  
+[out] Index value of this generic parameter.
+
+## Return Value
+If successful, returns `S_OK`; otherwise, returns an error code.
+
+## Remarks
+For example, for Dictionary(K,V), K is index 0, V is index 1.
+
+## Example
+The following example shows how to implement this method for a **CDebugGenericParamFieldType** object that exposes the [IDebugGenericParamField](../../../extensibility/debugger/reference/idebuggenericparamfield.md) interface.
+
+```cpp
+HRESULT CDebugGenericParamFieldType::GetIndex(DWORD* pIndex)
+{
+    HRESULT hr = S_OK;
+
+    METHOD_ENTRY( CDebugGenericParamFieldType::GetIndex );
+
+    IfFalseGo(pIndex, E_INVALIDARG );
+    IfFailGo( this->LoadProps() );
+    *pIndex = m_index;
+
+Error:
+
+    METHOD_EXIT( CDebugGenericParamFieldType::GetIndex, hr );
+    return hr;
+}
+```
+
+## See Also
+[IDebugGenericParamField](../../../extensibility/debugger/reference/idebuggenericparamfield.md)

--- a/docs/extensibility/debugger/reference/idebuggenericparamfield-getindex.md
+++ b/docs/extensibility/debugger/reference/idebuggenericparamfield-getindex.md
@@ -18,13 +18,13 @@ Retrieves the index of this generic parameter.
 
 ```cpp
 HRESULT GetIndex(
-   DWORD* pIndex
+    DWORD* pIndex
 );
 ```
 
 ```csharp
 int GetIndex(
-   out uint pIndex
+    out uint pIndex
 );
 ```
 


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.