### PR TITLE
Include both regedit and regedit32 in instructions

### DIFF
--- a/docs/vs-2015/deployment/how-to-configure-the-clickonce-trust-prompt-behavior.md
+++ b/docs/vs-2015/deployment/how-to-configure-the-clickonce-trust-prompt-behavior.md
@@ -54,7 +54,7 @@ You can configure the ClickOnce trust prompt to control whether end users are gi
   
     1.  Click **Start**, and then click **Run**.  
   
-    2.  In the **Open** box, type `regedit32`, and then click **OK**.  
+    2.  In the **Open** box, type `regedit` (or `regedit32` on 32-bit Windows), and then click **OK**.  
   
 2.  Find the following registry key:  
   
@@ -113,7 +113,7 @@ You can configure the ClickOnce trust prompt to control whether end users are gi
   
     1.  Click **Start**, and then click **Run**.  
   
-    2.  In the **Open** box, type `regedit`, and then click **OK**.  
+    2.  In the **Open** box, type `regedit` (or `regedit32` on 32-bit Windows), and then click **OK**.  
   
 2.  Find the following registry key:  
   
@@ -170,7 +170,7 @@ You can configure the ClickOnce trust prompt to control whether end users are gi
   
     1.  Click **Start**, and then click **Run**.  
   
-    2.  In the **Open** box, type `regedit`, and then click **OK**.  
+    2.  In the **Open** box, type `regedit` (or `regedit32` on 32-bit Windows), and then click **OK**.  
   
 2.  Find the following registry key:  
   


### PR DESCRIPTION
A user I support was confused because when he typed `regedit32`, nothing appeared in his Start menu. He is using a 64-bit version of Windows. I updated the instructions to include both `regedit` and `regedit32`.