### PR TITLE
Update unit-testing-visual-csharp-code-in-a-store-app.md

### DIFF
--- a/docs/test/unit-testing-visual-csharp-code-in-a-store-app.md
+++ b/docs/test/unit-testing-visual-csharp-code-in-a-store-app.md
@@ -89,14 +89,17 @@ This article also creates a single Visual Studio solution and separate projects 
 3. Add the following code to the Rooter class *Rooter.cs* file:
 
    ```csharp
-   public Rooter()
+   public class Rooter
    {
-   }
+       public Rooter()
+       {
+       }
 
-   // estimate the square root of a number
-   public double SquareRoot(double x)
-   {
-       return 0.0;
+       // estimate the square root of a number
+       public double SquareRoot(double x)
+       {
+           return 0.0;
+       }
    }
    ```
 


### PR DESCRIPTION
Rooter class needs to be declared public in order to be referenced by the unit tests. Updated the code samples to reflect that.