### PR TITLE
Update ca1507.md

### DIFF
--- a/docs/code-quality/ca1507.md
+++ b/docs/code-quality/ca1507.md
@@ -29,7 +29,7 @@ A `string` literal or constant that matches the name of a parameter of the conta
 
 ## Rule description
 
-Rule CA1507 flags the use of a `string` literal as an argument to a method or constructor where a [nameof](/dotnet/csharp/language-reference/keywords/nameof) (`NameOf` in Visual Basic) expression would add readability and maintainability. The rule fires if all of the following conditions are met:
+Rule CA1507 flags the use of a `string` literal as an argument to a method or constructor where a [nameof](/dotnet/csharp/language-reference/keywords/nameof) (`NameOf` in Visual Basic) expression would add maintainability. The rule fires if all of the following conditions are met:
 
 - The argument is a `string` literal or constant.
 


### PR DESCRIPTION
The usage of `nameof` really doesn't add any readability in my opinion. It's just good to use it for maintainability, specially, when renaming arguments.

```csharp
throw new ArgumentNullException(nameof(arg));
throw new ArgumentNullException("arg");
```

Both lines are as same readable.