### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/docs/extensibility/debugger/reference/idebugprogramnode2-getprogramname.md
+++ b/docs/extensibility/debugger/reference/idebugprogramnode2-getprogramname.md
@@ -20,13 +20,13 @@ Gets the name of the program.
 
 ```cpp
 HRESULT GetProgramName (
-   BSTR* pbstrProgramName
+    BSTR* pbstrProgramName
 );
 ```
 
 ```csharp
 int GetProgramName (
-   out string pbstrProgramName
+    out string pbstrProgramName
 );
 ```
 
@@ -45,12 +45,12 @@ The following example shows how to implement this method for a simple `CProgram`
 
 ```cpp
 HRESULT CProgram::GetProgramName(BSTR* pbstrProgramName) {
-   if (!pbstrProgramName)
-      return E_INVALIDARG;
+    if (!pbstrProgramName)
+        return E_INVALIDARG;
 
-   // Assign the member program name to the passed program name.
-   *pbstrProgramName = MakeBstr(m_pszProgramName);
-   return NOERROR;
+    // Assign the member program name to the passed program name.
+    *pbstrProgramName = MakeBstr(m_pszProgramName);
+    return NOERROR;
 }
 ```
 

--- a/docs/extensibility/debugger/reference/idebugprogramnode2-getprogramname.md
+++ b/docs/extensibility/debugger/reference/idebugprogramnode2-getprogramname.md
@@ -2,57 +2,57 @@
 title: "IDebugProgramNode2::GetProgramName | Microsoft Docs"
 ms.date: "11/04/2016"
 ms.topic: "conceptual"
-f1_keywords: 
+f1_keywords:
   - "IDebugProgramNode2::GetProgramName"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "IDebugProgramNode2::GetProgramName"
 ms.assetid: 510c7f5d-48ff-4d9f-ad79-fbad9f15239d
 author: "gregvanl"
 ms.author: "gregvanl"
 manager: jillfra
-ms.workload: 
+ms.workload:
   - "vssdk"
 ---
 # IDebugProgramNode2::GetProgramName
-Gets the name of the program.  
-  
-## Syntax  
-  
-```cpp  
-HRESULT GetProgramName (   
-   BSTR* pbstrProgramName  
-);  
-```  
-  
-```csharp  
-int GetProgramName (   
-   out string pbstrProgramName  
-);  
-```  
-  
-#### Parameters  
- `pbstrProgramName`  
- [out] Returns the name of the program.  
-  
-## Return Value  
- If successful, returns `S_OK`; otherwise, returns an error code.  
-  
-## Remarks  
- The name of a program is not the same thing as the path to the program, although the name of the program may be part of such a path.  
-  
-## Example  
- The following example shows how to implement this method for a simple `CProgram` object that implements the [IDebugProgramNode2](../../../extensibility/debugger/reference/idebugprogramnode2.md) interface. The `MakeBstr` function allocates a copy of the specified string as a BSTR.  
-  
-```cpp  
-HRESULT CProgram::GetProgramName(BSTR* pbstrProgramName) {    
-   if (!pbstrProgramName)    
-      return E_INVALIDARG;    
-  
-   // Assign the member program name to the passed program name.    
-   *pbstrProgramName = MakeBstr(m_pszProgramName);    
-   return NOERROR;    
-}    
-```  
-  
-## See Also  
- [IDebugProgramNode2](../../../extensibility/debugger/reference/idebugprogramnode2.md)
+Gets the name of the program.
+
+## Syntax
+
+```cpp
+HRESULT GetProgramName (
+   BSTR* pbstrProgramName
+);
+```
+
+```csharp
+int GetProgramName (
+   out string pbstrProgramName
+);
+```
+
+#### Parameters
+`pbstrProgramName`  
+[out] Returns the name of the program.
+
+## Return Value
+If successful, returns `S_OK`; otherwise, returns an error code.
+
+## Remarks
+The name of a program is not the same thing as the path to the program, although the name of the program may be part of such a path.
+
+## Example
+The following example shows how to implement this method for a simple `CProgram` object that implements the [IDebugProgramNode2](../../../extensibility/debugger/reference/idebugprogramnode2.md) interface. The `MakeBstr` function allocates a copy of the specified string as a BSTR.
+
+```cpp
+HRESULT CProgram::GetProgramName(BSTR* pbstrProgramName) {
+   if (!pbstrProgramName)
+      return E_INVALIDARG;
+
+   // Assign the member program name to the passed program name.
+   *pbstrProgramName = MakeBstr(m_pszProgramName);
+   return NOERROR;
+}
+```
+
+## See Also
+[IDebugProgramNode2](../../../extensibility/debugger/reference/idebugprogramnode2.md)


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.