### PR TITLE
The link to Visual Studio for Mac workloads is broken

### DIFF
--- a/mac/ide-tour.md
+++ b/mac/ide-tour.md
@@ -110,7 +110,7 @@ For more information on using version control in Visual Studio, see the [Version
 ## Next steps
 
 - [Install Visual Studio for Mac](installation.md)
-- [Review the available workloads](/mac/workloads.md)
+- [Review the available workloads](workloads.md)
 
 ## Related Video
 

--- a/mac/ide-tour.md
+++ b/mac/ide-tour.md
@@ -110,7 +110,7 @@ For more information on using version control in Visual Studio, see the [Version
 ## Next steps
 
 - [Install Visual Studio for Mac](installation.md)
-- [Review the available workloads](/visualstudio/mac/workloads.md)
+- [Review the available workloads](/mac/workloads.md)
 
 ## Related Video
 

--- a/mac/ide-tour.md
+++ b/mac/ide-tour.md
@@ -110,7 +110,7 @@ For more information on using version control in Visual Studio, see the [Version
 ## Next steps
 
 - [Install Visual Studio for Mac](installation.md)
-- [Review the available workloads](/visualstudio/mac/workloads/)
+- [Review the available workloads](/visualstudio/mac/workloads.md)
 
 ## Related Video
 


### PR DESCRIPTION
Added ".md" to the link to resolve correctly.

The current link results in a 404 error:
https://github.com/MicrosoftDocs/visualstudio-docs/blob/master/mac/workloads/

The correct link should be:
https://github.com/MicrosoftDocs/visualstudio-docs/blob/master/mac/workloads.md

NOTE: There are other instances throughout this GitHub repo where this will have to be changed as well.
