### PR TITLE
PopBrowseContext is misspelled and also C++-only

### DIFF
--- a/docs/ide/default-keyboard-shortcuts-in-visual-studio.md
+++ b/docs/ide/default-keyboard-shortcuts-in-visual-studio.md
@@ -373,7 +373,7 @@ The sections in the following table include commands that are global in that you
 |View.ObjectBrowser|**Ctrl+Alt+J**|
 |View.ObjectBrowserGoToSearchCombo|**Ctrl+K, Ctrl+R**|
 |View.Output|**Ctrl+Alt+O** (letter 'O')|
-|View.PopBrowseContex|**Ctrl+Shift+8**|
+|View.PopBrowseContext|**Ctrl+Shift+8** (C++ Language Only)|
 |View.PropertiesWindow|**F4**|
 |View.PropertyPages|**Shift+F4**|
 |View.ResourceView|**Ctrl+Shift+E**|

--- a/docs/ide/default-keyboard-shortcuts-in-visual-studio.md
+++ b/docs/ide/default-keyboard-shortcuts-in-visual-studio.md
@@ -373,7 +373,7 @@ The sections in the following table include commands that are global in that you
 |View.ObjectBrowser|**Ctrl+Alt+J**|
 |View.ObjectBrowserGoToSearchCombo|**Ctrl+K, Ctrl+R**|
 |View.Output|**Ctrl+Alt+O** (letter 'O')|
-|View.PopBrowseContext|**Ctrl+Shift+8** (C++ Language Only)|
+|View.PopBrowseContext|**Ctrl+Shift+8** (C++ only)|
 |View.PropertiesWindow|**F4**|
 |View.PropertyPages|**Shift+F4**|
 |View.ResourceView|**Ctrl+Shift+E**|


### PR DESCRIPTION
Until VS2013 View.PopBrowseContext worked in .NET language (presumably it broke when Roslyn was introduced?).
There is a bug about it not working in .NET language context but it has been closed "Low Priority":
https://developercommunity.visualstudio.com/content/problem/94907/vs2017-the-command-viewpopbrowsecontext-with-the-k.html
So add a comment that View.PopBrowseContext/Ctrl+Shift+8 is "C++ Language Only"