### PR TITLE
Remove duplicated section in "annotating-function-parameters-and-return-values" document

### DIFF
--- a/docs/code-quality/annotating-function-parameters-and-return-values.md
+++ b/docs/code-quality/annotating-function-parameters-and-return-values.md
@@ -225,34 +225,6 @@ For the annotations in the following table, when a pointer parameter is being an
 
      The `_bytes_` variant gives the size in bytes instead of elements. Use this only when the size cannot be expressed as elements.  For example, `char` strings would use the `_bytes_` variant only if a similar function that uses `wchar_t` would.
 
-- `_Inout_updates_z_(s)`
-
-     A pointer to an array that is null-terminated and has a known size. The elements up through the null terminator—which must be present—must be valid in both pre-state and post-state.  The value in the post-state is presumed to be different from the value in the pre-state; this includes the location of the null terminator. If the size is known in bytes, scale `s` by the element size.
-
-- `_Out_writes_to_(s,c)`
-
-     `_Out_writes_bytes_to_(s,c)`
-
-     `_Out_writes_all_(s)`
-
-     `_Out_writes_bytes_all_(s)`
-
-     A pointer to an array of `s` elements.  The elements do not have to be valid in pre-state.  In post-state, the elements up to the `c`-th element must be valid.  If the size is known in bytes, scale `s` and `c` by the element size or use the `_bytes_` variant, which is defined as:
-
-     `_Out_writes_to_(_Old_(s), _Old_(s))    _Out_writes_bytes_to_(_Old_(s), _Old_(s))`
-
-     In other words, every element that exists in the buffer up to `s` in the pre-state is valid in the post-state.  For example:
-
-     `void *memcpy(_Out_writes_bytes_all_(s) char *p1,    _In_reads_bytes_(s) char *p2,    _In_ int s); void * wordcpy(_Out_writes_all_(s) DWORD *p1,     _In_reads_(s) DWORD *p2,    _In_ int s);`
-
-- `_Inout_updates_to_(s,c)`
-
-     `_Inout_updates_bytes_to_(s,c)`
-
-     A pointer to an array, which is both read and written by the function.  It is of size `s` elements, all of which must be valid in pre-state, and `c` elements must be valid in post-state.
-
-     The `_bytes_` variant gives the size in bytes instead of elements. Use this only when the size cannot be expressed as elements.  For example, `char` strings would use the `_bytes_` variant only if a similar function that uses `wchar_t` would.
-
 - `_Inout_updates_all_(s)`
 
      `_Inout_updates_bytes_all_(s)`

--- a/docs/code-quality/annotating-function-parameters-and-return-values.md
+++ b/docs/code-quality/annotating-function-parameters-and-return-values.md
@@ -1,6 +1,6 @@
 ---
 title: Annotating Function Parameters and Return Values
-ms.date: 07/11/2019
+ms.date: 10/15/2019
 ms.topic: "conceptual"
 f1_keywords:
   - "_Outptr_opt_result_bytebuffer_to_"


### PR DESCRIPTION
Remove 3 sections in document that were duplicated. The following sections are repeated in the block directly above the removed lines:
- `_Inout_updates_z_(s)`
- `_Out_writes_to_(s,c)` + 3 variants
- `_Inout_updates_to_(s,c)` + 1 variant