### PR TITLE
Fix indentation

### DIFF
--- a/docs/msbuild/msbuild-inline-tasks.md
+++ b/docs/msbuild/msbuild-inline-tasks.md
@@ -123,7 +123,7 @@ Log.LogError("Hello, world!");
 
 ```xml
 <ParameterGroup>
-    <Text />
+  <Text />
 </ParameterGroup>
 ```
 
@@ -139,9 +139,9 @@ For example,
 
 ```xml
 <ParameterGroup>
-    <Expression Required="true" />
-      <Files ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="true" />
-    <Tally ParameterType="System.Int32" Output="true" />
+  <Expression Required="true" />
+  <Files ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="true" />
+  <Tally ParameterType="System.Int32" Output="true" />
 </ParameterGroup>
 ```
 


### PR DESCRIPTION
The indentation of three sibling child items in the ParameterGroup was different, making it look like the first and third were parenting the second.

Also the rest of the file uses two spaces for XML indentation, not four.