### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/idebugprogramnode2-gethostname.md
+++ b/docs/extensibility/debugger/reference/idebugprogramnode2-gethostname.md
@@ -2,92 +2,92 @@
 title: "IDebugProgramNode2::GetHostName | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-f1_keywords: 
+f1_keywords:
   - "IDebugProgramNode2::GetHostName"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "IDebugProgramNode2::GetHostName"
 ms.assetid: 16aad1ff-ad34-4394-a2e4-5621374a7729
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # IDebugProgramNode2::GetHostName
-Gets the name of the process hosting the program.  
-  
-## Syntax  
-  
-```cpp  
-HRESULT GetHostName (   
-   GETHOSTNAME_TYPE dwHostNameType,  
-   BSTR*            pbstrHostName  
-);  
-```  
-  
-```csharp  
-int GetHostName (   
-   enum_GETHOSTNAME_TYPE dwHostNameType,  
-   out string            pbstrHostName  
-);  
-```  
-  
-#### Parameters  
- `dwHostNameType`  
- [in] A value from the [GETHOSTNAME_TYPE](../../../extensibility/debugger/reference/gethostname-type.md) enumeration that specifies the type of name to return.  
-  
- `pbstrHostName`  
- [out] Returns the name of the hosting process.  
-  
-## Return Value  
- If successful, returns `S_OK`; otherwise, returns an error code.  
-  
-## Example  
- The following example shows how to implement this method for a simple `CProgram` object that exposes the [IDebugProgramNode2](../../../extensibility/debugger/reference/idebugprogramnode2.md) interface. This example ignores the `dwHostNameType` parameter and returns only the name of the program as taken from the base name of the module's file path.  
-  
-```cpp  
-HRESULT CProgram::GetHostName(DWORD dwHostNameType, BSTR* pbstrHostName) {    
-   // Check for valid argument.    
-   if (pbstrHostName)    
-   {    
-      char szModule[_MAX_PATH];    
-  
-      // Attempt to assign to szModule the path for the file used  
-      // to create the calling process.    
-      if (GetModuleFileName(NULL, szModule, sizeof (szModule)))    
-      {    
-         // If successful then declare several char arrays    
-         char  szDrive[_MAX_DRIVE];    
-         char  szDir[_MAX_DIR];    
-         char  szName[_MAX_FNAME];    
-         char  szExt[_MAX_EXT];    
-         char  szFilename[_MAX_FNAME + _MAX_EXT];    
-         WCHAR wszFilename[_MAX_FNAME + _MAX_EXT];    
-  
-         // Break the szModule path name into components.    
-         _splitpath(szModule, szDrive, szDir, szName, szExt);    
-  
-         // Copy the base file name szName into szFilename.    
-         lstrcpy(szFilename, szName);    
-         // Append the field extension szExt into szFilename.    
-         lstrcat(szFilename, szExt);    
-  
-         // Convert the szFilename sequence of multibyte characters    
-         // to the wszFilename sequence of wide characters.    
-         mbstowcs(wszFilename, szFilename, sizeof (wszFilename) / 2);    
-  
-         // Assign the wszFilename to the value at *pbstrHostName.    
-         *pbstrHostName = SysAllocString(wszFilename);    
-  
-          return S_OK;    
-      }    
-   }    
-  
-    return E_INVALIDARG;    
-}    
-```  
-  
-## See Also  
- [IDebugProgramNode2](../../../extensibility/debugger/reference/idebugprogramnode2.md)   
- [GETHOSTNAME_TYPE](../../../extensibility/debugger/reference/gethostname-type.md)   
- [IDebugProgramNode2](../../../extensibility/debugger/reference/idebugprogramnode2.md)
+Gets the name of the process hosting the program.
+
+## Syntax
+
+```cpp
+HRESULT GetHostName (
+   GETHOSTNAME_TYPE dwHostNameType,
+   BSTR*            pbstrHostName
+);
+```
+
+```csharp
+int GetHostName (
+   enum_GETHOSTNAME_TYPE dwHostNameType,
+   out string            pbstrHostName
+);
+```
+
+#### Parameters
+`dwHostNameType`  
+[in] A value from the [GETHOSTNAME_TYPE](../../../extensibility/debugger/reference/gethostname-type.md) enumeration that specifies the type of name to return.
+
+`pbstrHostName`  
+[out] Returns the name of the hosting process.
+
+## Return Value
+If successful, returns `S_OK`; otherwise, returns an error code.
+
+## Example
+The following example shows how to implement this method for a simple `CProgram` object that exposes the [IDebugProgramNode2](../../../extensibility/debugger/reference/idebugprogramnode2.md) interface. This example ignores the `dwHostNameType` parameter and returns only the name of the program as taken from the base name of the module's file path.
+
+```cpp
+HRESULT CProgram::GetHostName(DWORD dwHostNameType, BSTR* pbstrHostName) {
+   // Check for valid argument.
+   if (pbstrHostName)
+   {
+      char szModule[_MAX_PATH];
+
+      // Attempt to assign to szModule the path for the file used
+      // to create the calling process.
+      if (GetModuleFileName(NULL, szModule, sizeof (szModule)))
+      {
+         // If successful then declare several char arrays
+         char  szDrive[_MAX_DRIVE];
+         char  szDir[_MAX_DIR];
+         char  szName[_MAX_FNAME];
+         char  szExt[_MAX_EXT];
+         char  szFilename[_MAX_FNAME + _MAX_EXT];
+         WCHAR wszFilename[_MAX_FNAME + _MAX_EXT];
+
+         // Break the szModule path name into components.
+         _splitpath(szModule, szDrive, szDir, szName, szExt);
+
+         // Copy the base file name szName into szFilename.
+         lstrcpy(szFilename, szName);
+         // Append the field extension szExt into szFilename.
+         lstrcat(szFilename, szExt);
+
+         // Convert the szFilename sequence of multibyte characters
+         // to the wszFilename sequence of wide characters.
+         mbstowcs(wszFilename, szFilename, sizeof (wszFilename) / 2);
+
+         // Assign the wszFilename to the value at *pbstrHostName.
+         *pbstrHostName = SysAllocString(wszFilename);
+
+          return S_OK;
+      }
+   }
+
+    return E_INVALIDARG;
+}
+```
+
+## See Also
+[IDebugProgramNode2](../../../extensibility/debugger/reference/idebugprogramnode2.md)  
+[GETHOSTNAME_TYPE](../../../extensibility/debugger/reference/gethostname-type.md)  
+[IDebugProgramNode2](../../../extensibility/debugger/reference/idebugprogramnode2.md)

