### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/idebugpendingbreakpoint2-enable.md
+++ b/docs/extensibility/debugger/reference/idebugpendingbreakpoint2-enable.md
@@ -2,79 +2,79 @@
 title: "IDebugPendingBreakpoint2::Enable | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-f1_keywords: 
+f1_keywords:
   - "IDebugPendingBreakpoint2::Enable"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "IDebugPendingBreakpoint2::Enable method"
   - "Enable method"
 ms.assetid: 09e32d05-464b-40a6-a41d-76f2759cf2cd
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # IDebugPendingBreakpoint2::Enable
-Toggles the enabled state of the pending breakpoint.  
-  
-## Syntax  
-  
-```cpp  
-HRESULT Enable(   
-   BOOL fEnable  
-);  
-```  
-  
-```csharp  
-int Enable(   
-   int fEnable  
-);  
-```  
-  
-#### Parameters  
- `fEnable`  
- [in] Set to nonzero (`TRUE`) to enable a pending breakpoint, or to zero (`FALSE`) to disable.  
-  
-## Return Value  
- If successful, returns `S_OK`; otherwise, returns an error code. Returns `E_BP_DELETED` if the breakpoint has been deleted.  
-  
-## Remarks  
- When a pending breakpoint is enabled or disabled, all breakpoints bound from it are set to the same state.  
-  
- This method may be called as many times as necessary, even if the breakpoint is already enabled or disabled.  
-  
-## Example  
- The following example shows how to implement this method for a simple `CPendingBreakpoint` object that exposes the [IDebugPendingBreakpoint2](../../../extensibility/debugger/reference/idebugpendingbreakpoint2.md) interface.  
-  
-```cpp  
-HRESULT CPendingBreakpoint::Enable(BOOL fEnable)    
-{    
-   HRESULT hr;    
-  
-   // Verify that the pending breakpoint has not been deleted. If deleted,   
-   // then return hr = E_BP_DELETED.    
-   if (m_state.state != PBPS_DELETED)    
-   {    
-      // If the bound breakpoint member variable is valid, then enable or   
-      // disable the bound breakpoint.    
-      if (m_pBoundBP)    
-      {    
-         m_pBoundBP->Enable(fEnable);    
-      }    
-      // Set the PENDING_BP_STATE in the PENDING_BP_STATE_INFO structure   
-      // to enabled or disabled depending on the passed BOOL condition.    
-      m_state.state = fEnable ? PBPS_ENABLED : PBPS_DISABLED;    
-      hr = S_OK;    
-  
-   }    
-   else    
-   {    
-      hr = E_BP_DELETED;    
-   }    
-  
-   return hr;    
-}    
-```  
-  
-## See Also  
- [IDebugPendingBreakpoint2](../../../extensibility/debugger/reference/idebugpendingbreakpoint2.md)
+Toggles the enabled state of the pending breakpoint.
+
+## Syntax
+
+```cpp
+HRESULT Enable(
+   BOOL fEnable
+);
+```
+
+```csharp
+int Enable(
+   int fEnable
+);
+```
+
+#### Parameters
+`fEnable`  
+[in] Set to nonzero (`TRUE`) to enable a pending breakpoint, or to zero (`FALSE`) to disable.
+
+## Return Value
+If successful, returns `S_OK`; otherwise, returns an error code. Returns `E_BP_DELETED` if the breakpoint has been deleted.
+
+## Remarks
+When a pending breakpoint is enabled or disabled, all breakpoints bound from it are set to the same state.
+
+This method may be called as many times as necessary, even if the breakpoint is already enabled or disabled.
+
+## Example
+The following example shows how to implement this method for a simple `CPendingBreakpoint` object that exposes the [IDebugPendingBreakpoint2](../../../extensibility/debugger/reference/idebugpendingbreakpoint2.md) interface.
+
+```cpp
+HRESULT CPendingBreakpoint::Enable(BOOL fEnable)
+{
+   HRESULT hr;
+
+   // Verify that the pending breakpoint has not been deleted. If deleted,
+   // then return hr = E_BP_DELETED.
+   if (m_state.state != PBPS_DELETED)
+   {
+      // If the bound breakpoint member variable is valid, then enable or
+      // disable the bound breakpoint.
+      if (m_pBoundBP)
+      {
+         m_pBoundBP->Enable(fEnable);
+      }
+      // Set the PENDING_BP_STATE in the PENDING_BP_STATE_INFO structure
+      // to enabled or disabled depending on the passed BOOL condition.
+      m_state.state = fEnable ? PBPS_ENABLED : PBPS_DISABLED;
+      hr = S_OK;
+
+   }
+   else
+   {
+      hr = E_BP_DELETED;
+   }
+
+   return hr;
+}
+```
+
+## See Also
+[IDebugPendingBreakpoint2](../../../extensibility/debugger/reference/idebugpendingbreakpoint2.md)

--- a/docs/extensibility/debugger/reference/idebugpendingbreakpoint2-enable.md
+++ b/docs/extensibility/debugger/reference/idebugpendingbreakpoint2-enable.md
@@ -21,13 +21,13 @@ Toggles the enabled state of the pending breakpoint.
 
 ```cpp
 HRESULT Enable(
-   BOOL fEnable
+    BOOL fEnable
 );
 ```
 
 ```csharp
 int Enable(
-   int fEnable
+    int fEnable
 );
 ```
 
@@ -49,30 +49,30 @@ The following example shows how to implement this method for a simple `CPendingB
 ```cpp
 HRESULT CPendingBreakpoint::Enable(BOOL fEnable)
 {
-   HRESULT hr;
+    HRESULT hr;
 
-   // Verify that the pending breakpoint has not been deleted. If deleted,
-   // then return hr = E_BP_DELETED.
-   if (m_state.state != PBPS_DELETED)
-   {
-      // If the bound breakpoint member variable is valid, then enable or
-      // disable the bound breakpoint.
-      if (m_pBoundBP)
-      {
-         m_pBoundBP->Enable(fEnable);
-      }
-      // Set the PENDING_BP_STATE in the PENDING_BP_STATE_INFO structure
-      // to enabled or disabled depending on the passed BOOL condition.
-      m_state.state = fEnable ? PBPS_ENABLED : PBPS_DISABLED;
-      hr = S_OK;
+    // Verify that the pending breakpoint has not been deleted. If deleted,
+    // then return hr = E_BP_DELETED.
+    if (m_state.state != PBPS_DELETED)
+    {
+        // If the bound breakpoint member variable is valid, then enable or
+        // disable the bound breakpoint.
+        if (m_pBoundBP)
+        {
+            m_pBoundBP->Enable(fEnable);
+        }
+        // Set the PENDING_BP_STATE in the PENDING_BP_STATE_INFO structure
+        // to enabled or disabled depending on the passed BOOL condition.
+        m_state.state = fEnable ? PBPS_ENABLED : PBPS_DISABLED;
+        hr = S_OK;
 
-   }
-   else
-   {
-      hr = E_BP_DELETED;
-   }
+    }
+    else
+    {
+        hr = E_BP_DELETED;
+    }
 
-   return hr;
+    return hr;
 }
 ```
 


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.