### PR TITLE
Update convert-local-function-method.md

### DIFF
--- a/docs/ide/reference/convert-local-function-method.md
+++ b/docs/ide/reference/convert-local-function-method.md
@@ -5,18 +5,10 @@ ms.topic: reference
 author: kendrahavens
 ms.author: kehavens
 manager: jillfra
-dev_langs:
-  - CSharp
-  - VB
 ms.workload:
   - "dotnet"
 ---
 # Convert a local function to a method
-
-This refactoring applies to:
-
-- C#
-- Visual Basic
 
 **What:** Convert a local function to a method.
 

--- a/docs/ide/reference/convert-local-function-method.md
+++ b/docs/ide/reference/convert-local-function-method.md
@@ -10,6 +10,10 @@ ms.workload:
 ---
 # Convert a local function to a method
 
+This refactoring applies to:
+
+- C#
+
 **What:** Convert a local function to a method.
 
 **When:** You have a local function that you want to define outside your current local context.


### PR DESCRIPTION
I've made two changes here:

1. Removed `dev_langs` from metadata, because the selection between vb and c# in the page doesn't do anything.

2. Removed  `This refactoring applies to:  C#, Visual Basic`. (There is no local functions in visual basic)