### PR TITLE
Remove any mention of VSWorkspaceSettings.json

### DIFF
--- a/docs/ide/customize-build-and-debug-tasks-in-visual-studio.md
+++ b/docs/ide/customize-build-and-debug-tasks-in-visual-studio.md
@@ -8,7 +8,6 @@ helpviewer_keywords:
   - customize codebases [Visual Studio]
   - tasks.vs.json file [Visual Studio]
   - launch.vs.json file [Visual Studio]
-  - vsworkspacesettings.json file [Visual Studio]
 author: gewarren
 ms.author: gewarren
 manager: jillfra
@@ -27,7 +26,6 @@ Customize your project-less codebase by using the following *.json* files:
 |-|-|
 |*tasks.vs.json*|Specify custom build commands and compiler switches, and arbitrary (non-build related) tasks.<br>Accessed via the **Solution Explorer** right-click menu item **Configure Tasks**.|
 |*launch.vs.json*|Specify command-line arguments for debugging.<br>Accessed via the **Solution Explorer** right-click menu item **Debug and Launch Settings**.|
-|*VSWorkspaceSettings.json*|Generic settings that may impact tasks and launch. For example, defining `envVars` in *VSWorkspaceSettings.json* adds the specified environment variables to externally run commands.<br>You create this file manually.|
 
 These *.json* files are located in a hidden folder called *.vs* in the root folder of your codebase. The *tasks.vs.json* and *launch.vs.json* files are created by Visual Studio on an as-needed basis when you choose either **Configure Tasks** or **Debug and Launch Settings** on a file or folder in **Solution Explorer**. These *.json* files are hidden because users generally don't want to check them into source control. However, if you want to be able to check them into source control, drag the files into the root of your codebase, where they are visible.
 
@@ -187,7 +185,7 @@ Multiple *tasks.vs.json* files can exist at the root and subdirectories of a cod
 - The current directory’s parent directory, all the way up to the root directory.
 - Settings files in the root directory.
 
-These aggregation rules apply to *tasks.vs.json* and *VSWorkspaceSettings.json* files. For information on how settings in other file are aggregated, see the corresponding section for that file in this article.
+These aggregation rules apply to *tasks.vs.json*. For information on how settings in other file are aggregated, see the corresponding section for that file in this article.
 
 ### Properties for tasks.vs.json
 
@@ -283,10 +281,6 @@ When you save this file, the name of the new configuration appears in the debug 
 
 > [!NOTE]
 > The `configurations` array property in *launch.vs.json* is read from two file locations&mdash;the root directory for the codebase, and the *.vs* directory. If there is a conflict, priority is given to the value in *.vs\launch.vs.json*.
-
-## Define workspace settings in VSWorkspaceSettings.json
-
-You can specify generic settings that may impact tasks and launch in the *VSWorkspaceSettings.json* file. For example, if you define `envVars` in *VSWorkspaceSettings.json*, Visual Studio adds the specified environment variables to commands that are run externally. To use this file, you must create it manually.
 
 ## Additional settings files
 


### PR DESCRIPTION
Hey Michael and Colin,
Per a conversation with Will and Steven from the AnyCode team, we have decided to remove VSWorkspaceSettings.json from the documentation. The user was never intended to be user-editable - so it's our fault it's included in the first place and has led to some customer confusion. I've tried to clean up this file - let me know if I'm missing something, if there are other files I need to address, or if you have any questions. Thanks for your help!