### PR TITLE
Fix missing quotation mark in example

### DIFF
--- a/docs/msbuild/how-to-exclude-files-from-the-build.md
+++ b/docs/msbuild/how-to-exclude-files-from-the-build.md
@@ -94,7 +94,7 @@ In a project file you can use wildcards to include all the files in one director
     </PropertyGroup>
 
     <ItemGroup>
-        <CSFile Include="*.cs Exclude="Form2.cs"/>
+        <CSFile Include="*.cs" Exclude="Form2.cs"/>
 
         <Reference Include="System.dll"/>
         <Reference Include="System.Data.dll"/>


### PR DESCRIPTION
I'm unsure if it's the only issue causing #2780 but the syntax highlighting makes it obviously wrong.

(You can replace all of this text with your description.)

Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for docs.microsoft.com, see the contributor guide at https://docs.microsoft.com/contribute/.
