### PR TITLE
Updated VSIX references spacing

### DIFF
--- a/docs/extensibility/how-to-use-wizards-with-project-templates.md
+++ b/docs/extensibility/how-to-use-wizards-with-project-templates.md
@@ -54,11 +54,11 @@ This procedure shows how to create a custom wizard that opens a Windows Form bef
 
 2. In **Solution Explorer**, select the VSIX project node. Below **Solution Explorer**, you should see the **Properties** window. If you do not, select **View** > **Properties Window**, or press **F4**. In the **Properties** window, select the following fields to `true`:
 
-   - **IncludeAssemblyInVSIXContainer**
+   - **Include Assembly In VSIX Container**
 
-   - **IncludeDebugSymbolsInVSIXContainer**
+   - **Include Debug Symbols In VSIX Container**
 
-   - **IncludeDebugSymbolsInLocalVSIXDeployment**
+   - **Include Debug Symbols In Local VSIX Deployment**
 
 3. Add the assembly as an asset to the VSIX project. Open the *source.extension.vsixmanifest* file and select the **Assets** tab. In the **Add New Asset** window, for **Type** select **Microsoft.VisualStudio.Assembly**, for **Source** select **A project in current solution**, and for **Project** select **MyProjectWizard**.
 


### PR DESCRIPTION
Fixed VSIX assembly reference spacing for the documentation, in the past 
we are seeing the reference like "IncludeAssemblyInVSIXContainer" and its awful to read and changed to a spacing
version "Include Assembly In VSIX Container"
