### PR TITLE
Use uniform syntax for bl command line switch

### DIFF
--- a/docs/msbuild/obtaining-build-logs-with-msbuild.md
+++ b/docs/msbuild/obtaining-build-logs-with-msbuild.md
@@ -85,7 +85,7 @@ You can save the log in compressed, binary format using the **-binaryLogger** (*
 In the following example, a binary log file is created with the name *binarylogfilename*.
 
 ```cmd
-/bl:binarylogfilename.binlog
+-bl:binarylogfilename.binlog
 ```
 
 For more information, see [Command-line reference](../msbuild/msbuild-command-line-reference.md).


### PR DESCRIPTION
This is just a tiny adjustment to make the syntax in the code block for
the `bl` switch match the preceding "**-binaryLogger**" text as well as
the other switches in the document.