### PR TITLE
Edit.OpenFile vs File.OpenFile

### DIFF
--- a/docs/ide/default-keyboard-shortcuts-in-visual-studio.md
+++ b/docs/ide/default-keyboard-shortcuts-in-visual-studio.md
@@ -181,7 +181,7 @@ The sections in the following table include commands that are global in that you
 |Edit.NavigateTo|**Ctrl+,**|
 |Edit.NextBookmark|**Ctrl+K, Ctrl+N**|
 |Edit.NextBookmarkInFolder|**Ctrl+Shift+K, Ctrl+Shift+N**|
-|Edit.OpenFile|**Ctrl+Shift+G**|
+|Edit.OpenFile|**Ctrl+Shift+G** (Opens the file name under the cursor)|
 |Edit.Paste|**Ctrl+V**<br /><br /> or<br /><br /> **Shift+Ins**|
 |Edit.PreviousBookmark|**Ctrl+K, Ctrl+P**|
 |Edit.PreviousBookmarkInFolder|**Ctrl+Shift+K, Ctrl+Shift+P**|


### PR DESCRIPTION
It's not obvious how Edit.OpenFile and File.OpenFile are different, so add a note.

Note that Edit.OpenFile is currently broken in VS2019, but set to be fixed in 16.2:
https://developercommunity.visualstudio.com/content/problem/535917/shift-ctrl-g-is-mapped-to-editopenfile-but-isnt-wo.html