### PR TITLE
Add .NET Core and Standard JS Tests Documentation

### DIFF
--- a/docs/javascript/unit-testing-javascript-with-visual-studio.md
+++ b/docs/javascript/unit-testing-javascript-with-visual-studio.md
@@ -171,5 +171,11 @@ To enable this, right-click the project node in the Solution Explorer, choose **
 Next, add your tests to the test root folder you specified, and they will be available to run in the
 Test Explorer window. If they don't initially appear, you may need to rebuild the project.
 
-> [!NOTE]
-> This currently doesn't work for .NET Standard and .NET Core projects.
+### Unit test .NET Core and .NET Standard
+Additional to the properties above, you will also need to install the NuGet package [Microsoft.JavaScript.UnitTest](https://www.nuget.org/packages/Microsoft.JavaScript.UnitTest/) and the property:
+
+```xml
+<PropertyGroup>
+    <GenerateProgramFile>false</GenerateProgramFile>
+</PropertyGroup>
+```

--- a/docs/javascript/unit-testing-javascript-with-visual-studio.md
+++ b/docs/javascript/unit-testing-javascript-with-visual-studio.md
@@ -172,7 +172,7 @@ Next, add your tests to the test root folder you specified, and they will be ava
 Test Explorer window. If they don't initially appear, you may need to rebuild the project.
 
 ### Unit test .NET Core and .NET Standard
-Additional to the properties above, you will also need to install the NuGet package [Microsoft.JavaScript.UnitTest](https://www.nuget.org/packages/Microsoft.JavaScript.UnitTest/) and the property:
+In addition to the properties above, you will also need to install the NuGet package [Microsoft.JavaScript.UnitTest](https://www.nuget.org/packages/Microsoft.JavaScript.UnitTest/) and set the property:
 
 ```xml
 <PropertyGroup>


### PR DESCRIPTION
Added documentation for JavaScript and TypeScript unit tests support on .NET Core and .NET Standard.

The feature is yet to be released so please avoid merging this pull request until is publicly available. I can chime in when that happens.