### PR TITLE
Add ARM64 to CV_CPU_TYPE_e

### DIFF
--- a/docs/debugger/debug-interface-access/cv-cpu-type-e.md
+++ b/docs/debugger/debug-interface-access/cv-cpu-type-e.md
@@ -84,6 +84,7 @@ typedef enum CV_CPU_TYPE_e {
     CV_CFL_EBC          = 0xE0,
     CV_CFL_THUMB        = 0xF0
     CV_CFL_ARMNT        = 0xF4,
+    CV_CFL_ARM64        = 0xF6,
     CV_CFL_D3D11_SHADER = 0x100,
 } CV_CPU_TYPE_e;
 ```


### PR DESCRIPTION
ARM64 is missing in the list of CV_CPU_TYPE_e.