### PR TITLE
Update walkthrough-accessing-the-dte-object-from-an-editor-extension.md

### DIFF
--- a/docs/extensibility/walkthrough-accessing-the-dte-object-from-an-editor-extension.md
+++ b/docs/extensibility/walkthrough-accessing-the-dte-object-from-an-editor-extension.md
@@ -40,8 +40,13 @@ In VSPackages, you can get the DTE object by calling the <xref:Microsoft.VisualS
 
     ```
 
-4. In the `GetDTEProvider` class, import a <xref:Microsoft.VisualStudio.Shell.SVsServiceProvider>.
+4. In the `GetDTEProvider` class and add the following `using` directives:
 
+    ```csharp
+    using Microsoft.VisualStudio.Shell;
+    ```
+    And import a <xref:Microsoft.VisualStudio.Shell.SVsServiceProvider>:
+    
     ```csharp
     [Import]
     internal SVsServiceProvider ServiceProvider = null;

--- a/docs/extensibility/walkthrough-accessing-the-dte-object-from-an-editor-extension.md
+++ b/docs/extensibility/walkthrough-accessing-the-dte-object-from-an-editor-extension.md
@@ -40,7 +40,7 @@ In VSPackages, you can get the DTE object by calling the <xref:Microsoft.VisualS
 
     ```
 
-4. In the `GetDTEProvider` class and add the following `using` directives:
+4. In the `GetDTEProvider` class, add the following `using` directive:
 
     ```csharp
     using Microsoft.VisualStudio.Shell;


### PR DESCRIPTION
Add missing using directive that needs to be imported.

Fixes #2163