### PR TITLE
Category Moved for Modeling SDK

### DIFF
--- a/docs/modeling/includes/modeling_sdk_info.md
+++ b/docs/modeling/includes/modeling_sdk_info.md
@@ -2,4 +2,4 @@
 ms.topic: include
 ---
 > [!NOTE]
-> The **Text Template Transformation** component is automatically installed as part of the **Visual Studio extension development** workload. You can also install it from the **Individual components** tab of Visual Studio Installer, under the **Code tools** category. Install the **Modeling SDK** component from the **Individual components** tab.
+> The **Text Template Transformation** component is automatically installed as part of the **Visual Studio extension development** workload. You can also install it from the **Individual components** tab of Visual Studio Installer, under the **SDKs, libraries, and frameworks** category. Install the **Modeling SDK** component from the **Individual components** tab.


### PR DESCRIPTION
Modeling SDK moved categories using Installer Version 2.1.3129.607. Verified location under individual components for VS 2017 and 2019.
