### PR TITLE
Update documentation to match implementation

### DIFF
--- a/docs/msbuild/common-msbuild-project-items.md
+++ b/docs/msbuild/common-msbuild-project-items.md
@@ -40,9 +40,9 @@ In [!INCLUDE[vstecmsbuild](../extensibility/internals/includes/vstecmsbuild_md.m
 |Item metadata name|Description|
 |---------------|-----------------|
 |Name|Optional string. The display name of the component.|
-|Guid|Optional string. A GUID for the component, in the form {12345678-1234-1234-1234-1234567891234}.|
-|VersionMajor|Optional string. The major part of the version number of the component. For example, "5" if the full version number is "5.46."|
-|VersionMinor|Optional string. The minor part of the version number of the component. For example, "46" if the full version number is "5.46."|
+|Guid|Required string. A GUID for the component, in the form {12345678-1234-1234-1234-1234567891234}.|
+|VersionMajor|Required string. The major part of the version number of the component. For example, "5" if the full version number is "5.46."|
+|VersionMinor|Required string. The minor part of the version number of the component. For example, "46" if the full version number is "5.46."|
 |LCID|Optional string. The LocaleID for the component.|
 |WrapperTool|Optional string. The name of the wrapper tool that is used on the component, for example, "tlbimp."|
 |Isolated|Optional boolean. Specifies whether the component is a reg-free component.|


### PR DESCRIPTION
Update the documentation for `COMReference` item based on the implementation: https://github.com/Microsoft/msbuild/blob/master/src/Tasks/ResolveComReference.cs#L1421-L1425.
