### PR TITLE
Added `System` namespace to BankAccountTests.cs

### DIFF
--- a/docs/test/walkthrough-creating-and-running-unit-tests-for-managed-code.md
+++ b/docs/test/walkthrough-creating-and-running-unit-tests-for-managed-code.md
@@ -207,7 +207,7 @@ namespace BankTests
 
 ### Add a using statement
 
-Add a [`using` statement](/dotnet/csharp/language-reference/keywords/using-statement) to the test class to be able to call into the project under test (here, the `BankAccount` class) without using fully qualified names. We will also add `System` namespace for calling the `ArgumentOutOfRangeException` when we [create and run new test methods](#create-and-run-new-test-methods) below. At the top of the class file, add:
+Add a [`using` statement](/dotnet/csharp/language-reference/keywords/using-statement) to the test class to be able to call into the project under test (here, the `BankAccount` class) without using fully qualified names. We also add a `System` namespace for calling the `ArgumentOutOfRangeException` when we [create and run new test methods](#create-and-run-new-test-methods) below. At the top of the class file, add:
 
 ```csharp
 using BankAccountNS;

--- a/docs/test/walkthrough-creating-and-running-unit-tests-for-managed-code.md
+++ b/docs/test/walkthrough-creating-and-running-unit-tests-for-managed-code.md
@@ -207,10 +207,11 @@ namespace BankTests
 
 ### Add a using statement
 
-Add a [`using` statement](/dotnet/csharp/language-reference/keywords/using-statement) to the test class to be able to call into the project under test without using fully qualified names. At the top of the class file, add:
+Add a [`using` statement](/dotnet/csharp/language-reference/keywords/using-statement) to the test class to be able to call into the project under test (here, the `BankAccount` class) without using fully qualified names. We will also add `System` namespace for calling the `ArgumentOutOfRangeException` when we [create and run new test methods](#create-and-run-new-test-methods) below. At the top of the class file, add:
 
 ```csharp
 using BankAccountNS;
+using System;
 ```
 
 ### Test class requirements


### PR DESCRIPTION
The BankAccountTests.cs needs the `System` namespace for the `ArgumentOutOfRangeException` class that is used in [Create and run new test methods](#create-and-run-new-test-methods) section.

Before creating my pull request, I have checked my content against these quality criteria:

- I did not choose the title in the metadata section and the H1 heading, so I did not consider search engine optimization (SEO)
- This is not a new article, hence I did not add it to the table of contents
- I did not update the "ms.date" metadata, since this is not a new or significantly updated article
- I have introduced and explained technical terms and concepts, and I have spelled out acronyms on first mention
- I defer to the page creators whether this this page should be linked to from other pages or Microsoft web sites

For more information about creating content for docs.microsoft.com, see the contributor guide at https://docs.microsoft.com/contribute/.
