### PR TITLE
MSBuild: Clarify binding redirect version

### DIFF
--- a/docs/msbuild/updating-an-existing-application.md
+++ b/docs/msbuild/updating-an-existing-application.md
@@ -59,7 +59,7 @@ If you can't use NuGet packages, you can reference MSBuild assemblies that are d
 
 #### Binding redirects
 
-Reference the Microsoft.Build.Locator package to ensure that your application automatically uses the required binding redirects of all versions of MSBuild assemblies to version `15.1.0.0`.
+Reference the Microsoft.Build.Locator package to ensure that your application automatically uses the required binding redirects of all versions of MSBuild assemblies to version `15.1.0.0`, the assembly version of all versions of MSBuild 15 and MSBuild 16.
 
 ### Ensure output is clean
 


### PR DESCRIPTION
Clarifying that binding redirects to MSBuild 15.1.0.0 do not restrict to the use of MSBuild 15 (they support 16 too).
