### PR TITLE
chore: Updated Mardownlint config

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,7 +1,6 @@
 {
     "default": true,
     "MD001": false,
-    "MD002": false,
     "MD004": false,
     "MD007": false,
     "MD009": false,
@@ -34,5 +33,6 @@
     "MD045": false,
     "MD046": {
         "style": "fenced"
-    }
+    },
+    "MD047": false
 }


### PR DESCRIPTION

- New MD047/single-trailing-newline that isn't passing
- MD002 is deprecated