### PR TITLE
Update troubleshooting-code-coverage.md

### DIFF
--- a/docs/test/troubleshooting-code-coverage.md
+++ b/docs/test/troubleshooting-code-coverage.md
@@ -51,7 +51,7 @@ The *.pdb* file must be generated from the same build as the *.dll* or *.exe* fi
 
 Resolution&mdash;Make sure that your build settings generate the *.pdb* file. If the *.pdb* files are not updated when the project is built, then open the project properties, select the **Build** page, choose **Advanced**, and inspect **Debug Info**.
 
-For C++ projects, ensure that the generated pdbs have full debug information by opening the project properties and ensuring that **Linker > Debugging > Generate Debug Info** setting is set to **Generate Debug Information optimized for sharing and publishing (/DEBUG:FULL)**.
+For C++ projects, ensure that the generated .pdb files have full debug information. Open the project properties and verify that **Linker** > **Debugging** > **Generate Debug Info** is set to **Generate Debug Information optimized for sharing and publishing (/DEBUG:FULL)**.
 
 If the *.pdb* and *.dll* or *.exe* files are in different places, copy the *.pdb* file to the same directory. It is also possible to configure code coverage engine to search for *.pdb* files in another location. For more information, see [Customize code coverage analysis](../test/customizing-code-coverage-analysis.md).
 

--- a/docs/test/troubleshooting-code-coverage.md
+++ b/docs/test/troubleshooting-code-coverage.md
@@ -51,6 +51,8 @@ The *.pdb* file must be generated from the same build as the *.dll* or *.exe* fi
 
 Resolution&mdash;Make sure that your build settings generate the *.pdb* file. If the *.pdb* files are not updated when the project is built, then open the project properties, select the **Build** page, choose **Advanced**, and inspect **Debug Info**.
 
+For C++ projects, ensure that the generated pdbs have full debug information by opening the project properties and ensuring that **Linker > Debugging > Generate Debug Info** setting is set to **Generate Debug Information optimized for sharing and publishing (/DEBUG:FULL)**.
+
 If the *.pdb* and *.dll* or *.exe* files are in different places, copy the *.pdb* file to the same directory. It is also possible to configure code coverage engine to search for *.pdb* files in another location. For more information, see [Customize code coverage analysis](../test/customizing-code-coverage-analysis.md).
 
 ### Use an instrumented or optimized binary


### PR DESCRIPTION
Add a line of text to aid trouble shooting of problems where code coverage does not work because of incorrect pdb settings for C++ projects.