### PR TITLE
fix: MD023/heading-start-left/header-start-left

### DIFF
--- a/docs/ide/reference/convert-foreach-linq.md
+++ b/docs/ide/reference/convert-foreach-linq.md
@@ -41,7 +41,7 @@ This refactoring applies to:
    
    ![LINQ call form result](media/convert-foreach-to-LINQ-callform-result.png)
    
- ### Sample Code
+### Sample Code
 
 ```csharp
 using System.Collections.Generic;


### PR DESCRIPTION

Headings must start at the beginning of the line