### PR TITLE
fix: MD003/heading-style/header-style

### DIFF
--- a/docs/debugger/debugging-f-hash.md
+++ b/docs/debugger/debugging-f-hash.md
@@ -17,7 +17,7 @@ manager: jillfra
 ms.workload:
   - "multiple"
 ---
-# Debugging F#
+# Debugging F\#
 Debugging F# is similar to debugging any managed language, with a few exceptions:
 
 -   The **Autos** window does not display F# variables.

--- a/docs/debugger/walkthrough-writing-a-visualizer-in-csharp.md
+++ b/docs/debugger/walkthrough-writing-a-visualizer-in-csharp.md
@@ -15,7 +15,7 @@ manager: jillfra
 ms.workload:
   - "dotnet"
 ---
-# Walkthrough: Writing a Visualizer in C# #
+# Walkthrough: Writing a Visualizer in C\#
 This walkthrough shows how to write a simple visualizer by using C#. The visualizer you will create in this walkthrough displays the contents of a string using a Windows forms message box. This simple string visualizer is not especially useful in itself, but it shows the basic steps that you must follow to create more useful visualizers for other data types.
 
 > [!NOTE]

--- a/docs/deployment/walkthrough-downloading-satellite-assemblies-on-demand-with-the-clickonce-deployment-api-using-the-designer.md
+++ b/docs/deployment/walkthrough-downloading-satellite-assemblies-on-demand-with-the-clickonce-deployment-api-using-the-designer.md
@@ -47,7 +47,7 @@ Windows Forms applications can be configured for multiple cultures through the u
 
 6.  Close the **Application Files** dialog box.
 
-### To download satellite assemblies on demand in C#
+### To download satellite assemblies on demand in C\#
 
 1.  Open the *Program.cs* file. If you do not see this file in Solution Explorer, select your project, and on the **Project** menu, click **Show All Files**.
 

--- a/docs/get-started/csharp/tutorial-projects-solutions.md
+++ b/docs/get-started/csharp/tutorial-projects-solutions.md
@@ -12,7 +12,7 @@ dev_langs:
 ms.workload:
   - "dotnet"
 ---
-# Learn about projects and solutions using C#
+# Learn about projects and solutions using C\#
 
 In this introductory article, we'll explore what it means to create a *solution* and a *project* in Visual Studio. A solution is a container that's used to organize one or more related code projects, for example a class library project and a corresponding test project. We'll look at the properties of a project and some of the files it can contain. We'll also create a reference from one project to another.
 

--- a/docs/get-started/csharp/tutorial-wpf.md
+++ b/docs/get-started/csharp/tutorial-wpf.md
@@ -14,7 +14,7 @@ manager: jillfra
 ms.workload:
   - "dotnet"
 ---
-# Tutorial: Create a simple application with C#
+# Tutorial: Create a simple application with C\#
 
 By completing this walkthrough, you'll become familiar with many of the tools, dialog boxes, and designers that you can use when you develop applications with Visual Studio. You'll create a "Hello, World" application, design the UI, add code, and debug errors, while you learn about working in the integrated development environment ([IDE](visual-studio-ide.md)).
 

--- a/docs/get-started/csharp/visual-studio-ide.md
+++ b/docs/get-started/csharp/visual-studio-ide.md
@@ -12,7 +12,7 @@ dev_langs:
 ms.workload:
   - "dotnet"
 ---
-# Welcome to the Visual Studio IDE | C#
+# Welcome to the Visual Studio IDE | C\#
 
 The Visual Studio *integrated development environment* is a creative launching pad that you can use to edit, debug, and build code, and then publish an app. An integrated development environment (IDE) is a feature-rich program that can be used for many aspects of software development. Over and above the standard editor and debugger that most IDEs provide, Visual Studio includes compilers, code completion tools, graphical designers, and many more features to ease the software development process.
 

--- a/docs/ide/how-to-suppress-compiler-warnings.md
+++ b/docs/ide/how-to-suppress-compiler-warnings.md
@@ -13,7 +13,7 @@ ms.workload:
 
 You can declutter a build log by filtering out one or more kinds of compiler warnings. For example, you might want to review only some of the output that's generated when you set the build log verbosity to **Normal**, **Detailed**, or **Diagnostic**. For more information about verbosity, see [How to: View, save, and configure build log files](../ide/how-to-view-save-and-configure-build-log-files.md).
 
