### PR TITLE
Removed dev_langs

### DIFF
--- a/docs/debugger/diagnostic-messages-in-the-output-window.md
+++ b/docs/debugger/diagnostic-messages-in-the-output-window.md
@@ -2,11 +2,6 @@
 title: "Send messages to the Output window | Microsoft Docs"
 ms.date: "11/08/2018"
 ms.topic: "conceptual"
-dev_langs:
-  - "CSharp"
-  - "VB"
-  - "FSharp"
-  - "C++"
 helpviewer_keywords:
   - "diagnostic messages [C#]"
   - "System.Diagnostics.Debug class, Output window"


### PR DESCRIPTION
Removed dev_langs because article doesn't contain any code.
The existence of dev_langs causes the page on docs.microsoft.com to show a useless selection between the languages.