### PR TITLE
Update install-certificates-for-visual-studio-offline.md

### DIFF
--- a/docs/install/install-certificates-for-visual-studio-offline.md
+++ b/docs/install/install-certificates-for-visual-studio-offline.md
@@ -65,6 +65,16 @@ If you are scripting the deployment of Visual Studio in an offline environment t
 
    certmgr.exe -add [layout path]\certificates\vs_installer_opc.RootCertificate.cer -n "Microsoft Root Certificate Authority" -s -r LocalMachine root
    ```
+   
+   Alternatively, create a batch file that uses certutil.exe, which ships with Windows, with the following commands:
+   
+      ```cmd
+   certutil.exe -addstore -f "Root" "[layout path]\certificates\manifestRootCertificate.cer
+
+   certutil.exe -addstore -f "Root" [layout path]\certificates\manifestCounterSignRootCertificate.cer"
+
+   certutil.exe -addstore -f "Root" "[layout path]\certificates\vs_installer_opc.RootCertificate.cer"
+   ```
 
 3. Deploy the batch file to the client. This command should be run from an elevated process.
 


### PR DESCRIPTION
When installing certificates from builds 15.8+, admins can also use a certificate utilty that ships with WIndows.  This change adds the commands to do so.

(You can replace all of this text with your description.)

Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for docs.microsoft.com, see the contributor guide at https://docs.microsoft.com/contribute/.
