### PR TITLE
fix: MD023/heading-start-left/header-start-left

### DIFF
--- a/docs/code-quality/C26414.md
+++ b/docs/code-quality/C26414.md
@@ -13,7 +13,9 @@ manager: jillfra
 ms.workload:
   - "multiple"
 ---
+
 # C26414 RESET_LOCAL_SMART_PTR
+
 "Move, copy, reassign or reset a local smart pointer."
 
 **C++ Core Guidelines**:
@@ -22,14 +24,16 @@ R.5: Prefer scoped objects, don't heap-allocate unnecessarily
 Smart pointers are convenient for dynamic resource management, but they are not always necessary. For example, creating of a local dynamic buffer can be easily (end sometimes more efficiently) managed by standard containers. For single objects it may be unnecessary to do dynamic allocation at all (e.g. if such objects never outlive their creator function) and they can be replaced with local variables. Smart pointers become handy when scenario requires changing of ownership, i.e. reassigning of a dynamic resource multiple times or in multiple paths. This also includes cases where resources are obtained from external code and smart pointers are used to extend resource’s lifetime.
 
 ## Remarks
+
 - In addition to the standard std::unique_pointer and std::shared_pointer templates, this check recognizes user defined types which are likely intended to be smart pointers. Such types are expected to define the following operations:
   - overloaded dereference or member access operators, that are public and not marked as deleted;
   - public destructor which is neither deleted nor defaulted. This includes destructors which are explicitly defined empty.
   - The type Microsoft::WRL::ComPtr behaves as a shared pointer, but it is often used in quite specific scenarios which are affected by the COM lifetime management. To avoid excessive noise this type is filtered out.
   - This check looks for explicit local allocations assigned to smart pointers to identify if scoped variables could word as an alternative. In addition to direct calls to operator new, special functions like std::make_unique and std::make_shared are also interpreted as direct allocations.
-    -
-    ## Example
-    dynamic buffer
+
+## Example
+
+dynamic buffer
 
 ```cpp
 void unpack_and_send(const frame &f)
@@ -39,7 +43,7 @@ void unpack_and_send(const frame &f)
     // ...
 }
 ```
-## Example
+
 dynamic buffer – replaced by container
 
 ```cpp

--- a/docs/code-quality/C26427.md
+++ b/docs/code-quality/C26427.md
@@ -13,7 +13,9 @@ manager: jillfra
 ms.workload:
   - "multiple"
 ---
+
 # C26427 NO_GLOBAL_INIT_EXTERNS
+
 "Global initializer accesses extern object."
 
 **C++ Core Guidelines**:
@@ -27,9 +29,11 @@ Global objects may be initialized in an inconsistent or undefined order which me
   - it is not in an anonymous namespace;
   - it is not marked as ‘const’;
   - Static class members are considered global, so their initializers are also checked.
-    ## Example
-    external version check
-    // api.cpp
+
+## Example
+
+external version check
+// api.cpp
 
 ```cpp
 int api_version = API_DEFAULT_VERSION; // Assume it can change at runtime, hence non-const.
@@ -39,7 +43,6 @@ extern int api_version;
 bool is_legacy_mode = api_version <= API_LEGACY_VERSION; // C26427, also stale value
 ```
 
-## Example
 external version check – made more reliable
 
 ```cpp

--- a/docs/code-quality/C26429.md
+++ b/docs/code-quality/C26429.md
@@ -13,7 +13,9 @@ manager: jillfra
 ms.workload:
   - "multiple"
 ---
+
 # C26429 USE_NOTNULL
+
 "Symbol is never tested for nullness, it can be marked as gsl::not_null."
 
 **C++ Core Guidelines**:
@@ -22,6 +24,7 @@ F.23: Use a not_null<T> to indicate that "null" is not a valid value
 It is a common practice to use asserts to enforce assumptions about validity of pointer values. The problem with asserts is that they do not expose assumptions through the interface (e.g. in return types or parameters). Asserts are also harder to maintain and keep in sync with other code changes. The recommendation is to use gsl::not_null from the Guidelines Support Library as a marker of resources which should never have null value. The rule USE_NOTNULL helps to identify places that omit checks for nullness and hence can be updated to use gsl::not_null.
 
 ## Remarks
+
 - The logic of the rule requires code to dereference a pointer variable so that nullness check (or enforcement of non-null value) would be justified. So, warning will be emitted only if pointers are dereferenced and never tested for nullness.
   - Current implementation handles only plain pointers (or their aliases) and doesn’t detect smart pointers even though gsl::not_null can be applied to smart pointers as well.
   - A variable is marked as checked for nullness when it is used in the following contexts:
@@ -29,8 +32,10 @@ It is a common practice to use asserts to enforce assumptions about validity of 
   - non-bitwise logical operations;
   - comparison operations where one operand is a constant expression which evaluates to zero.
   - The rule doesn’t have full dataflow tracking and can produce incorrect results in cases where indirect checks are used (e.g. when intermediate variable holds null value and later used in comparison).
-    ## Example
-    hidden expectation
+
+## Example
+
+hidden expectation
 
 ```cpp
 using client_collection = gsl::span<client*>;
@@ -47,7 +52,6 @@ void keep_alive(const connection *connection)   // C26429
 }
 ```
 
-## Example
 hidden expectation – clarified by gsl::not_null
 
 ```cpp

--- a/docs/code-quality/C26430.md
+++ b/docs/code-quality/C26430.md
@@ -15,6 +15,7 @@ ms.workload:
 ---
 
 # C26430 TEST_ON_ALL_PATHS
+
 "Symbol is not tested for nullness on all paths."
 
 **C++ Core Guidelines**:
@@ -23,6 +24,7 @@ F.23: Use a not_null<T> to indicate that "null" is not a valid value
 If code ever checks nullness of pointer variables it should do this consistently and validate pointers on all paths. Sometimes overaggressive checking for nullness is still better than possibility of a hard crash in one of the complicated branches. Ideally such code should be refactored to be less complex (by splitting into multiple functions) and to rely on markers like gsl::not_null (see Guidelines Support Library) to isolate parts of algorithm that can make safe assumption about valid pointer values. The rule TEST_ON_ALL_PATHS helps to find places where nullness checks are either inconsistent (hence assumptions may require review) or actual bugs where potential null value can bypass nullness check in some of the code paths.
 
 ## Remarks
+
 - This rule expects that code dereferences a pointer variable so that nullness check (or enforcement of non-null value) would be justified. If there is no dereference, the rule is suspended.
   - Current implementation handles only plain pointers (or their aliases) and doesn’t detect smart pointers even though nullness checks are applicable to smart pointers as well.
   - A variable is marked as checked for nullness when it is used in the following contexts:
@@ -33,8 +35,10 @@ If code ever checks nullness of pointer variables it should do this consistently
   - Implicit nullness checks are assumed when pointer value is assigned from:
   - an allocation performed with throwing operator new;
   - a pointer obtained from type marked with gsl::not_null.
-    ## Example
-    inconsistent testing reveals logic error
+
+## Example
+
+inconsistent testing reveals logic error
 
 ```cpp
 void merge_states(const state *left, const state *right) // C26430
@@ -50,7 +54,6 @@ void merge_states(const state *left, const state *right) // C26430
 }
 ```
 
-## Example
 inconsistent testing reveals logic error - corrected
 
 ```cpp

--- a/docs/code-quality/C26431.md
+++ b/docs/code-quality/C26431.md
@@ -13,7 +13,9 @@ manager: jillfra
 ms.workload:
   - "multiple"
 ---
+
 # C26431 DONT_TEST_NOTNULL
+
 "The type of expression is already gsl::not_null. Do not test it for nullness."
 
 **C++ Core Guidelines**:
@@ -22,13 +24,16 @@ F.23: Use a not_null<T> to indicate that "null" is not a valid value
 The marker type gsl::not_null from Guidelines Support Library is used to clearly indicate values which are never null pointers. It causes a hard failure if such assumption is not held at runtime. So, obviously, there is no need to check for nullness if expression evaluates to a result of type gsl::not_null.
 
 ## Remarks
+
 - Since gsl::not_null itself is a thin pointer wrapper class, the rule actually tracks temporary variables that hold results from calls to the overloaded conversion operator (which returns contained pointer object). Such logic makes this rule applicable to expressions that involve variables and eventually have result of the gsl::not_null type. But it currently skips expressions that contain function calls returning gsl::not_null.
   - Current heuristic for nullness checks detects the following contexts:
   - symbol expression in a branch condition, e.g. "if (p) { ... }";
   - non-bitwise logical operations;
   - comparison operations where one operand is a constant expression which evaluates to zero.
-    ## Example
-    unnecessary null checks reveal questionable logic
+
+## Example
+
+unnecessary null checks reveal questionable logic
 
 ```cpp
 class type {
@@ -59,7 +64,6 @@ public:
 };
 ```
 
-## Example
 unnecessary null checks reveal questionable logic - reworked
 
 ```cpp

--- a/docs/code-quality/C26437.md
+++ b/docs/code-quality/C26437.md
@@ -13,7 +13,9 @@ manager: jillfra
 ms.workload:
   - "multiple"
 ---
+
 # C26437 DONT_SLICE
+
 "Do not slice."
 
 **C++ Core Guidelines**:
@@ -22,10 +24,13 @@ ES.63: Don't slice
 Slicing is allowed by compiler and can be viewed as a special case of dangerous implicit cast. Even if it is done intentionally and doesn’t lead to immediate issues, it is still highly discouraged since it makes code rather unmaintainable by forcing additional requirements on related data types. This is especially true if types are polymorphic or involve resource management.
 
 ## Remarks
+
 - This rule would warn not only on explicit assignments, but also on implicit slicing which happens when result gets returned from current function or data passed as arguments to other functions.
   - Warnings would also flag cases where assignment doesn’t involve real data slicing (e.g. if types are empty or don’t make any dangerous data manipulations). Such warnings should still be addressed to prevent any undesirable regressions if types data or behavior changes in future.
-    ## Example
-    slicing points to outdated
+
+## Example
+
+slicing points to outdated
 
 ```cpp
 interface
@@ -47,11 +52,9 @@ bool read_id(stream &s, id &v) {
 }
 ```
 
-## Example
-slicing points to outdated
+slicing points to outdated, interface - corrected
 
 ```cpp
-interface - corrected
 // ...
 bool read_id(stream &s, id_ex &v) {
 // ...

--- a/docs/code-quality/C26438.md
+++ b/docs/code-quality/C26438.md
@@ -13,7 +13,9 @@ manager: jillfra
 ms.workload:
   - "multiple"
 ---
+
 # C26438 NO_GOTO
+
 "Avoid 'goto'."
 
 **C++ Core Guidelines**:
@@ -22,10 +24,13 @@ ES.76: Avoid goto
 Using of ‘goto’ is widely acknowledged as dangerous and error-prone practice. It is acceptable only in generated code (e.g. in a parser generated from a grammar). With modern C++ features and utilities provided by the Guidelines Support Library it should be easy to avoid ‘goto’ altogether.
 
 ## Remarks
+
 - This rule warns on any occurrence of ‘goto’, even if it happens in dead code, except template code which is never used and hence ignored by compiler.
   - Warnings can be noisy if they encounter a macro containing ‘goto’. Current reporting mechanism would point to all instances where such macro gets expanded. But the fix can usually be done in one place by changing the macro or avoiding use of it and leveraging more maintainable mechanisms.
-    ## Example
-    ‘goto cleanup’ in macro
+
+## Example
+
+‘goto cleanup’ in macro
 
 ```cpp
 #define ENSURE(E, L) if (!(E)) goto L;
@@ -48,7 +53,6 @@ end:
 }
 ```
 
-## Example
 ‘goto cleanup’ in macro - replaced with gsl::finally
 
 ```cpp

--- a/docs/code-quality/C26441.md
+++ b/docs/code-quality/C26441.md
@@ -13,7 +13,9 @@ manager: jillfra
 ms.workload:
   - "multiple"
 ---
+
 # C26441 NO_UNNAMED_GUARDS
+
 "Guard objects must be named."
 
 **C++ Core Guidelines**:
@@ -22,12 +24,15 @@ CP.44: Remember to name your lock_guards and unique_locks
 The standard library provides a few useful classes which help to control concurrent access to resources. Objects of such types lock exclusive access for the duration of their lifetime. This implies that every lock object must be named, i.e. have clearly defined lifetime which spans through the period in which access operations are executed. So, failing to assign a lock object to a variable is a mistake which is effectively disables locking mechanism (because temporary variables are transient). This rule tries to catch simple cases of such unintended behavior.
 
 ## Remarks
+
 - Only standard lock types are tracked: std::scoped_lock, std::unique_lock, and std::lock_quard.
   - Only simple calls to constructors are analyzed. More complex initializer expression may lead to inaccurate results, but this is rather an unusual scenario.
   - Locks passed as arguments to function calls or returned as results of function calls are ignored.
   - Locks created as temporaries but assigned to named references to extend their lifetime are ignored.
-    ## Example
-    missing scoped variable
+
+## Example
+
+missing scoped variable
 
 ```cpp
 void print_diagnostic(gsl::string_span<> text)
@@ -42,7 +47,6 @@ void print_diagnostic(gsl::string_span<> text)
 }
 ```
 
-## Example
 missing scoped variable - corrected
 
 ```cpp

--- a/docs/code-quality/C26472.md
+++ b/docs/code-quality/C26472.md
@@ -13,20 +13,25 @@ manager: jillfra
 ms.workload:
   - "multiple"
 ---
+
 # C26472 NO_CASTS_FOR_ARITHMETIC_CONVERSION
+
 "Don't use a static_cast for arithmetic conversions. Use brace initialization, gsl::narrow_cast or gsl::narrow."
 
 **C++ Core Guidelines**:
 Type.1: Avoid casts
 
 This rule helps to find places where static casts are used to convert between integral types, which is unsafe since compiler would not warn if any data loss occurs. Brace initializers are better for the cases where constants are used, and a compiler error is desired. There are also utilities from the Guidelines Support Library that help to describe intentions clearly:
--   gsl::narrow ensures lossless conversion and causes runtime crash if it is not possible.
--   gsl::narrow_cast clearly states that conversion can lose data and it is acceptable.
+- gsl::narrow ensures lossless conversion and causes runtime crash if it is not possible.
+- gsl::narrow_cast clearly states that conversion can lose data and it is acceptable.
 
 ## Remarks
