### PR TITLE
Edit.GoToNextLocation note

### DIFF
--- a/docs/ide/default-keyboard-shortcuts-in-visual-studio.md
+++ b/docs/ide/default-keyboard-shortcuts-in-visual-studio.md
@@ -167,8 +167,8 @@ The sections in the following table include commands that are global in that you
 |Edit.GoToDeclaration|**Ctrl+F12**|
 |Edit.GoToDefinition|**F12**|
 |Edit.GoToFindCombo|**Ctrl+D**|
-|Edit.GoToNextLocation|**F8**|
-|Edit.GoToPrevLocation|**Shift+F8**|
+|Edit.GoToNextLocation|**F8** (Next error in Error List or Output Window)|
+|Edit.GoToPrevLocation|**Shift+F8** (Previous error in Error List or Output Window)|
 |Edit.InsertSnippet|**Ctrl+K, Ctrl+X**|
 |Edit.MoveControlDown|**Ctrl+Down Arrow**|
 |Edit.MoveControlDownGrid|**Down Arrow**|

--- a/docs/ide/default-keyboard-shortcuts-in-visual-studio.md
+++ b/docs/ide/default-keyboard-shortcuts-in-visual-studio.md
@@ -167,7 +167,7 @@ The sections in the following table include commands that are global in that you
 |Edit.GoToDeclaration|**Ctrl+F12**|
 |Edit.GoToDefinition|**F12**|
 |Edit.GoToFindCombo|**Ctrl+D**|
-|Edit.GoToNextLocation|**F8** (Next error in Error List or Output Window)|
+|Edit.GoToNextLocation|**F8** (Next error in Error List or Output window)|
 |Edit.GoToPrevLocation|**Shift+F8** (Previous error in Error List or Output Window)|
 |Edit.InsertSnippet|**Ctrl+K, Ctrl+X**|
 |Edit.MoveControlDown|**Ctrl+Down Arrow**|

--- a/docs/ide/default-keyboard-shortcuts-in-visual-studio.md
+++ b/docs/ide/default-keyboard-shortcuts-in-visual-studio.md
@@ -168,7 +168,7 @@ The sections in the following table include commands that are global in that you
 |Edit.GoToDefinition|**F12**|
 |Edit.GoToFindCombo|**Ctrl+D**|
 |Edit.GoToNextLocation|**F8** (Next error in Error List or Output window)|
-|Edit.GoToPrevLocation|**Shift+F8** (Previous error in Error List or Output Window)|
+|Edit.GoToPrevLocation|**Shift+F8** (Previous error in Error List or Output window)|
 |Edit.InsertSnippet|**Ctrl+K, Ctrl+X**|
 |Edit.MoveControlDown|**Ctrl+Down Arrow**|
 |Edit.MoveControlDownGrid|**Down Arrow**|


### PR DESCRIPTION
Edit.GoToNextLocation's name is not helpful for figuring out what it does, and it doesn't appear to do anything unless you know you have to have the Error List or Output Pane open with errors in them so add a note to that effect.