### PR TITLE
Edit.CharTranspose is no longer bound to Ctrl+T

### DIFF
--- a/docs/ide/default-keyboard-shortcuts-in-visual-studio.md
+++ b/docs/ide/default-keyboard-shortcuts-in-visual-studio.md
@@ -773,7 +773,6 @@ The sections in the following table include commands that are global in that you
 | Edit.CharRight | **Right Arrow** |
 | Edit.CharRightExtend | **Shift+Right Arrow** |
 | Edit.CharRightExtendColumn | **Shift+Alt+Right Arrow** |
-| Edit.CharTranspose | **Ctrl+T** |
 | Edit.ClearBookmarks | **Ctrl+K, Ctrl+L** |
 | Edit.CollapseAllOutlining | **Ctrl+M, Ctrl+A** |
 | Edit.CollapseCurrentRegion | **Ctrl+M, Ctrl+S** |


### PR DESCRIPTION
EDIT: the description of this pull request was wrong - not sure how that happened. In any case the title says it all: Edit.CharTranspose is no longer bound to Ctrl+T since it's now used for Edit.GoToAll.