### PR TITLE
Fix for Visual Studio for Mac Workloads link from VS for Mac 2019 installation page

### DIFF
--- a/mac/installation.md
+++ b/mac/installation.md
@@ -76,7 +76,7 @@ Installing Visual Studio for Mac allows you to start writing code for your apps.
 
 ### .NET Core apps, ASP.NET Core web apps, Unity game development
 
-For other Workloads, refer to the [Workloads](/mac/workloads.md) page.
+For other Workloads, refer to the [Workloads](workloads.md) page.
 
 ## Related Video
 

--- a/mac/installation.md
+++ b/mac/installation.md
@@ -76,7 +76,7 @@ Installing Visual Studio for Mac allows you to start writing code for your apps.
 
 ### .NET Core apps, ASP.NET Core web apps, Unity game development
 
-For other Workloads, refer to the [Workloads](/visualstudio/mac/workloads) page.
+For other Workloads, refer to the [Workloads](/mac/workloads.md) page.
 
 ## Related Video
 


### PR DESCRIPTION
The current link resolves to a 404 error:
https://github.com/MicrosoftDocs/visualstudio-docs/blob/master/visualstudio/mac/workloads/

The correct link needs to be:
https://github.com/MicrosoftDocs/visualstudio-docs/blob/master/mac/workloads.md

Notice that after "master" there is no "visualstudio" folder in the Mac Visual Studio repo, so it just needs to be "mac". Unless of course the whole thing needs to be moved to a "visualstudio" folder, but that's another matter on its own.

(You can replace all of this text with your description.)

Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for docs.microsoft.com, see the contributor guide at https://docs.microsoft.com/contribute/.
