### PR TITLE
fix: docs/debugger/includes/remote-debugger-symbols.md

### DIFF
--- a/docs/debugger/includes/remote-debugger-symbols.md
+++ b/docs/debugger/includes/remote-debugger-symbols.md
@@ -13,9 +13,10 @@ translation.priority.ht:
   - "tr-tr"
   - "zh-cn"
   - "zh-tw"
---- 
- You should be able to debug your code with the symbols you generate on the Visual Studio computer. The performance of the remote debugger is much better when you use local symbols.  If you must   use remote symbols, you need to tell the remote debugging monitor to look for symbols on the remote machine.  
-  
- Starting in Visual Studio 2013 Update 2, you can use the following msvsmon command-line switch to use remote symbols for managed code: `Msvsmon /FallbackLoadRemoteManagedPdbs`  
-  
- For more information, please see the remote debugging help (press **F1** in the remote debugger window, or click **Help > Usage**). You can find more information at [.NET Remote Symbol Loading Changes in Visual Studio 2012 and 2013](http://blogs.msdn.com/b/visualstudioalm/archive/2013/10/16/net-remote-symbol-loading-changes-in-visual-studio-2012-and-2013.aspx)
+---
+
+You should be able to debug your code with the symbols you generate on the Visual Studio computer. The performance of the remote debugger is much better when you use local symbols.  If you must   use remote symbols, you need to tell the remote debugging monitor to look for symbols on the remote machine.  
+
+Starting in Visual Studio 2013 Update 2, you can use the following msvsmon command-line switch to use remote symbols for managed code: `Msvsmon /FallbackLoadRemoteManagedPdbs`  
+
+For more information, please see the remote debugging help (press **F1** in the remote debugger window, or click **Help > Usage**). You can find more information at [.NET Remote Symbol Loading Changes in Visual Studio 2012 and 2013](http://blogs.msdn.com/b/visualstudioalm/archive/2013/10/16/net-remote-symbol-loading-changes-in-visual-studio-2012-and-2013.aspx)


### PR DESCRIPTION
Remove whitespace after YAML frontmater
Doesn't look like this was causing an issue, but sometimes parsers seem to choke when the frontmatter `---` lines contain trailing space