### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/idebugpendingbreakpoint2-delete.md
+++ b/docs/extensibility/debugger/reference/idebugpendingbreakpoint2-delete.md
@@ -2,78 +2,78 @@
 title: "IDebugPendingBreakpoint2::Delete | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-f1_keywords: 
+f1_keywords:
   - "IDebugPendingBreakpoint2::Delete"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "IDebugPendingBreakpoint2::Delete method"
   - "Delete method"
 ms.assetid: 4cb5ed81-6f0c-41ce-a770-5adb6b4bf5d9
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # IDebugPendingBreakpoint2::Delete
-Deletes this pending breakpoint and all breakpoints bound from it.  
-  
-## Syntax  
-  
-```cpp  
-HRESULT Delete(   
-   void   
-);  
-```  
-  
-```csharp  
-int Delete();  
-```  
-  
-## Return Value  
- If successful, returns `S_OK`; otherwise, returns an error code. Returns `E_BP_DELETED` if the breakpoint has been deleted.  
-  
-## Example  
- The following example shows how to implement this method for a simple `CPendingBreakpoint` object that implements the [IDebugPendingBreakpoint2](../../../extensibility/debugger/reference/idebugpendingbreakpoint2.md) interface.  
-  
-```cpp  
-HRESULT CPendingBreakpoint::Delete(void)    
-{    
-   HRESULT hr;    
-  
-   // Verify that the pending breakpoint has not been deleted. If deleted,    
-   // then return hr = E_BP_DELETED.    
-   if (m_state.state != PBPS_DELETED)    
-   {    
-      // If the pending breakpoint has bound and has an associated bound   
-      // breakpoint, delete and release the bound breakpoint and set the   
-      // pointer to NULL.    
-      if (m_pBoundBP)    
-      {    
-         m_pBoundBP->Delete();    
-         m_pBoundBP->Release();    
-         m_pBoundBP = NULL;    
-      }    
-      // If the pending breakpoint did not bind and has an associated   
-      // error breakpoint, release the error breakpoint and set the   
-      // pointer to NULL.   
-      if (m_pErrorBP)    
-      {    
-         m_pErrorBP->Release();    
-         m_pErrorBP = NULL;    
-      }    
-  
-      // Set the PENDING_BP_STATE in the PENDING_BP_STATE_INFO structure   
-      // to deleted.     
-      m_state.state = PBPS_DELETED;    
-   }    
-   else    
-   {    
-      hr = E_BP_DELETED;    
-   }    
-  
-   return hr;    
-}    
-```  
-  
-## See Also  
- [IDebugPendingBreakpoint2](../../../extensibility/debugger/reference/idebugpendingbreakpoint2.md)
+Deletes this pending breakpoint and all breakpoints bound from it.
+
+## Syntax
+
+```cpp
+HRESULT Delete(
+   void
+);
+```
+
+```csharp
+int Delete();
+```
+
+## Return Value
+If successful, returns `S_OK`; otherwise, returns an error code. Returns `E_BP_DELETED` if the breakpoint has been deleted.
+
+## Example
+The following example shows how to implement this method for a simple `CPendingBreakpoint` object that implements the [IDebugPendingBreakpoint2](../../../extensibility/debugger/reference/idebugpendingbreakpoint2.md) interface.
+
+```cpp
+HRESULT CPendingBreakpoint::Delete(void)
+{
+   HRESULT hr;
+
+   // Verify that the pending breakpoint has not been deleted. If deleted,
+   // then return hr = E_BP_DELETED.
+   if (m_state.state != PBPS_DELETED)
+   {
+      // If the pending breakpoint has bound and has an associated bound
+      // breakpoint, delete and release the bound breakpoint and set the
+      // pointer to NULL.
+      if (m_pBoundBP)
+      {
+         m_pBoundBP->Delete();
+         m_pBoundBP->Release();
+         m_pBoundBP = NULL;
+      }
+      // If the pending breakpoint did not bind and has an associated
+      // error breakpoint, release the error breakpoint and set the
+      // pointer to NULL.
+      if (m_pErrorBP)
+      {
+         m_pErrorBP->Release();
+         m_pErrorBP = NULL;
+      }
+
+      // Set the PENDING_BP_STATE in the PENDING_BP_STATE_INFO structure
+      // to deleted.
+      m_state.state = PBPS_DELETED;
+   }
+   else
+   {
+      hr = E_BP_DELETED;
+   }
+
+   return hr;
+}
+```
+
+## See Also
+[IDebugPendingBreakpoint2](../../../extensibility/debugger/reference/idebugpendingbreakpoint2.md)

--- a/docs/extensibility/debugger/reference/idebugpendingbreakpoint2-delete.md
+++ b/docs/extensibility/debugger/reference/idebugpendingbreakpoint2-delete.md
@@ -21,7 +21,7 @@ Deletes this pending breakpoint and all breakpoints bound from it.
 
 ```cpp
 HRESULT Delete(
-   void
+    void
 );
 ```
 
@@ -38,40 +38,40 @@ The following example shows how to implement this method for a simple `CPendingB
 ```cpp
 HRESULT CPendingBreakpoint::Delete(void)
 {
-   HRESULT hr;
+    HRESULT hr;
 
-   // Verify that the pending breakpoint has not been deleted. If deleted,
-   // then return hr = E_BP_DELETED.
-   if (m_state.state != PBPS_DELETED)
-   {
-      // If the pending breakpoint has bound and has an associated bound
-      // breakpoint, delete and release the bound breakpoint and set the
-      // pointer to NULL.
-      if (m_pBoundBP)
-      {
-         m_pBoundBP->Delete();
-         m_pBoundBP->Release();
-         m_pBoundBP = NULL;
-      }
-      // If the pending breakpoint did not bind and has an associated
-      // error breakpoint, release the error breakpoint and set the
-      // pointer to NULL.
-      if (m_pErrorBP)
-      {
-         m_pErrorBP->Release();
-         m_pErrorBP = NULL;
-      }
+    // Verify that the pending breakpoint has not been deleted. If deleted,
+    // then return hr = E_BP_DELETED.
+    if (m_state.state != PBPS_DELETED)
+    {
+        // If the pending breakpoint has bound and has an associated bound
+        // breakpoint, delete and release the bound breakpoint and set the
+        // pointer to NULL.
+        if (m_pBoundBP)
+        {
+            m_pBoundBP->Delete();
+            m_pBoundBP->Release();
+            m_pBoundBP = NULL;
+        }
+        // If the pending breakpoint did not bind and has an associated
+        // error breakpoint, release the error breakpoint and set the
+        // pointer to NULL.
+        if (m_pErrorBP)
+        {
+            m_pErrorBP->Release();
+            m_pErrorBP = NULL;
+        }
 
-      // Set the PENDING_BP_STATE in the PENDING_BP_STATE_INFO structure
-      // to deleted.
-      m_state.state = PBPS_DELETED;
-   }
-   else
-   {
-      hr = E_BP_DELETED;
-   }
+        // Set the PENDING_BP_STATE in the PENDING_BP_STATE_INFO structure
+        // to deleted.
+        m_state.state = PBPS_DELETED;
+    }
+    else
+    {
+        hr = E_BP_DELETED;
+    }
 
-   return hr;
+    return hr;
 }
 ```
 


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.