### PR TITLE
Tools.GoToCommandLine doesn't do anything

### DIFF
--- a/docs/ide/default-keyboard-shortcuts-in-visual-studio.md
+++ b/docs/ide/default-keyboard-shortcuts-in-visual-studio.md
@@ -340,7 +340,6 @@ The sections in the following table include commands that are global in that you
 |Tools.AttachtoProcess|**Ctrl+Alt+P**|
 |Tools.CodeSnippetsManager|**Ctrl+K, Ctrl+B**|
 |Tools.ForceGC|**Ctrl+Shift+Alt+F12, Ctrl+Shift+Alt+F12**|
-|Tools.GoToCommandLine|**Ctrl+/**|
 
 ### <a name="bkmk_view"></a> View
 


### PR DESCRIPTION
Ctrl-/ is bound to Tools.GoToCommandLine which has no effect in VS2019 (it used to focus the "Visual Studio Command Line" element on the "Standard" toolbar, but that has been removed leaving this command to do nothing - so remove mention of it.

Details of the old feature: https://blogs.msdn.microsoft.com/saraford/2008/03/03/did-you-know-you-can-press-ctrl-to-reach-the-visual-studio-command-line-163/

At some point hopefully Ctrl+/ will be default bound to Edit.ToggleLineComment:
https://developercommunity.visualstudio.com/content/problem/564925/visual-studio-code-scheme-wrong-shortcut-for-editt.html