### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/idebuggenericparamfield-getowner.md
+++ b/docs/extensibility/debugger/reference/idebuggenericparamfield-getowner.md
@@ -2,89 +2,89 @@
 title: "IDebugGenericParamField::GetOwner | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "IDebugGenericParamField::GetOwner"
 ms.assetid: c7f6d166-a69e-40c4-bd0b-1a1fdf9aaacf
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # IDebugGenericParamField::GetOwner
-Retrieves the type or method owner of this generic parameter.  
-  
-## Syntax  
-  
-```cpp  
-HRESULT GetOwner(  
-   IDebugField** ppOwner  
-);  
-```  
-  
-```csharp  
-int GetOwner(  
-   out IDebugField ppOwner  
-);  
-```  
-  
-#### Parameters  
- `ppOwner`  
- [out] Returns the [IDebugField](../../../extensibility/debugger/reference/idebugfield.md) object that owns this generic parameter.  
-  
-## Return Value  
- If successful, returns `S_OK`; otherwise, returns an error code.  
-  
-## Example  
- The following example shows how to implement this method for a **CDebugGenericParamFieldType** object that exposes the [IDebugGenericParamField](../../../extensibility/debugger/reference/idebuggenericparamfield.md) interface.  
-  
-```cpp  
-HRESULT CDebugGenericParamFieldType::GetOwner(IDebugField** ppOwner)  
-{  
-    HRESULT hr = S_OK;  
-    CComPtr<IMetaDataImport> pMetadata;  
-  
-    METHOD_ENTRY( CDebugGenericParamFieldType::GetOwner );  
-  
-    IfFalseGo(ppOwner, E_INVALIDARG );  
-    *ppOwner = NULL;  
-  
-    IfFailGo( this->LoadProps() );  
-    IfFailGo( m_spSH->GetMetadata( m_idModule, &pMetadata ) );  
-  
-    switch (TypeFromToken(m_tokOwner))  
-    {  
-        case mdtMethodDef:  
-            {  
-                mdTypeDef tokClass;  
-                CComPtr<IDebugField> pClass;  
-                CDEBUG_ADDRESS caddr;  
-                CComPtr<IDebugContainerField> pContainer;  
-  
-                IfFailGo( pMetadata->GetMethodProps( m_tokOwner, &tokClass, NULL, 0, NULL, NULL, NULL, NULL, NULL, NULL ) );  
-                IfFailGo( m_spSH->CreateClassType(m_idModule, tokClass, &pClass) );  
-                IfFailGo( pClass->QueryInterface( &pContainer ) );  
-                IfFailGo( caddr.InitializeMethod( m_idModule, tokClass, m_tokOwner, 0, 0 ) );  
-                IfFailGo( m_spSH->CreateMethodSymbol( pContainer, caddr, FIELD_SYM_MEMBER, ppOwner ) );  
-                break;  
-            }  
-        case mdtTypeDef:  
-            {  
-                IfFailGo( m_spSH->CreateClassType(m_idModule, m_tokOwner, ppOwner) );  
-                break;  
-            }  
-        default:  
-            {  
-                ASSERT(!"Unexpected Owner type for Generic Param Field");  
-                hr = E_FAIL;  
-            }  
-    }  
-Error:  
-  
-    METHOD_EXIT( CDebugGenericParamFieldType::GetOwner, hr );  
-    return hr;  
-}  
-```  
-  
-## See Also  
- [IDebugGenericParamField](../../../extensibility/debugger/reference/idebuggenericparamfield.md)
+Retrieves the type or method owner of this generic parameter.
+
+## Syntax
+
+```cpp
+HRESULT GetOwner(
+   IDebugField** ppOwner
+);
+```
+
+```csharp
+int GetOwner(
+   out IDebugField ppOwner
+);
+```
+
+#### Parameters
+`ppOwner`  
+[out] Returns the [IDebugField](../../../extensibility/debugger/reference/idebugfield.md) object that owns this generic parameter.
+
+## Return Value
+If successful, returns `S_OK`; otherwise, returns an error code.
+
+## Example
+The following example shows how to implement this method for a **CDebugGenericParamFieldType** object that exposes the [IDebugGenericParamField](../../../extensibility/debugger/reference/idebuggenericparamfield.md) interface.
+
+```cpp
+HRESULT CDebugGenericParamFieldType::GetOwner(IDebugField** ppOwner)
+{
+    HRESULT hr = S_OK;
+    CComPtr<IMetaDataImport> pMetadata;
+
+    METHOD_ENTRY( CDebugGenericParamFieldType::GetOwner );
+
+    IfFalseGo(ppOwner, E_INVALIDARG );
+    *ppOwner = NULL;
+
+    IfFailGo( this->LoadProps() );
+    IfFailGo( m_spSH->GetMetadata( m_idModule, &pMetadata ) );
+
+    switch (TypeFromToken(m_tokOwner))
+    {
+        case mdtMethodDef:
+            {
+                mdTypeDef tokClass;
+                CComPtr<IDebugField> pClass;
+                CDEBUG_ADDRESS caddr;
+                CComPtr<IDebugContainerField> pContainer;
+
+                IfFailGo( pMetadata->GetMethodProps( m_tokOwner, &tokClass, NULL, 0, NULL, NULL, NULL, NULL, NULL, NULL ) );
+                IfFailGo( m_spSH->CreateClassType(m_idModule, tokClass, &pClass) );
+                IfFailGo( pClass->QueryInterface( &pContainer ) );
+                IfFailGo( caddr.InitializeMethod( m_idModule, tokClass, m_tokOwner, 0, 0 ) );
+                IfFailGo( m_spSH->CreateMethodSymbol( pContainer, caddr, FIELD_SYM_MEMBER, ppOwner ) );
+                break;
+            }
+        case mdtTypeDef:
+            {
+                IfFailGo( m_spSH->CreateClassType(m_idModule, m_tokOwner, ppOwner) );
+                break;
+            }
+        default:
+            {
+                ASSERT(!"Unexpected Owner type for Generic Param Field");
+                hr = E_FAIL;
+            }
+    }
+Error:
+
+    METHOD_EXIT( CDebugGenericParamFieldType::GetOwner, hr );
+    return hr;
+}
+```
+
+## See Also
+[IDebugGenericParamField](../../../extensibility/debugger/reference/idebuggenericparamfield.md)

--- a/docs/extensibility/debugger/reference/idebuggenericparamfield-getowner.md
+++ b/docs/extensibility/debugger/reference/idebuggenericparamfield-getowner.md
@@ -18,13 +18,13 @@ Retrieves the type or method owner of this generic parameter.
 
 ```cpp
 HRESULT GetOwner(
-   IDebugField** ppOwner
+    IDebugField** ppOwner
 );
 ```
 
 ```csharp
 int GetOwner(
-   out IDebugField ppOwner
+    out IDebugField ppOwner
 );
 ```
 


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.