+
 - This rule is implemented only for static_casts. Using of C-style casts is generally discouraged.
-  ## Example
-  unhandled unexpected data
+
+## Example
+
+unhandled unexpected data
 
 ```cpp
 rgb from_24bit(std::uint32_t v) noexcept {
@@ -38,7 +43,6 @@ rgb from_24bit(std::uint32_t v) noexcept {
 }
 ```
 
-## Example
 unhandled unexpected data – safer version
 
 ```cpp

--- a/docs/code-quality/C26473.md
+++ b/docs/code-quality/C26473.md
@@ -13,7 +13,9 @@ manager: jillfra
 ms.workload:
   - "multiple"
 ---
+
 # C26473 NO_IDENTITY_CAST
+
 "Don't cast between pointer types where the source type and the target type are the same."
 
 **C++ Core Guidelines**:
@@ -22,9 +24,12 @@ Type.1: Avoid casts
 This rule helps to remove unnecessary or suspicious casts. Obviously, when type is converted to itself, such conversion is ineffective, yet the fact that the cast is used may indicate subtle design issue or a potential for regression if types change in future. It is always safer to use as few casts as possible.
 
 ## Remarks
+
 - This rule is implemented for static and reinterpret casts and checks only pointer types.
-  ## Example
-  dangerously generic lookup
+
+## Example
+
+dangerously generic lookup
 
 ```cpp
 gsl::span<server> servers_;
@@ -43,7 +48,6 @@ void promote(server *s, int index) noexcept {
 }
 ```
 
-## Example
 dangerously generic lookup - reworked
 
 ```cpp

--- a/docs/code-quality/C26474.md
+++ b/docs/code-quality/C26474.md
@@ -13,7 +13,9 @@ manager: jillfra
 ms.workload:
   - "multiple"
 ---
+
 # C26474 NO_IMPLICIT_CAST
+
 "Don't cast between pointer types when the conversion could be implicit."
 
 **C++ Core Guidelines**:
@@ -22,14 +24,17 @@ Type.1: Avoid casts
 In some cases, implicit casts between pointer types can safely be done and don’t require user to write specific cast expression. This rule finds instances of such unnecessary casting which can be removed.
 
 ## Remarks
+
 - The rule ID is a bit misleading: it should be interpreted as "implicit cast is not used where it is acceptable".
   - The rule is applicable to pointers only and checks static casts and reinterpret casts.
   - The following cases are acceptable pointer conversions that should not use explicit cast expressions:
   - conversion to nullptr_t;
   - conversion to void*;
   - conversion from derived type to its base.
-    ## Example
-    unnecessary conversion hides logic error
+
+## Example
+
+unnecessary conversion hides logic error
 
 ```cpp
 template<class T>
@@ -49,7 +54,6 @@ void merge_bytes(std::uint8_t *left, std::uint8_t *right)
 }
 ```
 
-## Example
 unnecessary conversion hides logic error - reworked
 
 ```cpp

--- a/docs/code-quality/C26475.md
+++ b/docs/code-quality/C26475.md
@@ -13,28 +13,36 @@ manager: jillfra
 ms.workload:
   - "multiple"
 ---
+
 # C26475 NO_FUNCTION_STYLE_CASTS
+
 "Do not use function style C-casts."
 
 **C++ Core Guidelines**:
 ES.49: If you must use a cast, use a named cast
 
 Function style casts (e.g. "int(1.1)") are another incarnation of C-style casts (like "(int)1.1") with all its questionable safety. Specifically, compiler doesn’t try to check if any data loss can occur neither in C-casts, nor in function casts. In both cases it is better either to avoid casting or use brace initializer if possible. If neither works, static casts may be suitable, but it is still better to use utilities from the Guidelines Support Library:
--   gsl::narrow ensures lossless conversion and causes runtime crash if it is not possible.
--   gsl::narrow_cast clearly states that conversion can lose data and it is acceptable.
+- gsl::narrow ensures lossless conversion and causes runtime crash if it is not possible.
+- gsl::narrow_cast clearly states that conversion can lose data and it is acceptable.
 
 ## Remarks
 - This rule fires only for constants of primitive types - these are the cases where compiler can clearly detect data loss and emit error if brace initializer is used. The cases which would require runtime execution are flagged by C26493 NO_CSTYLE_CAST.
   - Default initializers are not flagged (e.g. "int()").
-    ## Example
-    dangerous conversion
+
+## Example
+
+dangerous conversion
 
 ```cpp
 constexpr auto planck_constant = float( 6.62607004082e-34 ); // C26475
-## Example
+```
+
+```cpp
 dangerous conversion – detecting potential data loss
 constexpr auto planck_constant = float{ 6.62607004082e-34 }; // Error C2397
-## Example
+```
+
+```cpp
 dangerous conversion – corrected
 constexpr auto planck_constant = double{ 6.62607004082e-34 };
 ```

--- a/docs/code-quality/cpp-core-guidelines-warnings.md
+++ b/docs/code-quality/cpp-core-guidelines-warnings.md
@@ -168,14 +168,15 @@ Sometimes it may be useful to do focused code analysis and still leverage the Vi
 You can use the C++ Core Guidelines checks in automated builds.
 
 ### MSBuild
- The Native Code Analysis checker (PREfast) is integrated into MSBuild environment by custom targets files. You can use project properties to enable it, and add the C++ Core Guidelines Checker (which is based on PREfast):
 
- ```xml
-  <PropertyGroup>
-    <EnableCppCoreCheck>true</EnableCppCoreCheck>
-    <CodeAnalysisRuleSet>CppCoreCheckRules.ruleset</CodeAnalysisRuleSet>¬¬
-    <RunCodeAnalysis>true</RunCodeAnalysis>
-  </PropertyGroup>
+The Native Code Analysis checker (PREfast) is integrated into MSBuild environment by custom targets files. You can use project properties to enable it, and add the C++ Core Guidelines Checker (which is based on PREfast):
+
+```xml
+<PropertyGroup>
+  <EnableCppCoreCheck>true</EnableCppCoreCheck>
+  <CodeAnalysisRuleSet>CppCoreCheckRules.ruleset</CodeAnalysisRuleSet>¬¬
+  <RunCodeAnalysis>true</RunCodeAnalysis>
+</PropertyGroup>
 ```
 
 Make sure you add these properties before the import of the Microsoft.Cpp.targets file. You can pick specific rule sets or create a custom rule set or use the default rule set that includes other PREfast checks.
@@ -215,14 +216,16 @@ You will need to set a few environment variables and use proper command line opt
    - `/analyze:plugin EspXEngine.dll` This option loads the Code Analysis Extensions engine into the PREfast. This engine, in turn, loads the C++ Core Guidelines Checker.
 
 ## Use the Guideline Support Library
