### PR TITLE
Wrong bracket in the Example

### DIFF
--- a/docs/debugger/using-the-debuggerdisplay-attribute.md
+++ b/docs/debugger/using-the-debuggerdisplay-attribute.md
@@ -141,7 +141,7 @@ class MyHashtable
         hashtable = new Hashtable();
     }
 
-    private string DebuggerDisplay { get { return "Count = " + hashtable.Count); } }
+    private string DebuggerDisplay { get { return "Count = " + hashtable.Count; } }
 
     private class HashtableDebugView
     {


### PR DESCRIPTION
Removed a wrong bracket in the Example code.