--- a/docs/extensibility/debugger/reference/idebugprogramnode2-gethostname.md
+++ b/docs/extensibility/debugger/reference/idebugprogramnode2-gethostname.md
@@ -20,15 +20,15 @@ Gets the name of the process hosting the program.
 
 ```cpp
 HRESULT GetHostName (
-   GETHOSTNAME_TYPE dwHostNameType,
-   BSTR*            pbstrHostName
+    GETHOSTNAME_TYPE dwHostNameType,
+    BSTR*            pbstrHostName
 );
 ```
 
 ```csharp
 int GetHostName (
-   enum_GETHOSTNAME_TYPE dwHostNameType,
-   out string            pbstrHostName
+    enum_GETHOSTNAME_TYPE dwHostNameType,
+    out string            pbstrHostName
 );
 ```
 
@@ -47,41 +47,41 @@ The following example shows how to implement this method for a simple `CProgram`
 
 ```cpp
 HRESULT CProgram::GetHostName(DWORD dwHostNameType, BSTR* pbstrHostName) {
-   // Check for valid argument.
-   if (pbstrHostName)
-   {
-      char szModule[_MAX_PATH];
+    // Check for valid argument.
+    if (pbstrHostName)
+    {
+        char szModule[_MAX_PATH];
 
-      // Attempt to assign to szModule the path for the file used
-      // to create the calling process.
-      if (GetModuleFileName(NULL, szModule, sizeof (szModule)))
-      {
-         // If successful then declare several char arrays
-         char  szDrive[_MAX_DRIVE];
-         char  szDir[_MAX_DIR];
-         char  szName[_MAX_FNAME];
-         char  szExt[_MAX_EXT];
-         char  szFilename[_MAX_FNAME + _MAX_EXT];
-         WCHAR wszFilename[_MAX_FNAME + _MAX_EXT];
+        // Attempt to assign to szModule the path for the file used
+        // to create the calling process.
+        if (GetModuleFileName(NULL, szModule, sizeof (szModule)))
+        {
+            // If successful then declare several char arrays
+            char  szDrive[_MAX_DRIVE];
+            char  szDir[_MAX_DIR];
+            char  szName[_MAX_FNAME];
+            char  szExt[_MAX_EXT];
+            char  szFilename[_MAX_FNAME + _MAX_EXT];
+            WCHAR wszFilename[_MAX_FNAME + _MAX_EXT];
 
-         // Break the szModule path name into components.
-         _splitpath(szModule, szDrive, szDir, szName, szExt);
+            // Break the szModule path name into components.
+            _splitpath(szModule, szDrive, szDir, szName, szExt);
 
-         // Copy the base file name szName into szFilename.
-         lstrcpy(szFilename, szName);
-         // Append the field extension szExt into szFilename.
-         lstrcat(szFilename, szExt);
+            // Copy the base file name szName into szFilename.
+            lstrcpy(szFilename, szName);
+            // Append the field extension szExt into szFilename.
+            lstrcat(szFilename, szExt);
 
-         // Convert the szFilename sequence of multibyte characters
-         // to the wszFilename sequence of wide characters.
-         mbstowcs(wszFilename, szFilename, sizeof (wszFilename) / 2);
+            // Convert the szFilename sequence of multibyte characters
+            // to the wszFilename sequence of wide characters.
+            mbstowcs(wszFilename, szFilename, sizeof (wszFilename) / 2);
 
-         // Assign the wszFilename to the value at *pbstrHostName.
-         *pbstrHostName = SysAllocString(wszFilename);
+            // Assign the wszFilename to the value at *pbstrHostName.
+            *pbstrHostName = SysAllocString(wszFilename);
 
-          return S_OK;
-      }
-   }
+            return S_OK;
+        }
+    }
 
     return E_INVALIDARG;
 }


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.