### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/idebugpendingbreakpoint2-virtualize.md
+++ b/docs/extensibility/debugger/reference/idebugpendingbreakpoint2-virtualize.md
@@ -2,79 +2,79 @@
 title: "IDebugPendingBreakpoint2::Virtualize | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-f1_keywords: 
+f1_keywords:
   - "IDebugPendingBreakpoint2::Virtualize"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "Virtualize method"
   - "IDebugPendingBreakpoint2::Virtualize method"
 ms.assetid: 58c8e9a5-4494-47c2-bddb-56f628da6a2d
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # IDebugPendingBreakpoint2::Virtualize
-Toggles the virtualized state of this pending breakpoint. When a pending breakpoint is virtualized, the debug engine will attempt to bind it every time new code loads into the program.  
-  
-## Syntax  
-  
-```cpp  
-HRESULT Virtualize(   
-   BOOL fVirtualize  
-);  
-```  
-  
-```cpp  
-int Virtualize(   
-   int fVirtualize  
-);  
-```  
-  
-#### Parameters  
- `fVirtualize`  
- [in] Set to nonzero (`TRUE`) to virtualize the pending breakpoint, or to zero (`FALSE`) to turn off virtualization.  
-  
-## Return Value  
- If successful, returns `S_OK`; otherwise, returns an error code. Returns `E_BP_DELETED` if the breakpoint has been deleted.  
-  
-## Remarks  
- A virtualized breakpoint is bound every time code is loaded.  
-  
-## Example  
- The following example shows how to implement this method for a simple `CPendingBreakpoint` object that exposes the [IDebugPendingBreakpoint2](../../../extensibility/debugger/reference/idebugpendingbreakpoint2.md) interface.  
-  
-```cpp  
-HRESULT CPendingBreakpoint::Virtualize(BOOL fVirtualize)    
-{    
-   HRESULT hr;    
-  
-   // Verify that the pending breakpoint has not been deleted. If deleted,   
-   // then return hr = E_BP_DELETED.    
-   if (m_state.state != PBPS_DELETED)    
-   {    
-      if (fVirtualize)    
-      {    
-         // Set the PBPSF_VIRTUALIZED flag in the PENDING_BP_STATE_FLAGS   
-         // structure.    
-         SetFlag(m_state.flags, PBPSF_VIRTUALIZED);    
-      }    
-      else    
-      {    
-         // Clear the PBPSF_VIRTUALIZED flag in the PENDING_BP_STATE_FLAGS   
-         // structure.    
-         ClearFlag(m_state.flags, PBPSF_VIRTUALIZED);    
-      }    
-      hr = S_OK;    
-   }    
-   else    
-   {    
-      hr = E_BP_DELETED;    
-   }    
-  
-   return hr;    
-}    
-```  
-  
-## See Also  
- [IDebugPendingBreakpoint2](../../../extensibility/debugger/reference/idebugpendingbreakpoint2.md)
+Toggles the virtualized state of this pending breakpoint. When a pending breakpoint is virtualized, the debug engine will attempt to bind it every time new code loads into the program.
+
+## Syntax
+
+```cpp
+HRESULT Virtualize(
+   BOOL fVirtualize
+);
+```
+
+```cpp
+int Virtualize(
+   int fVirtualize
+);
+```
+
+#### Parameters
+`fVirtualize`  
+[in] Set to nonzero (`TRUE`) to virtualize the pending breakpoint, or to zero (`FALSE`) to turn off virtualization.
+
+## Return Value
+If successful, returns `S_OK`; otherwise, returns an error code. Returns `E_BP_DELETED` if the breakpoint has been deleted.
+
+## Remarks
+A virtualized breakpoint is bound every time code is loaded.
+
+## Example
+The following example shows how to implement this method for a simple `CPendingBreakpoint` object that exposes the [IDebugPendingBreakpoint2](../../../extensibility/debugger/reference/idebugpendingbreakpoint2.md) interface.
+
+```cpp
+HRESULT CPendingBreakpoint::Virtualize(BOOL fVirtualize)
+{
+   HRESULT hr;
+
+   // Verify that the pending breakpoint has not been deleted. If deleted,
+   // then return hr = E_BP_DELETED.
+   if (m_state.state != PBPS_DELETED)
+   {
+      if (fVirtualize)
+      {
+         // Set the PBPSF_VIRTUALIZED flag in the PENDING_BP_STATE_FLAGS
+         // structure.
+         SetFlag(m_state.flags, PBPSF_VIRTUALIZED);
+      }
+      else
+      {
+         // Clear the PBPSF_VIRTUALIZED flag in the PENDING_BP_STATE_FLAGS
+         // structure.
+         ClearFlag(m_state.flags, PBPSF_VIRTUALIZED);
+      }
+      hr = S_OK;
+   }
+   else
+   {
+      hr = E_BP_DELETED;
+   }
+
+   return hr;
+}
+```
+
+## See Also
+[IDebugPendingBreakpoint2](../../../extensibility/debugger/reference/idebugpendingbreakpoint2.md)

--- a/docs/extensibility/debugger/reference/idebugpendingbreakpoint2-virtualize.md
+++ b/docs/extensibility/debugger/reference/idebugpendingbreakpoint2-virtualize.md
@@ -21,13 +21,13 @@ Toggles the virtualized state of this pending breakpoint. When a pending breakpo
 
 ```cpp
 HRESULT Virtualize(
-   BOOL fVirtualize
+    BOOL fVirtualize
 );
 ```
 
 ```cpp
 int Virtualize(
-   int fVirtualize
+    int fVirtualize
 );
 ```
 
@@ -47,32 +47,32 @@ The following example shows how to implement this method for a simple `CPendingB
 ```cpp
 HRESULT CPendingBreakpoint::Virtualize(BOOL fVirtualize)
 {
-   HRESULT hr;
+    HRESULT hr;
 
-   // Verify that the pending breakpoint has not been deleted. If deleted,
-   // then return hr = E_BP_DELETED.
-   if (m_state.state != PBPS_DELETED)
-   {
-      if (fVirtualize)
-      {
-         // Set the PBPSF_VIRTUALIZED flag in the PENDING_BP_STATE_FLAGS
-         // structure.
-         SetFlag(m_state.flags, PBPSF_VIRTUALIZED);
-      }
-      else
-      {
-         // Clear the PBPSF_VIRTUALIZED flag in the PENDING_BP_STATE_FLAGS
-         // structure.
-         ClearFlag(m_state.flags, PBPSF_VIRTUALIZED);
-      }
-      hr = S_OK;
-   }
-   else
-   {
-      hr = E_BP_DELETED;
-   }
+    // Verify that the pending breakpoint has not been deleted. If deleted,
+    // then return hr = E_BP_DELETED.
+    if (m_state.state != PBPS_DELETED)
+    {
+        if (fVirtualize)
+        {
+            // Set the PBPSF_VIRTUALIZED flag in the PENDING_BP_STATE_FLAGS
+            // structure.
+            SetFlag(m_state.flags, PBPSF_VIRTUALIZED);
+        }
+        else
+        {
+            // Clear the PBPSF_VIRTUALIZED flag in the PENDING_BP_STATE_FLAGS
+            // structure.
+            ClearFlag(m_state.flags, PBPSF_VIRTUALIZED);
+        }
+        hr = S_OK;
+    }
+    else
+    {
+        hr = E_BP_DELETED;
+    }
 
-   return hr;
+    return hr;
 }
 ```
 


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.