### PR TITLE
Update C26432.md

### DIFF
--- a/docs/code-quality/C26409.md
+++ b/docs/code-quality/C26409.md
@@ -14,7 +14,12 @@ ms.workload:
   - "multiple"
 ---
 # C26409 NO_NEW_DELETE
-  Even if code is clean of calls to malloc() and free() we still suggest that you consider better options than explicit use of operators [new and delete](/cpp/cpp/new-and-delete-operators). See more details in the description of the rule *R.11: Avoid calling new and delete explicitly*. The ultimate fix is to start using smart pointers with appropriate factory functions, such as [std::make_unique](/cpp/standard-library/memory-functions#make_unique).
+Even if code is clean of calls to malloc() and free() we still suggest that you consider better options than explicit use of operators [new and delete](/cpp/cpp/new-and-delete-operators).
+
+  **C++ Core Guidelines**:
+[R.11: Avoid calling new and delete explicitly](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#r11-avoid-calling-new-and-delete-explicitly)
+
+The ultimate fix is to start using smart pointers with appropriate factory functions, such as [std::make_unique](/cpp/standard-library/memory-functions#make_unique).
 
 ## Remarks
 - The checker warns on calls to any kind of operator `new` or `delete`: scalar, vector, overloaded versions (global and class-specific), as well as on placement versions. The latter case may require some clarifications on the Core Guidelines in terms of suggested fixes and may be omitted in the future.

--- a/docs/code-quality/C26432.md
+++ b/docs/code-quality/C26432.md
@@ -17,7 +17,7 @@ ms.workload:
 "If you define or delete any default operation in the type, define or delete them all."
 
 **C++ Core Guidelines**:
-C.21: If you define or =delete any default operation, define or =delete them all
+[C.21: If you define or =delete any default operation, define or =delete them all](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c21-if-you-define-or-delete-any-default-operation-define-or-delete-them-all)
 
 Special operations like constructors are assumed to alter behavior of types so that they rely more on language mechanisms to automatically enforce specific scenarios (the canonical example is resource management). If any of these operations is explicitly defined, defaulted or deleted (as an indication that user wants to avoid any special handling of a type) it would be inconsistent to leave the other operations from the same group unspecified (i.e. implicitly defined by compiler).
 


### PR DESCRIPTION
Add hyperlinks to C++ Core Guidelines. Fixes #1772 and #1773. I hope it's okay to do this in one PR, since the changes are very similar. I slightly changed the sentence structure in C26409.md so the formatting matches.