-## Suppress specific warnings for Visual C# or F# #
+## Suppress specific warnings for Visual C# or F\#
 
 Use the **Build** property page to suppress specific warnings for C# and F# projects.
 

--- a/docs/ide/managing-application-settings-dotnet.md
+++ b/docs/ide/managing-application-settings-dotnet.md
@@ -78,7 +78,7 @@ If any user-scoped settings are changed during run time, for example in testing 
 
 We strongly recommend that you use the `My.Settings` object and the default *.settings* file to access settings. This is because you can use the **Settings Designer** to assign properties to settings, and, additionally, user settings are automatically saved before application shutdown. However, your Visual Basic application can access settings directly. In that case you have to access the `MySettings` class and use a custom *.settings* file in the root of the project. You must save the user settings before ending the application, as you would do for a C# application; this is described in the following section.
 
-## Access or change application settings at run time in C# #
+## Access or change application settings at run time in C\#
 
 In languages other than Visual Basic, such as C#, you must access the `Settings` class directly, as shown in the following [!INCLUDE[csprcs](../data-tools/includes/csprcs_md.md)] example.
 

--- a/docs/ide/managing-application-settings-dotnet.md
+++ b/docs/ide/managing-application-settings-dotnet.md
@@ -78,7 +78,9 @@ If any user-scoped settings are changed during run time, for example in testing 
 
 We strongly recommend that you use the `My.Settings` object and the default *.settings* file to access settings. This is because you can use the **Settings Designer** to assign properties to settings, and, additionally, user settings are automatically saved before application shutdown. However, your Visual Basic application can access settings directly. In that case you have to access the `MySettings` class and use a custom *.settings* file in the root of the project. You must save the user settings before ending the application, as you would do for a C# application; this is described in the following section.
 
-## Access or change application settings at run time in C\#
+<!-- markdownlint-disable MD003 -->
+## Access or change application settings at run time in C#
+<!-- markdownlint-enable MD003 -->
 
 In languages other than Visual Basic, such as C#, you must access the `Settings` class directly, as shown in the following [!INCLUDE[csprcs](../data-tools/includes/csprcs_md.md)] example.
 

--- a/docs/ide/quickstart-fsharp.md
+++ b/docs/ide/quickstart-fsharp.md
@@ -12,7 +12,7 @@ ms.workload:
   - "aspnet"
   - "dotnetcore"
 ---
-# Quickstart: Use Visual Studio to create your first ASP.NET Core web service in F#
+# Quickstart: Use Visual Studio to create your first ASP.NET Core web service in F\#
 
 In this 5-10 minute introduction to F# in Visual Studio , you'll create an F# ASP.NET Core web application.
 

--- a/docs/ide/walkthrough-building-an-application.md
+++ b/docs/ide/walkthrough-building-an-application.md
@@ -186,7 +186,7 @@ For more information, see [How to: Change the build output directory](../ide/how
 
      ![Build Solution command on the Build menu](../ide/media/exploreide-buildsolution.png)
 
-### Specify a release build for C# #
+### Specify a release build for C\#
 
 1. Open the **Project Designer**.
 

--- a/docs/profiling/how-to-use-the-concurrency-visualizer-markers-sdk.md
+++ b/docs/profiling/how-to-use-the-concurrency-visualizer-markers-sdk.md
@@ -72,7 +72,7 @@ This topic shows how to use the Concurrency Visualizer SDK to create spans and w
 
      ![Concurrency Visualizer with 3 custom marker series](../profiling/media/cvmarkerseriesnative.png "CvMarkerSeriesNative")
 
-### To Use Visual Basic or C# #
+### To Use Visual Basic or C\#
 
 1.  Add Concurrency Visualizer SDK support to your application. For more information, see [Concurrency Visualizer SDK](../profiling/concurrency-visualizer-sdk.md).
 


### PR DESCRIPTION

Mostly from C# at the end of the titles.
This can trigger parsing confusion because that is an alternate header style