### PR TITLE
Added typescript as a code snippet language

### DIFF
--- a/docs/ide/code-snippets-schema-reference.md
+++ b/docs/ide/code-snippets-schema-reference.md
@@ -111,6 +111,7 @@ There are three attributes available for the Code element:
    |`CPP`|Identifies a C++ code snippet.|
    |`XML`|Identifies an XML code snippet.|
    |`JavaScript`|Identifies a JavaScript code snippet.|
+   |`TypeScript`|Identifies a TypeScript code snippet.|
    |`SQL`|Identifies a SQL code snippet.|
    |`HTML`|Identifies an HTML code snippet.|
 

--- a/docs/ide/code-snippets-schema-reference.md
+++ b/docs/ide/code-snippets-schema-reference.md
@@ -1,6 +1,6 @@
 ---
 title: Code snippets schema reference
-ms.date: 11/04/2016
+ms.date: 25/02/2019
 ms.topic: reference
 helpviewer_keywords:
   - "schema reference [Visual Studio]"

--- a/docs/ide/code-snippets-schema-reference.md
+++ b/docs/ide/code-snippets-schema-reference.md
@@ -1,6 +1,6 @@
 ---
 title: Code snippets schema reference
-ms.date: 25/02/2019
+ms.date: 02/25/2019
 ms.topic: reference
 helpviewer_keywords:
   - "schema reference [Visual Studio]"


### PR DESCRIPTION
TypeScript has been added as a value for the `Language` attribute for the `Code` element in code snippets schema reference.
This value was taken from the provided TypeScript snippets in Visual Studio
