### PR TITLE
Fixed NuGet package id for Microsoft.Build.Utilities.Core

### DIFF
--- a/docs/msbuild/updating-an-existing-application.md
+++ b/docs/msbuild/updating-an-existing-application.md
@@ -43,7 +43,7 @@ For example, you can use this XML:
 ```xml
 <ItemGroup>
   <PackageReference Include="Microsoft.Build" Version="15.1.548" ExcludeAssets="runtime" />
-  <PackageReference Include="Microsoft.Build.Utilities" Version="15.1.548" ExcludeAssets="runtime" />
+  <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.1.548" ExcludeAssets="runtime" />
 </ItemGroup>
 ```
 


### PR DESCRIPTION
The package Id `Microsoft.Build.Utilities` does not exist. The correct Id is `Microsoft.Build.Utilities.Core`.
