### PR TITLE
Update customizing-code-coverage-analysis.md

### DIFF
--- a/docs/test/customizing-code-coverage-analysis.md
+++ b/docs/test/customizing-code-coverage-analysis.md
@@ -83,7 +83,7 @@ If **Include** is empty, then code coverage processing includes all assemblies t
 
 Include and exclude nodes use regular expressions. For more information, see [Use regular expressions in Visual Studio](../ide/using-regular-expressions-in-visual-studio.md). Regular expressions aren't the same as wildcards. In particular:
 
-- **.\\*** matches a string of any characters
+- **.\*** matches a string of any characters
 
 - **\\.** matches a dot ".")
 


### PR DESCRIPTION
Remove wrong backslash from match-any-characters regex.

I have no clue why is last line is displayed as changed although there are no obvious changes to it. I also double-checked the other regexes in the list an they seem to be correct.

Fixes #3059 