### PR TITLE
CA2105 - Add related rules CA2104: Do not declare read only mutable reference types

### DIFF
--- a/docs/code-quality/ca2105-array-fields-should-not-be-read-only.md
+++ b/docs/code-quality/ca2105-array-fields-should-not-be-read-only.md
@@ -69,6 +69,10 @@ Before tampering: Grades: 90, 90, 90 Private Grades: 90, 90, 90  Secure Grades, 
 After tampering: Grades: 90, 555, 90 Private Grades: 90, 555, 90  Secure Grades, 90, 90, 90
 ```
 
+## Related Rules
+
+ - [CA2104 : Do not declare read only mutable reference types](../code-quality/ca2104-do-not-declare-read-only-mutable-reference-types.md) 
+
 ## See also
 
 - <xref:System.Array?displayProperty=fullName>

--- a/docs/code-quality/ca2105-array-fields-should-not-be-read-only.md
+++ b/docs/code-quality/ca2105-array-fields-should-not-be-read-only.md
@@ -69,7 +69,7 @@ Before tampering: Grades: 90, 90, 90 Private Grades: 90, 90, 90  Secure Grades, 
 After tampering: Grades: 90, 555, 90 Private Grades: 90, 555, 90  Secure Grades, 90, 90, 90
 ```
 
-## Related Rules
+## Related rules
 
  - [CA2104 : Do not declare read only mutable reference types](../code-quality/ca2104-do-not-declare-read-only-mutable-reference-types.md) 
 


### PR DESCRIPTION
Add related rule:
CA2104 : Do not declare read only mutable reference types
