### PR TITLE
Update unit-testing-visual-csharp-code-in-a-store-app.md

### DIFF
--- a/docs/test/unit-testing-visual-csharp-code-in-a-store-app.md
+++ b/docs/test/unit-testing-visual-csharp-code-in-a-store-app.md
@@ -161,7 +161,7 @@ You have set up the test and the code projects, and verified that you can run te
        {
            double expected = v;
            double actual = rooter.SquareRoot(v*v);
-           double tolerance = ToleranceHelper(expected);
+           double tolerance = expected/1000;
            Assert.AreEqual(expected, actual, tolerance);
        }
    }


### PR DESCRIPTION
The first implementation of `RangeTest` should used `exptected/1000` instead of `ToleranceHelper` because `ToleranceHelper` is not defined until the refactor so it would not build.