- The Guideline Support Library is designed to help you follow the Core Guidelines. The GSL includes definitions that let you replace error-prone constructs with safer alternatives. For example, you can replace a `T*, length` pair of parameters with the `span<T>` type. The GSL is available at [http://www.nuget.org/packages/Microsoft.Gsl](http://www.nuget.org/packages/Microsoft.Gsl). The library is open source, so you can view the sources, make comments, or contribute. The project can be found at [https://github.com/Microsoft/GSL](https://github.com/Microsoft/GSL).
 
- ## <a name="vs2015_corecheck"></a> Use the C++ Core Check guidelines in Visual Studio 2015 projects
-  If you use Visual Studio 2015, the C++ Core Check code analysis rule sets are not installed by default. You must perform some additional steps before you can enable the C++ Core Check code analysis tools in Visual Studio 2015. Microsoft provides support for Visual Studio 2015 projects by using a Nuget package. The package is named Microsoft.CppCoreCheck, and it is available at [http://www.nuget.org/packages/Microsoft.CppCoreCheck](http://www.nuget.org/packages/Microsoft.CppCoreCheck). This package requires you have at least Visual Studio 2015 with Update 1 installed.
+The Guideline Support Library is designed to help you follow the Core Guidelines. The GSL includes definitions that let you replace error-prone constructs with safer alternatives. For example, you can replace a `T*, length` pair of parameters with the `span<T>` type. The GSL is available at [http://www.nuget.org/packages/Microsoft.Gsl](http://www.nuget.org/packages/Microsoft.Gsl). The library is open source, so you can view the sources, make comments, or contribute. The project can be found at [https://github.com/Microsoft/GSL](https://github.com/Microsoft/GSL).
 
- The package also installs another package as a dependency, a header-only Guideline Support Library (GSL). The GSL is also available on GitHub at [https://github.com/Microsoft/GSL](https://github.com/Microsoft/GSL).
+## <a name="vs2015_corecheck"></a> Use the C++ Core Check guidelines in Visual Studio 2015 projects
 
- Because of the way the code analysis rules are loaded, you must install the Microsoft.CppCoreCheck NuGet package into each C++ project that you want to check within Visual Studio 2015.
+If you use Visual Studio 2015, the C++ Core Check code analysis rule sets are not installed by default. You must perform some additional steps before you can enable the C++ Core Check code analysis tools in Visual Studio 2015. Microsoft provides support for Visual Studio 2015 projects by using a Nuget package. The package is named Microsoft.CppCoreCheck, and it is available at [http://www.nuget.org/packages/Microsoft.CppCoreCheck](http://www.nuget.org/packages/Microsoft.CppCoreCheck). This package requires you have at least Visual Studio 2015 with Update 1 installed.
+
+The package also installs another package as a dependency, a header-only Guideline Support Library (GSL). The GSL is also available on GitHub at [https://github.com/Microsoft/GSL](https://github.com/Microsoft/GSL).
+
+Because of the way the code analysis rules are loaded, you must install the Microsoft.CppCoreCheck NuGet package into each C++ project that you want to check within Visual Studio 2015.
 
 ### To add the Microsoft.CppCoreCheck package to your project in Visual Studio 2015
 

--- a/docs/deployment/how-to-publish-a-wpf-application-with-visual-styles-enabled.md
+++ b/docs/deployment/how-to-publish-a-wpf-application-with-visual-styles-enabled.md
@@ -9,7 +9,9 @@ manager: jillfra
 ms.workload:
   - "multiple"
 ---
+
 # How to: Publish a WPF application with visual styles enabled
+
 Visual styles enable the appearance of common controls to change based on the theme chosen by the user. By default, visual styles are not enabled for Windows Presentation Foundation (WPF) applications, so you must enable them manually. However, enabling visual styles for a WPF application and then publishing the solution causes an error. This topic describes how to resolve this error and the process for publishing a WPF application with visual styles enabled. For more information about visual styles, see [Visual styles overview](/windows/desktop/Controls/visual-styles-overview). For more information about the error message, see [Troubleshoot specific errors in ClickOnce deployments](../deployment/troubleshooting-specific-errors-in-clickonce-deployments.md).
 
  To resolve the error and to publish the solution, you must perform the following tasks:
@@ -26,7 +28,7 @@ Visual styles enable the appearance of common controls to change based on the th
 
 ##  Publish the solution without visual styles enabled
 
-1.  Ensure that your project does not have visual styles enabled. First, check your project's manifest file for the following XML. Then, if the XML is present, enclose the XML with a comment tag.
+1. Ensure that your project does not have visual styles enabled. First, check your project's manifest file for the following XML. Then, if the XML is present, enclose the XML with a comment tag.
 
      By default, visual styles are not enabled.
 
@@ -40,36 +42,36 @@ Visual styles enable the appearance of common controls to change based on the th
 
      The following procedures show how to open the manifest file associated with your project.
 
-    ###### To open the manifest file in a Visual Basic project
+    **To open the manifest file in a Visual Basic project**
 
-    1.  On the menu bar, choose **Project**, *ProjectName* **Properties**, where *ProjectName* is the name of your WPF project.
+    1. On the menu bar, choose **Project**, *ProjectName* **Properties**, where *ProjectName* is the name of your WPF project.
 
          The property pages for your WPF project appear.
 
-    2.  On the **Application** tab, choose **View Windows Settings**.
+    2. On the **Application** tab, choose **View Windows Settings**.
 
          The app.manifest file opens in the **Code Editor**.
 
-    ###### To open the manifest file in a C# project
+    **To open the manifest file in a C# project**
 
-    1.  On the menu bar, choose **Project**, *ProjectName* **Properties**, where *ProjectName* is the name of your WPF project.
+    1. On the menu bar, choose **Project**, *ProjectName* **Properties**, where *ProjectName* is the name of your WPF project.
 
          The property pages for your WPF project appear.
 
-    2.  On the **Application** tab, make a note of the name that appears in the manifest field. This is the name of the manifest that is associated with your project.
+    2. On the **Application** tab, make a note of the name that appears in the manifest field. This is the name of the manifest that is associated with your project.
 
         > [!NOTE]
-        >  If **Embed manifest with default settings** or **Create application without manifest** appear in the manifest field, visual styles are not enabled. If the name of a manifest file appears in the manifest field, proceed to the next step in this procedure.
+        > If **Embed manifest with default settings** or **Create application without manifest** appear in the manifest field, visual styles are not enabled. If the name of a manifest file appears in the manifest field, proceed to the next step in this procedure.
 
-    3.  In **Solution Explorer**, choose **Show All Files**.
+    3. In **Solution Explorer**, choose **Show All Files**.
 
          This button shows all project items, including those that have been excluded and those that are normally hidden. The manifest file appears as a project item.
 
-2.  Build and publish your solution. For more information about how to publish the solution, see [How to: Publish a ClickOnce application using the Publish Wizard](../deployment/how-to-publish-a-clickonce-application-using-the-publish-wizard.md).
+2. Build and publish your solution. For more information about how to publish the solution, see [How to: Publish a ClickOnce application using the Publish Wizard](../deployment/how-to-publish-a-clickonce-application-using-the-publish-wizard.md).
 
 ## Create a manifest file
 
-1.  Paste the following XML into a Notepad file.
+1. Paste the following XML into a Notepad file.
 
      This XML describes the assembly that contains controls that support visual styles.
 
@@ -88,16 +90,16 @@ Visual styles enable the appearance of common controls to change based on the th
     </asmv1:assembly>
     ```
 
-2.  In Notepad, click **File**, and then click **Save As**.
+2. In Notepad, click **File**, and then click **Save As**.
 
-3.  In the **Save As** dialog box, in the **Save as type** drop-down list, select **All Files**.
+3. In the **Save As** dialog box, in the **Save as type** drop-down list, select **All Files**.
 
-4.  In the **File name** box, name the file and append *.manifest* to the end of the file name. For example: *themes.manifest*.
+4. In the **File name** box, name the file and append *.manifest* to the end of the file name. For example: *themes.manifest*.
 
-5.  Choose the **Browse Folders** button, select any folder, and then click **Save**.
+5. Choose the **Browse Folders** button, select any folder, and then click **Save**.
 
     > [!NOTE]
-    >  The remaining procedures assume that the name of this file is *themes.manifest* and that the file is saved to the *C:\temp* directory on your computer.
+    > The remaining procedures assume that the name of this file is *themes.manifest* and that the file is saved to the *C:\temp* directory on your computer.
 
 ## Embed the manifest file into the executable file of the published solution
 
@@ -106,15 +108,15 @@ Visual styles enable the appearance of common controls to change based on the th
     For more information about how to open the **Visual Studio Command Prompt**, see [Command prompts](/dotnet/framework/tools/developer-command-prompt-for-vs).
 
    > [!NOTE]
-   >  The remaining steps make the following assumptions about your solution:
+   > The remaining steps make the following assumptions about your solution:
    >
    > - The name of the solution is **MyWPFProject**.
-   >   -   The solution is located in the following directory: `%UserProfile%\Documents\Visual Studio 2010\Projects\`.
+   > - The solution is located in the following directory: `%UserProfile%\Documents\Visual Studio 2010\Projects\`.
    >
-   >   The solution is published to the following directory: `%UserProfile%\Documents\Visual Studio 2010\Projects\publish`.
-   >   -   The most recent version of the published application files is located in the following directory: `%UserProfile%\Documents\Visual Studio 2010\Projects\publish\Application Files\WPFApp_1_0_0_0`
+   > - The solution is published to the following directory: `%UserProfile%\Documents\Visual Studio 2010\Projects\publish`.
+   > - The most recent version of the published application files is located in the following directory: `%UserProfile%\Documents\Visual Studio 2010\Projects\publish\Application Files\WPFApp_1_0_0_0`
    >
-   >   You do not have to use the name or the directory locations described above. The name and locations described above are used only to illustrate the steps required to publish your solution.
+   > You do not have to use the name or the directory locations described above. The name and locations described above are used only to illustrate the steps required to publish your solution.
 
 2. At the command prompt, change the path to the directory that contains the most recent version of the published application files. The following example demonstrates this step.
 
@@ -137,7 +139,7 @@ Visual styles enable the appearance of common controls to change based on the th
    ```
 
    > [!NOTE]
-   >  This example assumes that only one file has the *.deploy* file extension. Make sure that you rename all files in this directory that have the *.deploy* file extension.
+   > This example assumes that only one file has the *.deploy* file extension. Make sure that you rename all files in this directory that have the *.deploy* file extension.
 
 2. At the command prompt, run the following command to sign the application manifest.
 
@@ -146,7 +148,7 @@ Visual styles enable the appearance of common controls to change based on the th
    ```
 
    > [!NOTE]
-   >  This example assumes that you sign the manifest by using the *.pfx* file of the project. If you are not signing the manifest, you can omit the `-cf` parameter that is used in this example. If you are signing the manifest with a certificate that requires a password, specify the `-password` option (`For example: mage -u MyWPFApp.exe.manifest -cf ..\..\..\MyWPFApp_TemporaryKey.pfx - password Password`).
+   > This example assumes that you sign the manifest by using the *.pfx* file of the project. If you are not signing the manifest, you can omit the `-cf` parameter that is used in this example. If you are signing the manifest with a certificate that requires a password, specify the `-password` option (`For example: mage -u MyWPFApp.exe.manifest -cf ..\..\..\MyWPFApp_TemporaryKey.pfx - password Password`).
 
 3. At the command prompt, run the following command to add the *.deploy* extension to the name of the file that you renamed in a previous step of this procedure.
 
@@ -155,7 +157,7 @@ Visual styles enable the appearance of common controls to change based on the th
    ```
 
    > [!NOTE]
-   >  This example assumes that only one file had a *.deploy* file extension. Make sure that you rename all files in this directory that previously had the *.deploy* file name extension.
+   > This example assumes that only one file had a *.deploy* file extension. Make sure that you rename all files in this directory that previously had the *.deploy* file name extension.
 
 4. At the command prompt, run the following command to sign the deployment manifest.
 
@@ -164,7 +166,7 @@ Visual styles enable the appearance of common controls to change based on the th
    ```
 
    > [!NOTE]
-   >  This example assumes that you sign the manifest by using the *.pfx* file of the project. If you are not signing the manifest, you can omit the `-cf` parameter that is used in this example. If you are signing the manifest with a certificate that requires a password, specify the `-password` option, as in this example:`For example: mage -u MyWPFApp.exe.manifest -cf ..\..\..\MyWPFApp_TemporaryKey.pfx - password Password`.
+   > This example assumes that you sign the manifest by using the *.pfx* file of the project. If you are not signing the manifest, you can omit the `-cf` parameter that is used in this example. If you are signing the manifest with a certificate that requires a password, specify the `-password` option, as in this example:`For example: mage -u MyWPFApp.exe.manifest -cf ..\..\..\MyWPFApp_TemporaryKey.pfx - password Password`.
 
    After you have performed these steps, you can move the published files to the location from which you want end users to install the application. If you intend to update the solution often, you can move these commands into a script and run the script each time that you publish a new version.
 

--- a/docs/extensibility/adding-an-lsp-extension.md
+++ b/docs/extensibility/adding-an-lsp-extension.md
@@ -9,6 +9,7 @@ manager: jillfra
 ms.workload:
   - "vssdk"
 ---
+
 # Add a Language Server Protocol extension
 
 The Language Server Protocol (LSP) is a common protocol, in the form of JSON RPC v2.0, used to provide language service features to various code editors. Using the protocol, developers can write a single language server to provide language service features like IntelliSense, error diagnostics, find all references, etc. to various code editors that support the LSP. Traditionally, language services in Visual Studio can be added by either using TextMate grammar files to provide basic functionalities such as syntax highlighting, or by writing custom language services using the full set of Visual Studio extensibility APIs to provide richer data. Now, support for the LSP offers a third option.
@@ -123,7 +124,7 @@ The LSP does not include specification on how to provide text colorization for l
 
 4. Create a *.pkgdef* file and add a line similar to this:
 
-    ```xml
+    ```
     [$RootKey$\TextMate\Repositories]
     "MyLang"="$PackageFolder$\Grammars"
     ```
@@ -307,13 +308,13 @@ Follow these steps below to add support for settings to your LSP language servic
 
 4. Add a .pkgdef file to the project (add new text file and change the file extension to .pkgdef). The pkgdef file should contain this info:
 
-    ```xml
+    ```
     [$RootKey$\OpenFolder\Settings\VSWorkspaceSettings\[settings-name]]
     @="$PackageFolder$\[settings-file-name].json"
     ```
 
     Sample:
-    ```xml
+    ```
     [$RootKey$\OpenFolder\Settings\VSWorkspaceSettings\MockLanguageExtension]
     @="$PackageFolder$\MockLanguageExtensionSettings.json"
     ```
@@ -339,8 +340,10 @@ Follow these steps below to add support for settings to your LSP language servic
         "foo.maxNumberOfProblems": 10
     }
     ```
-    ### Enabling diagnostics tracing
-    Diagnostics tracing can be enabled to output all messages between the client and server, which can be useful when debugging issues. To enable diagnostic tracing, do the following:
+
+### Enabling diagnostics tracing
+
+Diagnostics tracing can be enabled to output all messages between the client and server, which can be useful when debugging issues. To enable diagnostic tracing, do the following:
 
 4. Open or create the workspace settings file *VSWorkspaceSettings.json* (see "User editing of settings for a workspace").
 5. Add the following line in the settings json file:

--- a/docs/extensibility/managing-side-by-side-file-associations.md
+++ b/docs/extensibility/managing-side-by-side-file-associations.md
@@ -11,25 +11,28 @@ manager: jillfra
 ms.workload:
   - "vssdk"
 ---
+
 # Manage side-by-side file associations
+
 If your VSPackage provides file associations, you must decide how to handle side-by-side installations in which a particular version of [!INCLUDE[vsprvs](../code-quality/includes/vsprvs_md.md)] should be invoked to open a file. Incompatible file formats compound the issue.
 
- Users expect a new version of a product to be compatible with earlier versions, so that existing files can be loaded in a new version without losing data. Ideally, your VSPackage can both load and save the file formats of earlier versions. If that is not true, you should offer to upgrade the file format to the new version of your VSPackage. The downside to this approach is that the upgraded file cannot be opened in the earlier version.
+Users expect a new version of a product to be compatible with earlier versions, so that existing files can be loaded in a new version without losing data. Ideally, your VSPackage can both load and save the file formats of earlier versions. If that is not true, you should offer to upgrade the file format to the new version of your VSPackage. The downside to this approach is that the upgraded file cannot be opened in the earlier version.
 
- To avoid this issue, you can change extensions when file formats become incompatible. For example, version 1 of your VSPackage could use the extension, *.mypkg10*, and version 2 could use the extension, *.mypkg20*. This difference identifies the VSPackage that opens a particular file. If you add newer VSPackages to the list of programs that are associated with an old extension, users can right-click the file and choose to open it in a newer VSPackage. At that point, your VSPackage can offer to upgrade the file to the new format or open the file and maintain compatibility with earlier versions of the VSPackage.
+To avoid this issue, you can change extensions when file formats become incompatible. For example, version 1 of your VSPackage could use the extension, *.mypkg10*, and version 2 could use the extension, *.mypkg20*. This difference identifies the VSPackage that opens a particular file. If you add newer VSPackages to the list of programs that are associated with an old extension, users can right-click the file and choose to open it in a newer VSPackage. At that point, your VSPackage can offer to upgrade the file to the new format or open the file and maintain compatibility with earlier versions of the VSPackage.
 
 > [!NOTE]
->  You can combine these approaches. For example, you can offer backward compatibility by loading an older file and offer to upgrade the file format when the user saves it.
+> You can combine these approaches. For example, you can offer backward compatibility by loading an older file and offer to upgrade the file format when the user saves it.
 
 ## Face the Problem
- If you want multiple side-by-side VSPackages to use the same extension, you must choose the version of [!INCLUDE[vsprvs](../code-quality/includes/vsprvs_md.md)] that is associated with the extension. Here are two alternatives:
+
+If you want multiple side-by-side VSPackages to use the same extension, you must choose the version of [!INCLUDE[vsprvs](../code-quality/includes/vsprvs_md.md)] that is associated with the extension. Here are two alternatives:
 
 - Open the file in the latest version of [!INCLUDE[vsprvs](../code-quality/includes/vsprvs_md.md)] installed on a user's computer.
 
    In this approach, your installer is responsible for determining the latest version of [!INCLUDE[vsprvs](../code-quality/includes/vsprvs_md.md)] and including that in the registry entry written for the file association. In a Windows Installer package, you can include custom actions to set a property that indicates the latest version of [!INCLUDE[vsprvs](../code-quality/includes/vsprvs_md.md)].
 
   > [!NOTE]
-  >  In this context, "latest" means "latest supported version." These installer entries will not automatically detect a subsequent release of [!INCLUDE[vsprvs](../code-quality/includes/vsprvs_md.md)]. Entries in [Detecting System Requirements](../extensibility/internals/detecting-system-requirements.md) and in [Commands That Must Be Run After Installation](../extensibility/internals/commands-that-must-be-run-after-installation.md) are similar to the ones presented here and are required to support additional versions of [!INCLUDE[vsprvs](../code-quality/includes/vsprvs_md.md)].
+  > In this context, "latest" means "latest supported version." These installer entries will not automatically detect a subsequent release of [!INCLUDE[vsprvs](../code-quality/includes/vsprvs_md.md)]. Entries in [Detecting System Requirements](../extensibility/internals/detecting-system-requirements.md) and in [Commands That Must Be Run After Installation](../extensibility/internals/commands-that-must-be-run-after-installation.md) are similar to the ones presented here and are required to support additional versions of [!INCLUDE[vsprvs](../code-quality/includes/vsprvs_md.md)].
 
    The following rows in the CustomAction table set the DEVENV_EXE_LATEST property to be a property set by the AppSearch and RegLocator tables discussed in [Commands that must be run after installation](../extensibility/internals/commands-that-must-be-run-after-installation.md). Rows in the InstallExecuteSequence table schedule the custom actions early in the execute sequence. Values in the Condition column make the logic work:
 
@@ -41,7 +44,7 @@ If your VSPackage provides file associations, you must decide how to handle side
 
     The net result is that DEVENV_EXE_LATEST contains the path of the latest version of devenv.exe.
 
-  ### CustomAction table rows that determine the latest version of Visual Studio
+  **CustomAction table rows that determine the latest version of Visual Studio**
 
   |Action|Type|Source|Target|
   |------------|----------|------------|------------|
@@ -49,7 +52,7 @@ If your VSPackage provides file associations, you must decide how to handle side
   |CA_SetDevenvLatest_2003|51|DEVENV_EXE_LATEST|[DEVENV_EXE_2003]|
   |CA_SetDevenvLatest_2005|51|DEVENV_EXE_LATEST|[DEVENV_EXE_2005]|
 
-  ### InstallExecuteSequence table rows that determine the latest version of Visual Studio
+  **InstallExecuteSequence table rows that determine the latest version of Visual Studio**
 
   |Action|Condition|Sequence|
   |------------|---------------|--------------|
@@ -66,16 +69,18 @@ If your VSPackage provides file associations, you must decide how to handle side
    The launcher should be in a Windows Installer component that is shared with all versions of your VSPackage. This process makes sure that the latest version is always installed and is not removed until all versions of your VSPackage are uninstalled. In this way, the file associations and other registry entries of the launcher component are preserved even if one version of the VSPackage is uninstalled.
 
 ## Uninstall and file associations
- Uninstalling a VSPackage that writes registry entries for file associations removes the file associations. Therefore, the extension has no associated programs. Windows Installer does not "recover" the registry entries that were added when the VSPackage was installed. Here are some ways to fix a user's file associations:
 
--   Use a shared launcher component as previously described.
+Uninstalling a VSPackage that writes registry entries for file associations removes the file associations. Therefore, the extension has no associated programs. Windows Installer does not "recover" the registry entries that were added when the VSPackage was installed. Here are some ways to fix a user's file associations:
 
--   Instruct the user to run a repair of the version of the VSPackage that the user wants to own the file association.
+- Use a shared launcher component as previously described.
+
+- Instruct the user to run a repair of the version of the VSPackage that the user wants to own the file association.
 
 -   Provide a separate executable program that rewrites the appropriate registry entries.
 
 -   Provide a configuration options page or dialog box that lets users choose file associations and reclaim lost associations. Instruct users to run it after uninstallation.
 
 ## See also
+
 - [Register file name extensions for side-by-side deployments](../extensibility/registering-file-name-extensions-for-side-by-side-deployments.md)
 - [Register verbs for file name extensions](../extensibility/registering-verbs-for-file-name-extensions.md)

--- a/docs/ide/reference/options-text-editor-c-cpp-advanced.md
+++ b/docs/ide/reference/options-text-editor-c-cpp-advanced.md
@@ -15,184 +15,192 @@ manager: wpickett
 ms.workload:
   - "cplusplus"
 ---
+
 # Options, Text Editor, C/C++, Advanced
+
 By changing these options, you can change the behavior related to IntelliSense and the browsing database when you're programming in C or C++.
 
- To access this page, in the **Options** dialog box, in the left pane, expand **Text Editor**, expand **C/C++**, and then choose **Advanced**.
+To access this page, in the **Options** dialog box, in the left pane, expand **Text Editor**, expand **C/C++**, and then choose **Advanced**.
 
 > [!NOTE]
 > Your computer might show different names or locations for some of the Visual Studio user interface elements in the following instructions. The Visual Studio edition that you have and the settings that you use determine these elements. See [Personalize the Visual Studio IDE](../../ide/personalizing-the-visual-studio-ide.md).
 
 
 ## Browsing/Navigation
- You should never choose these options except in the rare case where a solution is so large that the database activity consumes an unacceptable amount of system resources.
 
- **Disable Database**
+You should never choose these options except in the rare case where a solution is so large that the database activity consumes an unacceptable amount of system resources.
 
- All use of the code browsing database (SDF), all other Browsing/Navigation options, and all IntelliSense features except for #include Auto Complete are disabled.
+**Disable Database**
 
- **Disable Database Updates**
+All use of the code browsing database (SDF), all other Browsing/Navigation options, and all IntelliSense features except for #include Auto Complete are disabled.
 
- The database will be opened read-only, and no updates will be performed as files are edited. Most features will still work. However, as edits are made, the data will become stale, and you'll get incorrect results.
+**Disable Database Updates**
 
- **Disable Database Auto Updates**
+The database will be opened read-only, and no updates will be performed as files are edited. Most features will still work. However, as edits are made, the data will become stale, and you'll get incorrect results.
 
- The code browsing database won't be automatically updated when source files are modified. However, if you open **Solution Explorer**, open the shortcut menu for the project, and then choose **Rescan Solution**, all out-of-date files will be checked, and the database will be updated.
+**Disable Database Auto Updates**
 
- **Disable Implicit Files**
+The code browsing database won't be automatically updated when source files are modified. However, if you open **Solution Explorer**, open the shortcut menu for the project, and then choose **Rescan Solution**, all out-of-date files will be checked, and the database will be updated.
 
- The code browsing database doesn't collect data for files that aren't specified in a project. A project contains source files and header files that are explicitly specified. Implicit files are included by explicit files (for example, afxwin.h, windows.h, and atlbase.h). Normally, the system finds these files and also indexes them for various browsing features (including Navigate To). If you choose this option, those files aren't indexed, and some features aren't available for them. If you choose this option, "Disable Implicit Cleanup" and "Disable External Dependencies" are also implicitly chosen.
+**Disable Implicit Files**
 
- **Disable Implicit Cleanup**
+The code browsing database doesn't collect data for files that aren't specified in a project. A project contains source files and header files that are explicitly specified. Implicit files are included by explicit files (for example, afxwin.h, windows.h, and atlbase.h). Normally, the system finds these files and also indexes them for various browsing features (including Navigate To). If you choose this option, those files aren't indexed, and some features aren't available for them. If you choose this option, "Disable Implicit Cleanup" and "Disable External Dependencies" are also implicitly chosen.
 
- The code browsing database doesn't clean up implicit files that are no longer referenced. This option prevents implicit files from being removed from the database when they're no longer used. For example, if you add an `#include` directive that references mapi.h to one of your source files, mapi.h will be found and indexed. If you then remove the #include and the file isn't referenced elsewhere, information about it will eventually be removed unless you choose this option. (See the **Rescan Solution Interval** option.) This option is ignored when you  explicitly rescan the solution.
+**Disable Implicit Cleanup**
 
- **Disable External Dependencies Folders**
+The code browsing database doesn't clean up implicit files that are no longer referenced. This option prevents implicit files from being removed from the database when they're no longer used. For example, if you add an `#include` directive that references mapi.h to one of your source files, mapi.h will be found and indexed. If you then remove the #include and the file isn't referenced elsewhere, information about it will eventually be removed unless you choose this option. (See the **Rescan Solution Interval** option.) This option is ignored when you  explicitly rescan the solution.
 
- The External Dependencies folder for each project isn't created or updated. In **Solution Explorer**, each project contains an External Dependencies folder, which contains all implicit files for that project. If you choose this option, that folder doesn't appear.
+**Disable External Dependencies Folders**
 
- **Recreate Database**
+The External Dependencies folder for each project isn't created or updated. In **Solution Explorer**, each project contains an External Dependencies folder, which contains all implicit files for that project. If you choose this option, that folder doesn't appear.
 
- Recreate the code browsing database from nothing the next time that the solution loads. If you choose this option, the SDF database file is deleted the next time you load the solution, thus causing the database to be recreated and all files indexed.
+**Recreate Database**
 
- **Rescan Solution Interval**
+Recreate the code browsing database from nothing the next time that the solution loads. If you choose this option, the SDF database file is deleted the next time you load the solution, thus causing the database to be recreated and all files indexed.
 
- A 'Rescan Solution Now' job is scheduled for the interval that you specify. You must specify between 0 and 5000 minutes. The default value is 60 minutes. While the solution is rescanned, file timestamps are checked to determine whether a file was changed outside of the IDE. (Changes that are made in the IDE are automatically tracked, and files are updated.) Implicitly included files are checked to determine whether they're all still referenced.
+**Rescan Solution Interval**
+
+A 'Rescan Solution Now' job is scheduled for the interval that you specify. You must specify between 0 and 5000 minutes. The default value is 60 minutes. While the solution is rescanned, file timestamps are checked to determine whether a file was changed outside of the IDE. (Changes that are made in the IDE are automatically tracked, and files are updated.) Implicitly included files are checked to determine whether they're all still referenced.
 
 ## Diagnostic Logging
- These options are provided in case Microsoft asks you to collect advanced information to diagnose an issue. The logging information isn't useful for users, and we recommend that you leave it disabled.
 
- **Enable Logging**
+These options are provided in case Microsoft asks you to collect advanced information to diagnose an issue. The logging information isn't useful for users, and we recommend that you leave it disabled.
 
- Enables diagnostic logging to the output window.
+**Enable Logging**
 
- **Logging Level**
+Enables diagnostic logging to the output window.
 
- Set the log verbosity, from 0 to 5.
+**Logging Level**
 
- **Logging Filter**
+Set the log verbosity, from 0 to 5.
 
- Filters displayed event types by using a bitmask.
+**Logging Filter**
 
- Set by using a sum of any of the following options:
+Filters displayed event types by using a bitmask.
 
--   0 - None
+Set by using a sum of any of the following options:
 
--   1 - General
+- 0 - None
 
--   2 - Idle
+- 1 - General
 
--   4 - WorkItem
+- 2 - Idle
 
--   8 - IntelliSense
+- 4 - WorkItem
 
--   16 - ACPerf
+- 8 - IntelliSense
 
--   32 - ClassView
+- 16 - ACPerf
+
+- 32 - ClassView
 
 ## Fallback Location
- The fallback location is where the SDF and IntelliSense support files (for example, iPCH) are put when the primary location (same directory as solution) isn't used. This situation could occur the user doesn't have the permissions to write to the solution directory or the solution directory is on a slow device. The default fallback location is in the user's temp directory.
 
- **Always Use Fallback Location**
+The fallback location is where the SDF and IntelliSense support files (for example, iPCH) are put when the primary location (same directory as solution) isn't used. This situation could occur the user doesn't have the permissions to write to the solution directory or the solution directory is on a slow device. The default fallback location is in the user's temp directory.
 
- Indicates that the code browsing database and IntelliSense files should always be stored in a folder that you specify as your "Fallback Location", not next to the .sln file. The IDE will never try to put the SDF or iPCH files next to the solution directory and will always use the fallback location.
+**Always Use Fallback Location**
 
- **Do Not Warn If Fallback Location Used**
+Indicates that the code browsing database and IntelliSense files should always be stored in a folder that you specify as your "Fallback Location", not next to the .sln file. The IDE will never try to put the SDF or iPCH files next to the solution directory and will always use the fallback location.
 
- You aren't informed or prompted if a 'Fallback Location' is used. Normally, the IDE will tell you if it had to use the fallback location. This option turns off that warning.
+**Do Not Warn If Fallback Location Used**
 
- **Fallback Location**
+You aren't informed or prompted if a 'Fallback Location' is used. Normally, the IDE will tell you if it had to use the fallback location. This option turns off that warning.
 
- This value is used as a secondary location to store the code browsing database or IntelliSense files. By default, your temporary directory is your fallback location. The IDE will create a subdirectory under the specified path (or the temp directory) that includes the name of the solution along with a hash of the full path to the solution, which avoids issues with solution names being identical.
+**Fallback Location**
+
+This value is used as a secondary location to store the code browsing database or IntelliSense files. By default, your temporary directory is your fallback location. The IDE will create a subdirectory under the specified path (or the temp directory) that includes the name of the solution along with a hash of the full path to the solution, which avoids issues with solution names being identical.
 
 ## IntelliSense
- **Auto Quick Info**
 
- Enables QuickInfo tooltips when you move the pointer over text.
+**Auto Quick Info**
 
- **Disable IntelliSense**
+Enables QuickInfo tooltips when you move the pointer over text.
 
- Disables all IntelliSense features. The IDE does not create VCPkgSrv.exe processes to service IntelliSense requests, and no IntelliSense features will work (QuickInfo, Member List, Auto Complete, Param Help). Semantic colorization and reference highlighting are also disabled. This option doesn't disable browsing features that rely solely on the database (including Navigation Bar, ClassView, and Property window).
+**Disable IntelliSense**
 
- **Disable Auto Updating**
+Disables all IntelliSense features. The IDE does not create VCPkgSrv.exe processes to service IntelliSense requests, and no IntelliSense features will work (QuickInfo, Member List, Auto Complete, Param Help). Semantic colorization and reference highlighting are also disabled. This option doesn't disable browsing features that rely solely on the database (including Navigation Bar, ClassView, and Property window).
 
- IntelliSense updating is delayed until an actual request for IntelliSense is made. This delay can result in a longer execution time of the first IntelliSense operation on a file, but it may be helpful to set this option on very slow or resource-constrained machines. If you choose this option, you also implicitly choose the "Disable Error Reporting" and "Disable Squiggles" options.
+**Disable Auto Updating**
 
- **Disable Error Reporting**
+IntelliSense updating is delayed until an actual request for IntelliSense is made. This delay can result in a longer execution time of the first IntelliSense operation on a file, but it may be helpful to set this option on very slow or resource-constrained machines. If you choose this option, you also implicitly choose the "Disable Error Reporting" and "Disable Squiggles" options.
 
- Disables reporting of IntelliSense errors through squiggles and the Error List window. Also disables the background parsing that's associated with error reporting. If you choose this option, you also implicitly choose the "Disable Squiggles" option.
+**Disable Error Reporting**
 
- **Disable Squiggles**
+Disables reporting of IntelliSense errors through squiggles and the Error List window. Also disables the background parsing that's associated with error reporting. If you choose this option, you also implicitly choose the "Disable Squiggles" option.
 
- Disables IntelliSense error squiggles. The red "squiggles" don't show in the editor window, but the error will still appear in the Error List window.
+**Disable Squiggles**
 
- **Auto Tune Max Cached Translation Units**
+Disables IntelliSense error squiggles. The red "squiggles" don't show in the editor window, but the error will still appear in the Error List window.
 
- The maximum number of translation units that will be kept active at any one time for IntelliSense requests. You must specify a value between 2 and 15. This number directly relates to the maximum number of VCPkgSrv.exe processes that will run (for a given instance of Visual Studio). The default value is 2, but if you have available memory, you can increase this value and possibly achieve slightly better performance on IntelliSense.
+**Auto Tune Max Cached Translation Units**
 
- For more information about translation units, see [Phases of Translation](/cpp/preprocessor/phases-of-translation).
+The maximum number of translation units that will be kept active at any one time for IntelliSense requests. You must specify a value between 2 and 15. This number directly relates to the maximum number of VCPkgSrv.exe processes that will run (for a given instance of Visual Studio). The default value is 2, but if you have available memory, you can increase this value and possibly achieve slightly better performance on IntelliSense.
 
- **Disable #include Auto Complete**
+For more information about translation units, see [Phases of Translation](/cpp/preprocessor/phases-of-translation).
 
- Disables auto-completion of `#include` statements.
+**Disable #include Auto Complete**
 
- **Use Forward Slash in #include Auto Complete**
+Disables auto-completion of `#include` statements.
 
- Triggers auto-completion of `#include` statements when "/" is used. The default delimiter is backslash '\'. The compiler can accept either, so use this option to specify what your code base uses.
+**Use Forward Slash in #include Auto Complete**
 
- **Disable Aggressive Member List**
+Triggers auto-completion of `#include` statements when "/" is used. The default delimiter is backslash '\'. The compiler can accept either, so use this option to specify what your code base uses.
 
- The member list doesn't appear while you type the name of a type or variable. The list appears only after you type one of the commit characters, as defined in the **Member List Commit Characters** option.
+**Disable Aggressive Member List**
 
- **Disable Member List Keywords**
+The member list doesn't appear while you type the name of a type or variable. The list appears only after you type one of the commit characters, as defined in the **Member List Commit Characters** option.
 
- Language keywords such as `void`, `class`, `switch` don't appear in member list suggestions.
+**Disable Member List Keywords**
 
- **Disable Member List Code Snippets**
+Language keywords such as `void`, `class`, `switch` don't appear in member list suggestions.
 
- Code snippets don't appear in member list suggestions.
+**Disable Member List Code Snippets**
 
- **Member List Filter Mode**
+Code snippets don't appear in member list suggestions.
 
- Sets the type of matching algorithm. **Fuzzy** finds the most possible matches because it uses an algorithm that's similar to a spell-checker to find matches that are similar but not identical. **Smart filtering** matches substrings even if they're not at the start of a word. **Prefix** only matches on identical substrings that start at the beginning of the word.
+**Member List Filter Mode**
 
- **Disable Semantic Colorization**
+Sets the type of matching algorithm. **Fuzzy** finds the most possible matches because it uses an algorithm that's similar to a spell-checker to find matches that are similar but not identical. **Smart filtering** matches substrings even if they're not at the start of a word. **Prefix** only matches on identical substrings that start at the beginning of the word.
 
- Turns off all code colorization except for language keywords, strings, and comments.
+**Disable Semantic Colorization**
 
- **Member List Commit Characters**
+Turns off all code colorization except for language keywords, strings, and comments.
 
- Specifies the characters that cause the currently highlighted Member List suggestion to be committed. You can add or remove characters from this list.
+**Member List Commit Characters**
 
- **Smart Member List Commit**
+Specifies the characters that cause the currently highlighted Member List suggestion to be committed. You can add or remove characters from this list.
 
- Adds a line when you choose the Enter key at the end of a fully typed word.
+**Smart Member List Commit**
 
- **Enable Member List Dot-To-Arrow**
+Adds a line when you choose the Enter key at the end of a fully typed word.
 
- Replaces '.' with '->' when applicable for Member List.
+**Enable Member List Dot-To-Arrow**
+
+Replaces '.' with '->' when applicable for Member List.
 
 ## References
- **Disable Resolving**
 
- For performance reasons, 'Find All References'  displays raw textual search results by default instead of using IntelliSense to verify each candidate. You can clear this check box for more accurate results on all find operations. To filter on a per-search basis, open the shortcut menu for  the result list, and then choose "Resolve Results."
+**Disable Resolving**
 
- **Hide Unconfirmed**
+For performance reasons, 'Find All References'  displays raw textual search results by default instead of using IntelliSense to verify each candidate. You can clear this check box for more accurate results on all find operations. To filter on a per-search basis, open the shortcut menu for  the result list, and then choose "Resolve Results."
 
- Hide unconfirmed items in the 'Find All References' results. If you unset the "Disable Resolving" option, you can use this option to hide unconfirmed items in the results.
+**Hide Unconfirmed**
 
- **Disable Reference Highlighting**
+Hide unconfirmed items in the 'Find All References' results. If you unset the "Disable Resolving" option, you can use this option to hide unconfirmed items in the results.
+
+**Disable Reference Highlighting**
 
 By default, when you select some text, all instances of the same text are automatically highlighted in the current document. You can disable this feature by setting **Disable Reference Highlighting** to **True**.
 
- ## Text Editor
- **Enable Surround with Braces**
+## Text Editor
 
- If enabled, you can surround selected text with curly braces by typing '{' into the text editor.
+**Enable Surround with Braces**
 
- **Enable Surround with Parentheses**
+If enabled, you can surround selected text with curly braces by typing '{' into the text editor.
 
- If enabled, you can surround selected text with parentheses by typing '(' into the text editor.
+**Enable Surround with Parentheses**
+
+If enabled, you can surround selected text with parentheses by typing '(' into the text editor.
 
 ## See Also
 

--- a/docs/profiling/span-span-constructor.md
+++ b/docs/profiling/span-span-constructor.md
@@ -13,7 +13,9 @@ manager: jillfra
 ms.workload:
   - "multiple"
 ---
+
 # span::span Constructor
+
 Initializes a new instance of the `span` class.
 
 ## Syntax
@@ -46,22 +48,25 @@ span(
 ```
 
 #### Parameters
- `_Series`
- Valid marker series context.
 
- `_Format`
- A composite format string that contains text intermixed with zero or more format items, which correspond to objects in the argument list.
+`_Series`
+Valid marker series context.
 
- `_Importance`
- Importance level.
+`_Format`
+A composite format string that contains text intermixed with zero or more format items, which correspond to objects in the argument list.
 
- `_Category`
- Category.
+`_Importance`
+Importance level.
+
+`_Category`
+Category.
 
 ## Requirements
- **Header:** *cvmarkersobj.h*
 
- **Namespace:** Concurrency::diagnostic
+**Header:** *cvmarkersobj.h*
 
- ## See also
+**Namespace:** Concurrency::diagnostic
+
+## See also
+
 - [span class](../profiling/span-class.md)

--- a/docs/profiling/span-tilde-span-destructor.md
+++ b/docs/profiling/span-tilde-span-destructor.md
@@ -13,7 +13,9 @@ manager: jillfra
 ms.workload:
   - "multiple"
 ---
+
 # span::~span destructor
+
 Destroys the `span` object and releases its resources.
 
 ## Syntax
@@ -23,9 +25,11 @@ Destroys the `span` object and releases its resources.
 ```
 
 ## Requirements
- **Header:** *cvmarkersobj.h*
 
- **Namespace:** Concurrency::diagnostic
+**Header:** *cvmarkersobj.h*
 
- ## See also
+**Namespace:** Concurrency::diagnostic
+
+## See also
+
 - [span class](../profiling/span-class.md)

--- a/docs/vs-2015/deployment/how-to-publish-a-wpf-application-with-visual-styles-enabled.md
+++ b/docs/vs-2015/deployment/how-to-publish-a-wpf-application-with-visual-styles-enabled.md
@@ -10,153 +10,183 @@ author: mikejo5000
 ms.author: mikejo
 manager: jillfra
 ---
+
 # How to: Publish a WPF Application with Visual Styles Enabled
+
 [!INCLUDE[vs2017banner](../includes/vs2017banner.md)]
 
-Visual styles enable the appearance of common controls to change based on the theme chosen by the user. By default, visual styles are not enabled for Windows Presentation Foundation (WPF) applications, so you must enable them manually. However, enabling visual styles for a WPF application and then publishing the solution causes an error. This topic describes how to resolve this error and the process for publishing a WPF application with visual styles enabled. For more information about visual styles, see [Visual Styles Overview](http://msdn.microsoft.com/5b5d7bb6-684f-478d-bf5f-b8d18bbcff2e). For more information about the error message, see [Troubleshooting Specific Errors in ClickOnce Deployments](../deployment/troubleshooting-specific-errors-in-clickonce-deployments.md).  
-  
- To resolve the error and to publish the solution, you must perform the following tasks:  
-  
-- [Publish the solution without visual styles enabled](#BKMK_publishsolwovs).  
-  
-- [Create a manifest file](#BKMK_CreateManifest).  
-  
-- [Embed the manifest file into the executable file of the published solution](#BKMK_embedmanifest).  
-  
-- [Sign the application and deployment manifests](#BKMK_signappdeplyman).  
-  
-  Then, you can move the published files to the location from which you want end users to install the application.  
-  
-##  <a name="BKMK_publishsolwovs"></a> Publish the solution without visual styles enabled  
-  
-1.  Ensure that your project does not have visual styles enabled. First, check your project’s manifest file for the following XML. Then, if the XML is present, enclose the XML with a comment tag.  
-  
-     By default, visual styles are not enabled.  
-  
-    ```  
-    <dependency>    <dependentAssembly>      <assemblyIdentity          type="win32"          name="Microsoft.Windows.Common-Controls"          version="6.0.0.0"          processorArchitecture="*"          publicKeyToken="6595b64144ccf1df"          language="*"        />    </dependentAssembly>  </dependency>  
-    ```  
-  
-     The following procedures show how to open the manifest file associated with your project.  
-  
-    ###### To open the manifest file in a Visual Basic project  
-  
-    1.  On the menu bar, choose **Project**, _ProjectName_**Properties**, where *ProjectName* is the name of your WPF project.  
-  
-         The property pages for your WPF project appear.  
-  
-    2.  On the **Application** tab, choose **View Windows Settings**.  
-  
-         The app.manifest file opens in the **Code Editor**.  
-  
-    ###### To open the manifest file in a C# project  
-  
-    1.  On the menu bar, choose **Project**, _ProjectName_**Properties**, where *ProjectName* is the name of your WPF project.  
-  
-         The property pages for your WPF project appear.  
-  
-    2.  On the **Application** tab, make a note of the name that appears in the manifest field. This is the name of the manifest that is associated with your project.  
-  
+Visual styles enable the appearance of common controls to change based on the theme chosen by the user. By default, visual styles are not enabled for Windows Presentation Foundation (WPF) applications, so you must enable them manually. However, enabling visual styles for a WPF application and then publishing the solution causes an error. This topic describes how to resolve this error and the process for publishing a WPF application with visual styles enabled. For more information about visual styles, see [Visual Styles Overview](http://msdn.microsoft.com/5b5d7bb6-684f-478d-bf5f-b8d18bbcff2e). For more information about the error message, see [Troubleshooting Specific Errors in ClickOnce Deployments](../deployment/troubleshooting-specific-errors-in-clickonce-deployments.md).
+
+ To resolve the error and to publish the solution, you must perform the following tasks:
+
+- [Publish the solution without visual styles enabled](#BKMK_publishsolwovs).
+
+- [Create a manifest file](#BKMK_CreateManifest).
+
+- [Embed the manifest file into the executable file of the published solution](#BKMK_embedmanifest).
+
+- [Sign the application and deployment manifests](#BKMK_signappdeplyman).
+
+  Then, you can move the published files to the location from which you want end users to install the application.
+
+## <a name="BKMK_publishsolwovs"></a> Publish the solution without visual styles enabled
+
+1. Ensure that your project does not have visual styles enabled. First, check your project’s manifest file for the following XML. Then, if the XML is present, enclose the XML with a comment tag.
+
+     By default, visual styles are not enabled.
+
+    ```xml
+    <dependency>
+        <dependentAssembly>
+          <assemblyIdentity
+              type="win32"
+              name="Microsoft.Windows.Common-Controls"
+              version="6.0.0.0"
+              processorArchitecture="*"
+              publicKeyToken="6595b64144ccf1df"
+              language="*" />
+        </dependentAssembly>
+      </dependency>
+    ```
+
+     The following procedures show how to open the manifest file associated with your project.
+
+    **To open the manifest file in a Visual Basic project**
+
+    1. On the menu bar, choose **Project**, _ProjectName_**Properties**, where *ProjectName* is the name of your WPF project.
+
+         The property pages for your WPF project appear.
+
+    2. On the **Application** tab, choose **View Windows Settings**.
+
+         The app.manifest file opens in the **Code Editor**.
+
+    **To open the manifest file in a C# project**
+
+    1. On the menu bar, choose **Project**, _ProjectName_**Properties**, where *ProjectName* is the name of your WPF project.
+
+         The property pages for your WPF project appear.
+
+    2. On the **Application** tab, make a note of the name that appears in the manifest field. This is the name of the manifest that is associated with your project.
+
         > [!NOTE]
-        >  If **Embed manifest with default settings** or **Create application without manifest** appear in the manifest field, visual styles are not enabled. If the name of a manifest file appears in the manifest field, proceed to the next step in this procedure.  
-  
-    3.  In **Solution Explorer**, choose **Show All Files** ().  
-  
-         This button shows all project items, including those that have been excluded and those that are normally hidden. The manifest file appears as a project item.  
-  
-2.  Build and publish your solution. For more information about how to publish the solution, see [How to: Publish a ClickOnce Application using the Publish Wizard](../deployment/how-to-publish-a-clickonce-application-using-the-publish-wizard.md).  
-  
-##  <a name="BKMK_CreateManifest"></a> Create a manifest file  
-  
-1.  Paste the following XML into a Notepad file.  
-  
-     This XML describes the assembly that contains controls that support visual styles.  
-  
-    ```  
-    <?xml version="1.0" encoding="utf-8"?><asmv1:assembly manifestVersion="1.0"                xmlns="urn:schemas-microsoft-com:asm.v1"                xmlns:asmv1="urn:schemas-microsoft-com:asm.v1"                xmlns:asmv2="urn:schemas-microsoft-com:asm.v2"                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">  <dependency>    <dependentAssembly>      <assemblyIdentity        type="win32"        name="Microsoft.Windows.Common-Controls"        version="6.0.0.0"        processorArchitecture="*"        publicKeyToken="6595b64144ccf1df"        language="*"        />    </dependentAssembly>  </dependency></asmv1:assembly>  
-    ```  
-  
-2.  In Notepad, click **File**, and then click **Save As**.  
-  
-3.  In the **Save As** dialog box, in the **Save as type** drop-down list, select **All Files**.  
-  
-4.  In the **File name** box, name the file and append **.manifest** to the end of the file name. For example: **themes.manifest**.  
-  
-5.  Choose the **Browse Folders** button, select any folder, and then click **Save**.  
-  
+        > If **Embed manifest with default settings** or **Create application without manifest** appear in the manifest field, visual styles are not enabled. If the name of a manifest file appears in the manifest field, proceed to the next step in this procedure.
+
+    3. In **Solution Explorer**, choose **Show All Files** ().
+
+         This button shows all project items, including those that have been excluded and those that are normally hidden. The manifest file appears as a project item.
+
+2. Build and publish your solution. For more information about how to publish the solution, see [How to: Publish a ClickOnce Application using the Publish Wizard](../deployment/how-to-publish-a-clickonce-application-using-the-publish-wizard.md).
+
+## <a name="BKMK_CreateManifest"></a> Create a manifest file
+
+1. Paste the following XML into a Notepad file.
+
+     This XML describes the assembly that contains controls that support visual styles.
+
+    ```xml
+    <?xml version="1.0" encoding="utf-8"?>
+     <asmv1:assembly manifestVersion="1.0"
+         xmlns="urn:schemas-microsoft-com:asm.v1"
+         xmlns:asmv1="urn:schemas-microsoft-com:asm.v1"
+         xmlns:asmv2="urn:schemas-microsoft-com:asm.v2"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <dependency>
+        <dependentAssembly>
+          <assemblyIdentity
+            type="win32"
+            name="Microsoft.Windows.Common-Controls"
+            version="6.0.0.0"
+            processorArchitecture="*"
+            publicKeyToken="6595b64144ccf1df"
+            language="*" />
+        </dependentAssembly>
+      </dependency>
+    </asmv1:assembly>
+    ```
+
+2. In Notepad, click **File**, and then click **Save As**.
+
+3. In the **Save As** dialog box, in the **Save as type** drop-down list, select **All Files**.
+
+4. In the **File name** box, name the file and append **.manifest** to the end of the file name. For example: **themes.manifest**.
+
+5. Choose the **Browse Folders** button, select any folder, and then click **Save**.
+
     > [!NOTE]
-    >  The remaining procedures assume that the name of this file is **themes.manifest** and that the file is saved to the C:\temp directory on your computer.  
-  
-##  <a name="BKMK_embedmanifest"></a> Embed the manifest file into the executable file of the published solution  
-  
-1. Open the **Visual Studio Command Prompt**.  
-  
-    For more information about how to open the **Visual Studio Command Prompt**, see [Command Prompts](http://msdn.microsoft.com/library/94fcf524-9045-4993-bfb2-e2d8bad44219).  
-  
+    > The remaining procedures assume that the name of this file is **themes.manifest** and that the file is saved to the C:\temp directory on your computer.
+
+## <a name="BKMK_embedmanifest"></a> Embed the manifest file into the executable file of the published solution
+
+1. Open the **Visual Studio Command Prompt**.
+
+    For more information about how to open the **Visual Studio Command Prompt**, see [Command Prompts](http://msdn.microsoft.com/library/94fcf524-9045-4993-bfb2-e2d8bad44219).
+
    > [!NOTE]
-   >  The remaining steps make the following assumptions about your solution:  
-   > 
-   > - The name of the solution is **MyWPFProject**.  
-   >   -   The solution is located in the following directory: `%UserProfile%\Documents\Visual Studio 2010\Projects\`.  
-   > 
-   >   The solution is published to the following directory: `%UserProfile%\Documents\Visual Studio 2010\Projects\publish`.  
-   >   -   The most recent version of the published application files is located in the following directory: `%UserProfile%\Documents\Visual Studio 2010\Projects\publish\Application Files\WPFApp_1_0_0_0`  
-   > 
-   >   You do not have to use the name or the directory locations described above. The name and locations described above are used only to illustrate the steps required to publish your solution.  
-  
-2. At the command prompt, change the path to the directory that contains the most recent version of the published application files. The following example demonstrates this step.  
-  
-   ```  
-   cd "%UserProfile%\Documents\Visual Studio 2010\Projects\MyWPFProject\publish\Application Files\WPFApp_1_0_0_0"  
-   ```  
-  
-3. At the command prompt, run the following command to embed the manifest file into the executable file of the application.  
-  
-   ```  
-   mt –manifest c:\temp\themes.manifest –outputresource:MyWPFApp.exe.deploy  
-   ```  
-  
-##  <a name="BKMK_signappdeplyman"></a> Sign the application and deployment manifests  
-  
-1. At the command prompt, run the following command to remove the `.deploy` extension from the executable file in the current directory.  
-  
-   ```  
-   ren MyWPFApp.exe.deploy MyWPFApp.exe  
-   ```  
-  
+   > The remaining steps make the following assumptions about your solution:
+   >
+   > - The name of the solution is **MyWPFProject**.
+   > - The solution is located in the following directory: `%UserProfile%\Documents\Visual Studio 2010\Projects\`.
+   >
+   > - The solution is published to the following directory: `%UserProfile%\Documents\Visual Studio 2010\Projects\publish`.
+   > - The most recent version of the published application files is located in the following directory: `%UserProfile%\Documents\Visual Studio 2010\Projects\publish\Application Files\WPFApp_1_0_0_0`
+   >
+   > You do not have to use the name or the directory locations described above. The name and locations described above are used only to illustrate the steps required to publish your solution.
+
+2. At the command prompt, change the path to the directory that contains the most recent version of the published application files. The following example demonstrates this step.
+
+   ```
+   cd "%UserProfile%\Documents\Visual Studio 2010\Projects\MyWPFProject\publish\Application Files\WPFApp_1_0_0_0"
+   ```
+
+3. At the command prompt, run the following command to embed the manifest file into the executable file of the application.
+
+   ```
+   mt –manifest c:\temp\themes.manifest –outputresource:MyWPFApp.exe.deploy
+   ```
+
+## <a name="BKMK_signappdeplyman"></a> Sign the application and deployment manifests
+
+1. At the command prompt, run the following command to remove the `.deploy` extension from the executable file in the current directory.
+
+   ```
+   ren MyWPFApp.exe.deploy MyWPFApp.exe
+   ```
+
    > [!NOTE]
-   >  This example assumes that only one file has the `.deploy` file extension. Make sure that you rename all files in this directory that have the `.deploy` file extension.  
-  
-2. At the command prompt, run the following command to sign the application manifest.  
-  
-   ```  
-   mage -u MyWPFApp.exe.manifest -cf ..\..\..\MyWPFApp_TemporaryKey.pfx  
-   ```  
-  
+   > This example assumes that only one file has the `.deploy` file extension. Make sure that you rename all files in this directory that have the `.deploy` file extension.
+
+2. At the command prompt, run the following command to sign the application manifest.
+
+   ```
+   mage -u MyWPFApp.exe.manifest -cf ..\..\..\MyWPFApp_TemporaryKey.pfx
+   ```
+
    > [!NOTE]
-   >  This example assumes that you sign the manifest by using the `.pfx` file of the project. If you are not signing the manifest, you can omit the `–cf` parameter that is used in this example. If you are signing the manifest with a certificate that requires a password, specify the `–password` option (`For example: mage –u MyWPFApp.exe.manifest –cf ..\..\..\MyWPFApp_TemporaryKey.pfx – password Password`).  
-  
-3. At the command prompt, run the following command to add the `.deploy` extension to the name of the file that you renamed in a previous step of this procedure.  
-  
-   ```  
-   ren MyWPFApp.exe MyWPFApp.exe.deploy  
-   ```  
-  
+   > This example assumes that you sign the manifest by using the `.pfx` file of the project. If you are not signing the manifest, you can omit the `–cf` parameter that is used in this example. If you are signing the manifest with a certificate that requires a password, specify the `–password` option (`For example: mage –u MyWPFApp.exe.manifest –cf ..\..\..\MyWPFApp_TemporaryKey.pfx – password Password`).
+
+3. At the command prompt, run the following command to add the `.deploy` extension to the name of the file that you renamed in a previous step of this procedure.
+
+   ```
+   ren MyWPFApp.exe MyWPFApp.exe.deploy
+   ```
+
    > [!NOTE]
-   >  This example assumes that only one file had a `.deploy` file extension. Make sure that you rename all files in this directory that previously had the `.deploy` file name extension.  
-  
-4. At the command prompt, run the following command to sign the deployment manifest.  
-  
-   ```  
-   mage -u ..\..\MyWPFApp.application -appm MyWPFApp.exe.manifest -cf ..\..\..\MyWPFApp_TemporaryKey.pfx  
-   ```  
-  
+   > This example assumes that only one file had a `.deploy` file extension. Make sure that you rename all files in this directory that previously had the `.deploy` file name extension.
+
+4. At the command prompt, run the following command to sign the deployment manifest.
+
+   ```
+   mage -u ..\..\MyWPFApp.application -appm MyWPFApp.exe.manifest -cf ..\..\..\MyWPFApp_TemporaryKey.pfx
+   ```
+
    > [!NOTE]
-   >  This example assumes that you sign the manifest by using the `.pfx` file of the project. If you are not signing the manifest, you can omit the `–cf` parameter that is used in this example. If you are signing the manifest with a certificate that requires a password, specify the `–password` option, as in this example:`For example: mage –u MyWPFApp.exe.manifest –cf ..\..\..\MyWPFApp_TemporaryKey.pfx – password Password`.  
-  
-   After you have performed these steps, you can move the published files to the location from which you want end users to install the application. If you intend to update the solution often, you can move these commands into a script and run the script each time that you publish a new version.  
-  
-## See Also  
- [Troubleshooting Specific Errors in ClickOnce Deployments](../deployment/troubleshooting-specific-errors-in-clickonce-deployments.md)   
- [Visual Styles Overview](http://msdn.microsoft.com/5b5d7bb6-684f-478d-bf5f-b8d18bbcff2e)   
- [Command Prompts](http://msdn.microsoft.com/library/94fcf524-9045-4993-bfb2-e2d8bad44219)
+   > This example assumes that you sign the manifest by using the `.pfx` file of the project. If you are not signing the manifest, you can omit the `–cf` parameter that is used in this example. If you are signing the manifest with a certificate that requires a password, specify the `–password` option, as in this example:`For example: mage –u MyWPFApp.exe.manifest –cf ..\..\..\MyWPFApp_TemporaryKey.pfx – password Password`.
+
+   After you have performed these steps, you can move the published files to the location from which you want end users to install the application. If you intend to update the solution often, you can move these commands into a script and run the script each time that you publish a new version.
+
+## See Also
+
+[Troubleshooting Specific Errors in ClickOnce Deployments](../deployment/troubleshooting-specific-errors-in-clickonce-deployments.md)
+[Visual Styles Overview](http://msdn.microsoft.com/5b5d7bb6-684f-478d-bf5f-b8d18bbcff2e)
+[Command Prompts](http://msdn.microsoft.com/library/94fcf524-9045-4993-bfb2-e2d8bad44219)

--- a/docs/vs-2015/extensibility/managing-side-by-side-file-associations.md
+++ b/docs/vs-2015/extensibility/managing-side-by-side-file-associations.md
@@ -4,80 +4,85 @@ ms.date: 11/15/2016
 ms.prod: "visual-studio-dev14"
 ms.technology: "vs-ide-sdk"
 ms.topic: conceptual
-helpviewer_keywords: 
+helpviewer_keywords:
   - "verbs, setting default"
 ms.assetid: 9b6df3bc-d15c-4a5d-9015-948a806193b7
 caps.latest.revision: 18
 ms.author: gregvanl
 manager: jillfra
 ---
+
 # Managing Side-by-Side File Associations
+
 [!INCLUDE[vs2017banner](../includes/vs2017banner.md)]
 
-If your VSPackage provides file associations, you must decide how to handle side-by-side installations in which a particular version of [!INCLUDE[vsprvs](../includes/vsprvs-md.md)] should be invoked to open a file. Incompatible file formats compound the issue.  
-  
- Users expect a new version of a product to be compatible with earlier versions, so that existing files can be loaded in a new version without losing data. Ideally, your VSPackage can both load and save the file formats of earlier versions. If that is not true, you should offer to upgrade the file format to the new version of your VSPackage. The downside to this approach is that the upgraded file cannot be opened in the earlier version.  
-  
- To avoid this issue, you can change extensions when file formats become incompatible. For example, version 1 of your VSPackage could use the extension, .mypkg10, and version 2 could use the extension, .mypkg20. This difference identifies the VSPackage that opens a particular file. If you add newer VSPackages to the list of programs that are associated with an old extension, users can right-click the file and choose to open it in a newer VSPackage. At that point, your VSPackage can offer to upgrade the file to the new format or open the file and maintain compatibility with earlier versions of the VSPackage.  
-  
+If your VSPackage provides file associations, you must decide how to handle side-by-side installations in which a particular version of [!INCLUDE[vsprvs](../includes/vsprvs-md.md)] should be invoked to open a file. Incompatible file formats compound the issue.
+
+Users expect a new version of a product to be compatible with earlier versions, so that existing files can be loaded in a new version without losing data. Ideally, your VSPackage can both load and save the file formats of earlier versions. If that is not true, you should offer to upgrade the file format to the new version of your VSPackage. The downside to this approach is that the upgraded file cannot be opened in the earlier version.
+
+To avoid this issue, you can change extensions when file formats become incompatible. For example, version 1 of your VSPackage could use the extension, .mypkg10, and version 2 could use the extension, .mypkg20. This difference identifies the VSPackage that opens a particular file. If you add newer VSPackages to the list of programs that are associated with an old extension, users can right-click the file and choose to open it in a newer VSPackage. At that point, your VSPackage can offer to upgrade the file to the new format or open the file and maintain compatibility with earlier versions of the VSPackage.
+
 > [!NOTE]
->  You can combine these approaches. For example, you can offer backward compatibility by loading an older file and offer to upgrade the file format when the user saves it.  
-  
-## Facing the Problem  
- If you want multiple side-by-side VSPackages to use the same extension, you must choose the version of [!INCLUDE[vsprvs](../includes/vsprvs-md.md)] that is associated with the extension. Here are two alternatives:  
-  
-- Open the file in the latest version of [!INCLUDE[vsprvs](../includes/vsprvs-md.md)] installed on a user's computer.  
-  
-   In this approach, your installer is responsible for determining the latest version of [!INCLUDE[vsprvs](../includes/vsprvs-md.md)] and including that in the registry entry written for the file association. In a Windows Installer package, you can include custom actions to set a property that indicates the latest version of [!INCLUDE[vsprvs](../includes/vsprvs-md.md)].  
-  
+> You can combine these approaches. For example, you can offer backward compatibility by loading an older file and offer to upgrade the file format when the user saves it.
+
+## Facing the Problem
+
+If you want multiple side-by-side VSPackages to use the same extension, you must choose the version of [!INCLUDE[vsprvs](../includes/vsprvs-md.md)] that is associated with the extension. Here are two alternatives:
+
+- Open the file in the latest version of [!INCLUDE[vsprvs](../includes/vsprvs-md.md)] installed on a user's computer.
+
+   In this approach, your installer is responsible for determining the latest version of [!INCLUDE[vsprvs](../includes/vsprvs-md.md)] and including that in the registry entry written for the file association. In a Windows Installer package, you can include custom actions to set a property that indicates the latest version of [!INCLUDE[vsprvs](../includes/vsprvs-md.md)].
+
   > [!NOTE]
-  >  In this context, "latest" means "latest supported version." These installer entries will not automatically detect a subsequent release of [!INCLUDE[vsprvs](../includes/vsprvs-md.md)]. Entries in [Detecting System Requirements](../extensibility/internals/detecting-system-requirements.md) and in [Commands That Must Be Run After Installation](../extensibility/internals/commands-that-must-be-run-after-installation.md) are similar to the ones presented here and are required to support additional versions of [!INCLUDE[vsprvs](../includes/vsprvs-md.md)].  
-  
-   The following rows in the CustomAction table set the DEVENV_EXE_LATEST property to be a property set by the AppSearch and RegLocator tables discussed in [Commands That Must Be Run After Installation](../extensibility/internals/commands-that-must-be-run-after-installation.md). Rows in the InstallExecuteSequence table schedule the custom actions early in the execute sequence. Values in the Condition column make the logic work:  
-  
-  - Visual Studio .NET 2002 is the latest version if it is the only present version.  
-  
-  - Visual Studio .NET 2003 is the latest version only if it is present and [!INCLUDE[vsprvs](../includes/vsprvs-md.md)] is not present.  
-  
-  - [!INCLUDE[vsprvs](../includes/vsprvs-md.md)] is the latest version if it is the only present version.  
-  
-    The net result is that DEVENV_EXE_LATEST contains the path of the latest version of devenv.exe.  
-  
-  ### CustomAction table rows that determine the latest version of Visual Studio  
-  
-  |Action|Type|Source|Target|  
-  |------------|----------|------------|------------|  
-  |CA_SetDevenvLatest_2002|51|DEVENV_EXE_LATEST|[DEVENV_EXE_2002]|  
-  |CA_SetDevenvLatest_2003|51|DEVENV_EXE_LATEST|[DEVENV_EXE_2003]|  
-  |CA_SetDevenvLatest_2005|51|DEVENV_EXE_LATEST|[DEVENV_EXE_2005]|  
-  
-  ### InstallExecuteSequence table rows that determine the latest version of Visual Studio  
-  
-  |Action|Condition|Sequence|  
-  |------------|---------------|--------------|  
-  |CA_SetDevenvLatest_2002|DEVENV_EXE_2002 AND NOT (DEVENV_EXE_2003 OR DEVENV_EXE_2005)|410|  
-  |CA_SetDevenvLatest_2003|DEVENV_EXE_2003 AND NOT DEVENV_EXE_2005|420|  
-  |CA_SetDevenvLatest_2005|DEVENV_EXE_2005|430|  
-  
-   You can use the DEVENV_EXE_LATEST property in the Registry table of the Windows Installer package to write the HKEY_CLASSES_ROOT*ProgId*ShellOpenCommand key's default value, [DEVENV_EXE_LATEST] "%1"  
-  
-- Run a shared launcher program that can make the best choice from available VSPackage versions.  
-  
-   The developers of [!INCLUDE[vsprvs](../includes/vsprvs-md.md)] chose this approach to handle the complex requirements of the multiple formats of solutions and projects that result from many versions of [!INCLUDE[vsprvs](../includes/vsprvs-md.md)]. In this approach, you register a launcher program as the extension handler. The launcher examines the file and decides which version of [!INCLUDE[vsprvs](../includes/vsprvs-md.md)] and your VSPackage can handle that particular file. For example, if a user opens a file that was last saved by a particular version of your VSPackage, the launcher can start that VSPackage in the matching version of [!INCLUDE[vsprvs](../includes/vsprvs-md.md)]. In addition, a user could configure the launcher to always start the latest version. A launcher also could prompt a user to upgrade the format of the file. If the format of the file includes a version number, the launcher could inform a user if the file format is from a version that is later than one or more of the installed VSPackages.  
-  
-   The launcher should be in a Windows Installer component that is shared with all versions of your VSPackage. This process makes sure that the latest version is always installed and is not removed until all versions of your VSPackage are uninstalled. In this way, the file associations and other registry entries of the launcher component are preserved even if one version of the VSPackage is uninstalled.  
-  
-## Uninstall and File Associations  
- Uninstalling a VSPackage that writes registry entries for file associations removes the file associations. Therefore, the extension has no associated programs. Windows Installer does not "recover" the registry entries that were added when the VSPackage was installed. Here are some ways to fix a user's file associations:  
-  
--   Use a shared launcher component as previously described.  
-  
--   Instruct the user to run a repair of the version of the VSPackage that the user wants to own the file association.  
-  
--   Provide a separate executable program that rewrites the appropriate registry entries.  
-  
--   Provide a configuration options page or dialog box that lets users choose file associations and reclaim lost associations. Instruct users to run it after uninstallation.  
-  
-## See Also  
- [Registering File Name Extensions for Side-By-Side Deployments](../extensibility/registering-file-name-extensions-for-side-by-side-deployments.md)   
- [Registering Verbs for File Name Extensions](../extensibility/registering-verbs-for-file-name-extensions.md)
+  > In this context, "latest" means "latest supported version." These installer entries will not automatically detect a subsequent release of [!INCLUDE[vsprvs](../includes/vsprvs-md.md)]. Entries in [Detecting System Requirements](../extensibility/internals/detecting-system-requirements.md) and in [Commands That Must Be Run After Installation](../extensibility/internals/commands-that-must-be-run-after-installation.md) are similar to the ones presented here and are required to support additional versions of [!INCLUDE[vsprvs](../includes/vsprvs-md.md)].
+
+   The following rows in the CustomAction table set the DEVENV_EXE_LATEST property to be a property set by the AppSearch and RegLocator tables discussed in [Commands That Must Be Run After Installation](../extensibility/internals/commands-that-must-be-run-after-installation.md). Rows in the InstallExecuteSequence table schedule the custom actions early in the execute sequence. Values in the Condition column make the logic work:
+
+  - Visual Studio .NET 2002 is the latest version if it is the only present version.
+
+  - Visual Studio .NET 2003 is the latest version only if it is present and [!INCLUDE[vsprvs](../includes/vsprvs-md.md)] is not present.
+
+  - [!INCLUDE[vsprvs](../includes/vsprvs-md.md)] is the latest version if it is the only present version.
+
+    The net result is that DEVENV_EXE_LATEST contains the path of the latest version of devenv.exe.
+
+  **CustomAction table rows that determine the latest version of Visual Studio**
+
+  |Action|Type|Source|Target|
+  |------------|----------|------------|------------|
+  |CA_SetDevenvLatest_2002|51|DEVENV_EXE_LATEST|[DEVENV_EXE_2002]|
+  |CA_SetDevenvLatest_2003|51|DEVENV_EXE_LATEST|[DEVENV_EXE_2003]|
+  |CA_SetDevenvLatest_2005|51|DEVENV_EXE_LATEST|[DEVENV_EXE_2005]|
+
+  **InstallExecuteSequence table rows that determine the latest version of Visual Studio**
+
+  |Action|Condition|Sequence|
+  |------------|---------------|--------------|
+  |CA_SetDevenvLatest_2002|DEVENV_EXE_2002 AND NOT (DEVENV_EXE_2003 OR DEVENV_EXE_2005)|410|
+  |CA_SetDevenvLatest_2003|DEVENV_EXE_2003 AND NOT DEVENV_EXE_2005|420|
+  |CA_SetDevenvLatest_2005|DEVENV_EXE_2005|430|
+
+   You can use the DEVENV_EXE_LATEST property in the Registry table of the Windows Installer package to write the HKEY_CLASSES_ROOT*ProgId*ShellOpenCommand key's default value, [DEVENV_EXE_LATEST] "%1"
+
+- Run a shared launcher program that can make the best choice from available VSPackage versions.
+
+   The developers of [!INCLUDE[vsprvs](../includes/vsprvs-md.md)] chose this approach to handle the complex requirements of the multiple formats of solutions and projects that result from many versions of [!INCLUDE[vsprvs](../includes/vsprvs-md.md)]. In this approach, you register a launcher program as the extension handler. The launcher examines the file and decides which version of [!INCLUDE[vsprvs](../includes/vsprvs-md.md)] and your VSPackage can handle that particular file. For example, if a user opens a file that was last saved by a particular version of your VSPackage, the launcher can start that VSPackage in the matching version of [!INCLUDE[vsprvs](../includes/vsprvs-md.md)]. In addition, a user could configure the launcher to always start the latest version. A launcher also could prompt a user to upgrade the format of the file. If the format of the file includes a version number, the launcher could inform a user if the file format is from a version that is later than one or more of the installed VSPackages.
+
+   The launcher should be in a Windows Installer component that is shared with all versions of your VSPackage. This process makes sure that the latest version is always installed and is not removed until all versions of your VSPackage are uninstalled. In this way, the file associations and other registry entries of the launcher component are preserved even if one version of the VSPackage is uninstalled.
+
+## Uninstall and File Associations
+
+Uninstalling a VSPackage that writes registry entries for file associations removes the file associations. Therefore, the extension has no associated programs. Windows Installer does not "recover" the registry entries that were added when the VSPackage was installed. Here are some ways to fix a user's file associations:
+
+- Use a shared launcher component as previously described.
+
+- Instruct the user to run a repair of the version of the VSPackage that the user wants to own the file association.
+
+- Provide a separate executable program that rewrites the appropriate registry entries.
+
+- Provide a configuration options page or dialog box that lets users choose file associations and reclaim lost associations. Instruct users to run it after uninstallation.
+
+## See Also
+
+[Registering File Name Extensions for Side-By-Side Deployments](../extensibility/registering-file-name-extensions-for-side-by-side-deployments.md)
+[Registering Verbs for File Name Extensions](../extensibility/registering-verbs-for-file-name-extensions.md)

--- a/docs/vs-2015/modeling/structure-your-modeling-solution.md
+++ b/docs/vs-2015/modeling/structure-your-modeling-solution.md
@@ -10,103 +10,109 @@ author: gewarren
 ms.author: gewarren
 manager: jillfra
 ---
+
 # Structure your modeling solution
+
 [!INCLUDE[vs2017banner](../includes/vs2017banner.md)]
 
-To use models effectively in a development project, the team members must be able to work on models of different parts of the project at the same time. This topic suggests a scheme for dividing the application into different parts that correspond to the layers in an overall layering diagram.  
-  
- To start on a project or subproject quickly, it is useful to have a project template that follows the project structure that you have chosen. This topic describes how to create and use such a template.  
-  
- This topic assumes that you are working on a project that is large enough to require several team members, and perhaps has several teams. The code and models of the project are stored on a source control system such as [!INCLUDE[esprtfs](../includes/esprtfs-md.md)]. At least some team members use Visual Studio to develop models, and other team members can view the models by using other Visual Studio versions.  
-  
- To see which versions of Visual Studio support each tool and modeling feature, see [Version support for architecture and modeling tools](../modeling/what-s-new-for-design-in-visual-studio.md#VersionSupport).  
-  
-## Solution structure  
- In a medium or large project, the structure of the team is based on the structure of the application. Each team uses a Visual Studio solution.  
-  
-#### To divide an application into layers  
-  
-1. Base the structure of your solutions on the structure of your application, such as web application, service application, or desktop application. A variety of common architectures is discussed in [Application Archetypes in the Microsoft Application Architecture Guide](http://go.microsoft.com/fwlink/?LinkId=196681).  
-  
-2. Create a [!INCLUDE[vsprvs](../includes/vsprvs-md.md)] solution, which we will call the Architecture solution. This solution will be used to create the overall design of the system. It will contain models but no code.  
-  
-    Add a layer diagram to this solution. On the layer diagram, draw the architecture you have chosen for your application. For example, the diagram might show these layers and the dependencies between them: Presentation; Business logic; and Data.  
-  
-    You can create the layer diagram and a new Visual Studio solution at the same time by using the **New UML or Layer Diagram** command on the **Architecture** menu.  
-  
-3. Add to the Architecture model UML diagrams that represent the important business concepts, and use cases that are referred to in the design of all the layers.  
-  
-4. Create a separate Visual Studio solution for each layer in the Architecture layer diagram.  
-  
-    These solutions will be used to develop the code of the layers.  
-  
-5. Create UML models that will represent the designs of the layers and the concepts that are common to all the layers. Arrange the models so that all the models can be seen from the Architecture solution, and the relevant models can be seen from each layer.  
-  
-    You can achieve this by using either of the following procedures. The first alternative creates a separate modeling project for each layer, and the second creates a single modeling project that is shared between the layers.  
-  
-   ###### To use a separate modeling project for each layer  
-  
-   1. Create a modeling project in each layer solution.  
-  
-       This model will contain UML diagrams that describe the requirements and design of that layer. It can also contain layer diagrams that show nested layers.  
-  
-       You now have a model for each layer, plus a model for the application architecture. Each model is contained in its own solution. This enables team members to work on the layers at the same time.  
-  
-   2. To the Architecture solution, add the modeling project of each layer solution. To do this, open the Architecture solution. In Solution Explorer, right-click the solution node, point to Add, and then click **Existing Project**. Navigate to the modeling project (.modelproj) in one layer solution.  
-  
-       Each model is now visible in two solutions: its "home" solution and the Architecture solution.  
-  
-   3. To the modeling project of each layer, add a layer diagram. Start with a copy of the Architecture layer diagram. You can delete parts that are not dependencies of the layer diagram.  
-  
-       You can also add layer diagrams that represent the detailed structure of this layer.  
-  
-       These diagrams are used to validate the code that is developed in this layer.  
-  
-   4. In the Architecture solution, edit the requirements and design models of all the layers by using Visual Studio.  
-  
-       In each layer solution, develop the code for that layer, referring to the model. If you are content to do the development without using the same computer to update the model, you can read the model and develop code by using versions of Visual Studio that cannot create models. You can also generate code from the model in these versions.  
-  
-      This method guarantees that no interference will be caused by developers who edit the layer models at the same time.  
-  
-      However, because the models are separate, it is difficult to refer to common concepts. Each model must have its own copy of the elements on which it is dependent from other layers and the architecture. The layer diagram in each layer must be kept in sync with the Architecture layer diagram. It is difficult to maintain synchronization when these elements change, although you could develop tools to accomplish this.  
-  
-   ###### To use a separate package for each layer  
-  
-   1. In the solution for each layer, add the Architecture modeling project. In Solution Explorer, right-click the solution node, point to **Add**, and then click **Existing Project**. The single modeling project can now be accessed from every solution: the Architecture project, and the development project for each layer.  
-  
-   2. In the shared UML model, create a package for each layer: In Solution Explorer, select the modeling project. In UML Model Explorer, right-click the model root node, point to **Add**, and then click **Package**.  
-  
-       Each package will contain UML diagrams that describe the requirements and design of the corresponding layer.  
-  
-   3. If required, add local layer diagrams for the internal structure of each layer.  
-  
-      This method allows the design elements of each layer to refer directly to those of the layers and common architecture on which it depends.  
-  
-      Although concurrent work on different packages can cause some conflicts, they are fairly easy to manage because the packages are stored in separate files. The major difficulty is caused by the deletion of an element that is referenced from a dependent package. For more information, see [Manage models and diagrams under version control](../modeling/manage-models-and-diagrams-under-version-control.md).  
-  
-## Creating architecture templates  
- In practice, you will not create all your Visual Studio solutions at the same time, but add them as the project progresses. You will probably also use the same solution structure in future projects.  To help you create new solutions quickly, you can create a solution or project template. You can capture the template in a Visual Studio Integration Extension (VSIX) so that it is easy to distribute and to install on other computers.  
-  
- For example, if you frequently use solutions that have Presentation, Business, and Data layers, you can configure a template that will create new solutions that have that structure.  
-  
-#### To create a solution template  
-  
-1.  [Download and install the Export Template Wizard](http://go.microsoft.com/fwlink/?LinkId=196686), if you have not already done this.  
-  
-2.  Create the solution structure that you want to use as a starting point for future projects.  
-  
-3.  On the **File** menu, click **Export Template as VSIX**. The **Export Template as VSIX Wizard** opens.  
-  
-4.  Following the instructions in the wizard, select the projects that you want to include in the template, provide a name and description for the template, and specify an output location.  
-  
+To use models effectively in a development project, the team members must be able to work on models of different parts of the project at the same time. This topic suggests a scheme for dividing the application into different parts that correspond to the layers in an overall layering diagram.
+
+To start on a project or subproject quickly, it is useful to have a project template that follows the project structure that you have chosen. This topic describes how to create and use such a template.
+
+This topic assumes that you are working on a project that is large enough to require several team members, and perhaps has several teams. The code and models of the project are stored on a source control system such as [!INCLUDE[esprtfs](../includes/esprtfs-md.md)]. At least some team members use Visual Studio to develop models, and other team members can view the models by using other Visual Studio versions.
+
+To see which versions of Visual Studio support each tool and modeling feature, see [Version support for architecture and modeling tools](../modeling/what-s-new-for-design-in-visual-studio.md#VersionSupport).
+
+## Solution structure
+
+In a medium or large project, the structure of the team is based on the structure of the application. Each team uses a Visual Studio solution.
+
+#### To divide an application into layers
+
+1. Base the structure of your solutions on the structure of your application, such as web application, service application, or desktop application. A variety of common architectures is discussed in [Application Archetypes in the Microsoft Application Architecture Guide](http://go.microsoft.com/fwlink/?LinkId=196681).
+
+2. Create a [!INCLUDE[vsprvs](../includes/vsprvs-md.md)] solution, which we will call the Architecture solution. This solution will be used to create the overall design of the system. It will contain models but no code.
+
+    Add a layer diagram to this solution. On the layer diagram, draw the architecture you have chosen for your application. For example, the diagram might show these layers and the dependencies between them: Presentation; Business logic; and Data.
+
+    You can create the layer diagram and a new Visual Studio solution at the same time by using the **New UML or Layer Diagram** command on the **Architecture** menu.
+
+3. Add to the Architecture model UML diagrams that represent the important business concepts, and use cases that are referred to in the design of all the layers.
+
+4. Create a separate Visual Studio solution for each layer in the Architecture layer diagram.
+
+    These solutions will be used to develop the code of the layers.
+
+5. Create UML models that will represent the designs of the layers and the concepts that are common to all the layers. Arrange the models so that all the models can be seen from the Architecture solution, and the relevant models can be seen from each layer.
+
+    You can achieve this by using either of the following procedures. The first alternative creates a separate modeling project for each layer, and the second creates a single modeling project that is shared between the layers.
+
+###### To use a separate modeling project for each layer
+
+1. Create a modeling project in each layer solution.
+
+    This model will contain UML diagrams that describe the requirements and design of that layer. It can also contain layer diagrams that show nested layers.
+
+    You now have a model for each layer, plus a model for the application architecture. Each model is contained in its own solution. This enables team members to work on the layers at the same time.
+
+2. To the Architecture solution, add the modeling project of each layer solution. To do this, open the Architecture solution. In Solution Explorer, right-click the solution node, point to Add, and then click **Existing Project**. Navigate to the modeling project (.modelproj) in one layer solution.
+
+    Each model is now visible in two solutions: its "home" solution and the Architecture solution.
+
+3. To the modeling project of each layer, add a layer diagram. Start with a copy of the Architecture layer diagram. You can delete parts that are not dependencies of the layer diagram.
+
+    You can also add layer diagrams that represent the detailed structure of this layer.
+
+    These diagrams are used to validate the code that is developed in this layer.
+
+4. In the Architecture solution, edit the requirements and design models of all the layers by using Visual Studio.
+
+    In each layer solution, develop the code for that layer, referring to the model. If you are content to do the development without using the same computer to update the model, you can read the model and develop code by using versions of Visual Studio that cannot create models. You can also generate code from the model in these versions.
+
+    This method guarantees that no interference will be caused by developers who edit the layer models at the same time.
+
+    However, because the models are separate, it is difficult to refer to common concepts. Each model must have its own copy of the elements on which it is dependent from other layers and the architecture. The layer diagram in each layer must be kept in sync with the Architecture layer diagram. It is difficult to maintain synchronization when these elements change, although you could develop tools to accomplish this.
+
+###### To use a separate package for each layer
+
+1. In the solution for each layer, add the Architecture modeling project. In Solution Explorer, right-click the solution node, point to **Add**, and then click **Existing Project**. The single modeling project can now be accessed from every solution: the Architecture project, and the development project for each layer.
+
+2. In the shared UML model, create a package for each layer: In Solution Explorer, select the modeling project. In UML Model Explorer, right-click the model root node, point to **Add**, and then click **Package**.
+
+    Each package will contain UML diagrams that describe the requirements and design of the corresponding layer.
+
+3. If required, add local layer diagrams for the internal structure of each layer.
+
+    This method allows the design elements of each layer to refer directly to those of the layers and common architecture on which it depends.
+
+    Although concurrent work on different packages can cause some conflicts, they are fairly easy to manage because the packages are stored in separate files. The major difficulty is caused by the deletion of an element that is referenced from a dependent package. For more information, see [Manage models and diagrams under version control](../modeling/manage-models-and-diagrams-under-version-control.md).
+
+## Creating architecture templates
+
+In practice, you will not create all your Visual Studio solutions at the same time, but add them as the project progresses. You will probably also use the same solution structure in future projects.  To help you create new solutions quickly, you can create a solution or project template. You can capture the template in a Visual Studio Integration Extension (VSIX) so that it is easy to distribute and to install on other computers.
+
+For example, if you frequently use solutions that have Presentation, Business, and Data layers, you can configure a template that will create new solutions that have that structure.
+
+#### To create a solution template
+
+1. [Download and install the Export Template Wizard](http://go.microsoft.com/fwlink/?LinkId=196686), if you have not already done this.
+
+2. Create the solution structure that you want to use as a starting point for future projects.
+
+3. On the **File** menu, click **Export Template as VSIX**. The **Export Template as VSIX Wizard** opens.
+
+4. Following the instructions in the wizard, select the projects that you want to include in the template, provide a name and description for the template, and specify an output location.
+
 > [!NOTE]
->  The material in this topic is abstracted and paraphrased from the Visual Studio Architecture Tooling Guidance, written by the Visual Studio ALM Rangers, which is a collaboration between Most Valued Professionals (MVPs), Microsoft Services, and the Visual Studio product team and writers. [Click here to download the complete Guidance package.](http://go.microsoft.com/fwlink/?LinkID=191984)  
-  
-## Related materials  
- [Organizing and Managing Your Models](http://channel9.msdn.com/posts/clinted/UML-with-VS-2010-Part-9-Organizing-and-Managing-Your-Models/) - video by Clint Edmondson.  
-  
- [Visual Studio Architecture Tooling Guidance](../modeling/visual-studio-architecture-tooling-guidance.md) – Further guidance on managing models in a team  
-  
-## See Also  
- [Manage models and diagrams under version control](../modeling/manage-models-and-diagrams-under-version-control.md)   
- [Use models in your development process](../modeling/use-models-in-your-development-process.md)
+> The material in this topic is abstracted and paraphrased from the Visual Studio Architecture Tooling Guidance, written by the Visual Studio ALM Rangers, which is a collaboration between Most Valued Professionals (MVPs), Microsoft Services, and the Visual Studio product team and writers. [Click here to download the complete Guidance package.](http://go.microsoft.com/fwlink/?LinkID=191984)
+
+## Related materials
+
+[Organizing and Managing Your Models](http://channel9.msdn.com/posts/clinted/UML-with-VS-2010-Part-9-Organizing-and-Managing-Your-Models/) - video by Clint Edmondson.
+
+[Visual Studio Architecture Tooling Guidance](../modeling/visual-studio-architecture-tooling-guidance.md) – Further guidance on managing models in a team
+
+## See Also
+
+[Manage models and diagrams under version control](../modeling/manage-models-and-diagrams-under-version-control.md)
+[Use models in your development process](../modeling/use-models-in-your-development-process.md)

--- a/docs/vs-2015/profiling/span-span-constructor.md
+++ b/docs/vs-2015/profiling/span-span-constructor.md
@@ -4,9 +4,9 @@ ms.date: 11/15/2016
 ms.prod: "visual-studio-dev14"
 ms.technology: "vs-ide-debug"
 ms.topic: conceptual
-f1_keywords: 
+f1_keywords:
   - "cvmarkersobj/Concurrency::diagnostic::span::span"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "Concurrency::diagnostic::span constructor"
 ms.assetid: 8b5578aa-5e5c-4ac7-87c7-ce87c4246e2c
 caps.latest.revision: 10
@@ -14,57 +14,62 @@ author: MikeJo5000
 ms.author: mikejo
 manager: jillfra
 ---
+
 # span::span Constructor
+
 [!INCLUDE[vs2017banner](../includes/vs2017banner.md)]
 
-Initializes a new instance of the `span` class.  
-  
-## Syntax  
-  
-```  
-span(  
-   const marker_series& _Series,  
-   _In_ LPCTSTR _Format,  
-   ...  
-);  
-span(  
-   const marker_series& _Series,  
-   marker_importance _Importance,  
-   _In_ LPCTSTR _Format,  
-   ...  
-);  
-span(  
-   const marker_series& _Series,  
-   int _Category,  
-   _In_ LPCTSTR _Format,  
-   ...  
-);  
-span(  
-   const marker_series& _Series,  
-   marker_importance _Importance,  
-   int _Category,  
-   _In_ LPCTSTR _Format,  
-   ...  
-);  
-```  
-  
-#### Parameters  
- `_Series`  
- Valid marker series context.  
-  
- `_Format`  
- A composite format string that contains text intermixed with zero or more format items, which correspond to objects in the argument list.  
-  
- `_Importance`  
- Importance level.  
-  
- `_Category`  
- Category.  
-  
-## Requirements  
- **Header:** cvmarkersobj.h  
-  
- **Namespace:** Concurrency::diagnostic
- 
- ## See Also
- [span Class](../profiling/span-class.md)
+Initializes a new instance of the `span` class.
+
+## Syntax
+
+```
+span(
+   const marker_series& _Series,
+   _In_ LPCTSTR _Format,
+   ...
+);
+span(
+   const marker_series& _Series,
+   marker_importance _Importance,
+   _In_ LPCTSTR _Format,
+   ...
+);
+span(
+   const marker_series& _Series,
+   int _Category,
+   _In_ LPCTSTR _Format,
+   ...
+);
+span(
+   const marker_series& _Series,
+   marker_importance _Importance,
+   int _Category,
+   _In_ LPCTSTR _Format,
+   ...
+);
+```
+
+#### Parameters
+
+`_Series`
+Valid marker series context.
+
+`_Format`
+A composite format string that contains text intermixed with zero or more format items, which correspond to objects in the argument list.
+
+`_Importance`
+Importance level.
+
+`_Category`
+ Category.
+
+## Requirements
+
+**Header:** cvmarkersobj.h
+
+**Namespace:** Concurrency::diagnostic
+
+## See Also
+
+[span Class](../profiling/span-class.md)

--- a/docs/vs-2015/profiling/span-tilde-span-destructor.md
+++ b/docs/vs-2015/profiling/span-tilde-span-destructor.md
@@ -4,9 +4,9 @@ ms.date: 11/15/2016
 ms.prod: "visual-studio-dev14"
 ms.technology: "vs-ide-debug"
 ms.topic: conceptual
-f1_keywords: 
+f1_keywords:
   - "cvmarkersobj/Concurrency::diagnostic::span::~span"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "Concurrency::diagnostic::span::~span destructor"
 ms.assetid: 9ff61542-9be7-4e81-bfe5-5d2c6eb112c1
 caps.latest.revision: 10
@@ -14,21 +14,25 @@ author: MikeJo5000
 ms.author: mikejo
 manager: jillfra
 ---
+
 # span::~span Destructor
+
 [!INCLUDE[vs2017banner](../includes/vs2017banner.md)]
 
-Destroys the `span` object and releases its resources.  
-  
-## Syntax  
-  
-```  
-~span();  
-```  
-  
-## Requirements  
- **Header:** cvmarkersobj.h  
-  
- **Namespace:** Concurrency::diagnostic
- 
- ## See Also
- [span Class](../profiling/span-class.md)
+Destroys the `span` object and releases its resources.
+
+## Syntax
+
+```
+~span();
+```
+
+## Requirements
+
+**Header:** cvmarkersobj.h
+
+**Namespace:** Concurrency::diagnostic
+
+## See Also
+
+[span Class](../profiling/span-class.md)


### PR DESCRIPTION

- Combined double Example headings in code quality docs
- Spaces around headers
- Leading spaces in lists
- Leading spaces in paragraphs
- Replace nested headers in lists with bold
- Remove incorrect code fence languges
- Trim trailing spaces