### PR TITLE
Changed Find the specific object instance in the **Locals** window to…

### DIFF
--- a/docs/debugger/using-breakpoints.md
+++ b/docs/debugger/using-breakpoints.md
@@ -261,7 +261,7 @@ When you select **Conditional Expression**, you can choose between two condition
 
 2. Start debugging, and when execution pauses at the breakpoint, select **Debug** > **Windows** > **Locals** or **Alt**+**4** to open the **Locals** window.
 
-   Find the breakpoint in the **Locals** window, right-click it, and select **Make Object ID**.
+   Find the specific object instance in the **Locals** window, right-click it, and select **Make Object ID**.
 
    You should see a **$** plus a number in the **Locals** window. This is the object ID.
 


### PR DESCRIPTION
… Find the specific object instance ...

The section correctly starts with "There are times when you want to observe the behavior of a specific object" then in step 2, needed to apply that change. AFAIK, you cannot find breakpoints in the Locals window, you find specific object instances (variables).
