### PR TITLE
Edit.NavigateTo is gone

### DIFF
--- a/docs/ide/default-keyboard-shortcuts-in-visual-studio.md
+++ b/docs/ide/default-keyboard-shortcuts-in-visual-studio.md
@@ -164,6 +164,7 @@ The sections in the following table include commands that are global in that you
 |Edit.FindPreviousSelected|**Ctrl+Shift+F3**|
 |Edit.GenerateMethod|**Ctrl+K, Ctrl+M**|
 |Edit.GoTo|**Ctrl+G**|
+|Edit.GoToAll|**Ctrl+,**|
 |Edit.GoToDeclaration|**Ctrl+F12**|
 |Edit.GoToDefinition|**F12**|
 |Edit.GoToFindCombo|**Ctrl+D**|
@@ -178,7 +179,6 @@ The sections in the following table include commands that are global in that you
 |Edit.MoveControlRightGrid|**Right Arrow**|
 |Edit.MoveControlUp|**Ctrl+Up Arrow**|
 |Edit.MoveControlUpGrid|**Up Arrow**|
-|Edit.NavigateTo|**Ctrl+,**|
 |Edit.NextBookmark|**Ctrl+K, Ctrl+N**|
 |Edit.NextBookmarkInFolder|**Ctrl+Shift+K, Ctrl+Shift+N**|
 |Edit.OpenFile|**Ctrl+Shift+G**|

--- a/docs/ide/default-keyboard-shortcuts-in-visual-studio.md
+++ b/docs/ide/default-keyboard-shortcuts-in-visual-studio.md
@@ -164,7 +164,7 @@ The sections in the following table include commands that are global in that you
 |Edit.FindPreviousSelected|**Ctrl+Shift+F3**|
 |Edit.GenerateMethod|**Ctrl+K, Ctrl+M**|
 |Edit.GoTo|**Ctrl+G**|
-|Edit.GoToAll|**Ctrl+,**|
+|Edit.GoToAll|**Ctrl+,** or **Ctrl+T**|
 |Edit.GoToDeclaration|**Ctrl+F12**|
 |Edit.GoToDefinition|**F12**|
 |Edit.GoToFindCombo|**Ctrl+D**|


### PR DESCRIPTION
Edit.NavigateTo appears to be removed and Ctrl+, now binds to Edit.GoToAll