### PR TITLE
refer to "using directive" as appropriate

### DIFF
--- a/docs/extensibility/walkthrough-implementing-code-snippets.md
+++ b/docs/extensibility/walkthrough-implementing-code-snippets.md
@@ -6,6 +6,9 @@ ms.assetid: adbc5382-d170-441c-9fd0-80faa1816478
 author: madskristensen
 ms.author: madsk
 manager: jillfra
+dev_langs:
+ - CSharp
+ - VB
 ms.workload:
   - "vssdk"
 ---

--- a/docs/extensibility/walkthrough-implementing-code-snippets.md
+++ b/docs/extensibility/walkthrough-implementing-code-snippets.md
@@ -129,7 +129,7 @@ You can create code snippets and include them in an editor extension so that use
      [!code-csharp[VSSDKCompletionTest#23](../extensibility/codesnippet/CSharp/walkthrough-implementing-code-snippets_2.cs)]
      [!code-vb[VSSDKCompletionTest#23](../extensibility/codesnippet/VisualBasic/walkthrough-implementing-code-snippets_2.vb)]
 
-8. Add the <xref:Microsoft.VisualStudio.Shell.ProvideLanguageCodeExpansionAttribute> to the `TestCompletionHandler` class. This attribute can be added to any public or internal (non-static) class in the project. (You may have to add a `using` statement for the Microsoft.VisualStudio.Shell namespace.)
+8. Add the <xref:Microsoft.VisualStudio.Shell.ProvideLanguageCodeExpansionAttribute> to the `TestCompletionHandler` class. This attribute can be added to any public or internal (non-static) class in the project. (You may have to add a `using` directive for the Microsoft.VisualStudio.Shell namespace.)
 
      [!code-csharp[VSSDKCompletionTest#24](../extensibility/codesnippet/CSharp/walkthrough-implementing-code-snippets_3.cs)]
      [!code-vb[VSSDKCompletionTest#24](../extensibility/codesnippet/VisualBasic/walkthrough-implementing-code-snippets_3.vb)]
@@ -159,7 +159,7 @@ You can create code snippets and include them in an editor extension so that use
 
 #### To implement snippet expansion
 
-1. To the file that contains the `TestCompletionCommandHandler` class, add the following `using` statements.
+1. To the file that contains the `TestCompletionCommandHandler` class, add the following `using` directives.
 
      [!code-csharp[VSSDKCompletionTest#26](../extensibility/codesnippet/CSharp/walkthrough-implementing-code-snippets_5.cs)]
      [!code-vb[VSSDKCompletionTest#26](../extensibility/codesnippet/VisualBasic/walkthrough-implementing-code-snippets_5.vb)]


### PR DESCRIPTION
Address incorrect use of ["using statement"](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-statement) to refer to a ["using directive"](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-directive).
