### PR TITLE
Document the selection-modifying commands in editor context

### DIFF
--- a/docs/ide/default-keyboard-shortcuts-in-visual-studio.md
+++ b/docs/ide/default-keyboard-shortcuts-in-visual-studio.md
@@ -779,6 +779,7 @@ These keyboard shortcuts are *global*, which means that you can use them when an
 | Edit.CollapseCurrentRegion | **Ctrl+M, Ctrl+S** |
 | Edit.CollapseTag | **Ctrl+M, Ctrl+T** |
 | Edit.CollapseToDefinitions | **Ctrl+M, Ctrl+O** (letter 'O') |
+| Edit.ContractSelection | **Shift+Alt+-** (non-C++ only) |
 | Edit.CommentSelection | **Ctrl+K, Ctrl+C** |
 | Edit.CompleteWord | **Ctrl+Space**<br /><br /> or<br /><br /> **Alt+Right Arrow** |
 | Edit.CopyParameterTip | **Ctrl+Shift+Alt+C** |
@@ -791,6 +792,8 @@ These keyboard shortcuts are *global*, which means that you can use them when an
 | Edit.DocumentStartExtend | **Ctrl+Shift+Home** |
 | Edit.ExpandAllOutlining | **Ctrl+M, Ctrl+X** |
 | Edit.ExpandCurrentRegion | **Ctrl+M, Ctrl+E** |
+| Edit.ExpandSelection | **Shift+Alt+=** (non-C++ only) |
+| Edit.ExpandSelectiontoContainingBlock | **Shift+Alt+]** |
 | Edit.FormatDocument | **Ctrl+K, Ctrl+D** |
 | Edit.FormatSelection | **Ctrl+K, Ctrl+F** |
 | Edit.GotoAll | **Ctrl+T**<br /><br /> or<br /><br /> **Ctrl+,** |


### PR DESCRIPTION
Expand/contract selection is described on https://devblogs.microsoft.com/visualstudio/improving-your-productivity-in-the-visual-studio-editor/ (tho the shortcut is given as "Shift+Alt++" whereas VS itself gives it as "Shift+Alt+=" which I assume is the correct way to state it.
I don't know if that feature ever worked in C++ editor but as bugged in https://developercommunity.visualstudio.com/idea/605357/expandcontract-selection-does-not-work-for-c.html it does not now so documented that (the bug has been changed to a "feature request" so apparently that's as-designed).
I checked that it works in other editors and it does work in XAML, C# and JSON editors so I presume it works in all editors other than C++.