### PR TITLE
Add suppress warnings in ca1707

### DIFF
--- a/docs/code-quality/ca1707-identifiers-should-not-contain-underscores.md
+++ b/docs/code-quality/ca1707-identifiers-should-not-contain-underscores.md
@@ -40,7 +40,7 @@ Remove all underscore characters from the name.
 
 ## When to suppress warnings
 
-Do not suppress a warning from this rule.
+CA1707 is meant only for production code, so should be explicitly turned off for test projects using [Rule severity](https://docs.microsoft.com/en-us/visualstudio/code-quality/use-roslyn-analyzers?view=vs-2019#rule-severity).
 
 ## Related rules
 

--- a/docs/code-quality/ca1707-identifiers-should-not-contain-underscores.md
+++ b/docs/code-quality/ca1707-identifiers-should-not-contain-underscores.md
@@ -40,7 +40,7 @@ Remove all underscore characters from the name.
 
 ## When to suppress warnings
 
-CA1707 is meant only for production code, so should be explicitly turned off for test projects using [Rule severity](https://docs.microsoft.com/en-us/visualstudio/code-quality/use-roslyn-analyzers?view=vs-2019#rule-severity).
+Do not suppress warnings for production code. However, it's safe to suppress this warning for test code. You can suppress warnings from this rule by setting its [severity](use-roslyn-analyzers.md#rule-severity) to **none**. 
 
 ## Related rules
 


### PR DESCRIPTION
This pull request is related to https://github.com/MicrosoftDocs/visualstudio-docs/issues/3971

Best practices for test naming convention is defined in https://docs.microsoft.com/en-us/dotnet/core/testing/unit-testing-best-practices as:

> The name of the method being tested.
> The scenario under which it's being tested.
> The expected behavior when the scenario is invoked.

And those three parts are represented in a method name separated by an underscore.
But the description's CA1707 warning is:

> By convention, identifier names do not contain the underscore (_) character. The rule checks namespaces, types, members, and parameters.
> 
> When to suppress warnings
> Do not suppress a warning from this rule.

I changed the suppress warnings with the suggestion.

Fixes #3971 