### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/idebuggenericparamfield-getnameofformalparam.md
+++ b/docs/extensibility/debugger/reference/idebuggenericparamfield-getnameofformalparam.md
@@ -19,18 +19,18 @@ Retrieves the name of this generic parameter.
 
 ```cpp
 HRESULT GetNameOfFormalParam (
-   BSTR* pbstrName
+    BSTR* pbstrName
 );
 ```
 
 ```csharp
 int GetNameOfFormalParam (
-   string pbstrName
+    string pbstrName
 );
 ```
 
 #### Parameters
-`pbstrName`
+`pbstrName`  
 [out] Name of this generic parameter.
 
 ## Return Value

--- a/docs/extensibility/debugger/reference/idebuggenericparamfield-getnameofformalparam.md
+++ b/docs/extensibility/debugger/reference/idebuggenericparamfield-getnameofformalparam.md
@@ -2,61 +2,61 @@
 title: "IDebugGenericParamField::GetNameOfFormalParam | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "IDebugGenericParamField::GetNameOfFormalParam"
   - "GetNameOfFormalParam"
 ms.assetid: 05032a83-49ce-4007-b5d6-7b56945b956c
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # IDebugGenericParamField::GetNameOfFormalParam
-Retrieves the name of this generic parameter.  
-  
-## Syntax  
-  
-```cpp  
-HRESULT GetNameOfFormalParam (  
-   BSTR* pbstrName  
-);  
-```  
-  
-```csharp  
-int GetNameOfFormalParam (  
-   string pbstrName  
-);  
-```  
-  
-#### Parameters  
- `pbstrName`  
- [out] Name of this generic parameter.  
-  
-## Return Value  
- If successful, returns `S_OK`; otherwise, returns an error code.  
-  
-## Example  
- The following example shows how to implement this method for a **CDebugGenericParamFieldType** object that exposes the [IDebugGenericParamField](../../../extensibility/debugger/reference/idebuggenericparamfield.md) interface.  
-  
-```cpp  
-HRESULT CDebugGenericParamFieldType::GetNameOfFormalParam(BSTR *pbstrName)  
-{  
-    HRESULT hr = S_OK;  
-    CComBSTR bstrName;  
-  
-    METHOD_ENTRY( CDebugGenericParamFieldType::GetNameOfFormalParam );  
-  
-    IfFalseGo( pbstrName, E_INVALIDARG );  
-    IfFailGo( this->LoadProps() );  
-    IfNullGo( *pbstrName = SysAllocString(m_bstrName), E_OUTOFMEMORY );  
-  
-Error:  
-  
-    METHOD_EXIT( CDebugGenericParamFieldType::GetNameOfFormalParam, hr );  
-    return hr;  
-}  
-```  
-  
-## See Also  
- [IDebugGenericParamField](../../../extensibility/debugger/reference/idebuggenericparamfield.md)
+Retrieves the name of this generic parameter.
+
+## Syntax
+
+```cpp
+HRESULT GetNameOfFormalParam (
+   BSTR* pbstrName
+);
+```
+
+```csharp
+int GetNameOfFormalParam (
+   string pbstrName
+);
+```
+
+#### Parameters
+`pbstrName`
+[out] Name of this generic parameter.
+
+## Return Value
+If successful, returns `S_OK`; otherwise, returns an error code.
+
+## Example
+The following example shows how to implement this method for a **CDebugGenericParamFieldType** object that exposes the [IDebugGenericParamField](../../../extensibility/debugger/reference/idebuggenericparamfield.md) interface.
+
+```cpp
+HRESULT CDebugGenericParamFieldType::GetNameOfFormalParam(BSTR *pbstrName)
+{
+    HRESULT hr = S_OK;
+    CComBSTR bstrName;
+
+    METHOD_ENTRY( CDebugGenericParamFieldType::GetNameOfFormalParam );
+
+    IfFalseGo( pbstrName, E_INVALIDARG );
+    IfFailGo( this->LoadProps() );
+    IfNullGo( *pbstrName = SysAllocString(m_bstrName), E_OUTOFMEMORY );
+
+Error:
+
+    METHOD_EXIT( CDebugGenericParamFieldType::GetNameOfFormalParam, hr );
+    return hr;
+}
+```
+
+## See Also
+[IDebugGenericParamField](../../../extensibility/debugger/reference/idebuggenericparamfield.md)


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.