### PR TITLE
correct misuse of "statement" for a "directive"

### DIFF
--- a/docs/ide/reference/generate-usings.md
+++ b/docs/ide/reference/generate-usings.md
@@ -18,15 +18,15 @@ This code generation applies to:
 
 - C#
 
-**What:** Lets you immediately add the necessary imports or [using statements](/dotnet/csharp/language-reference/keywords/using-statement) for copy-and-pasted code.
+**What:** Lets you immediately add the necessary imports or [using directives](/dotnet/csharp/language-reference/keywords/using-directive) for copy-and-pasted code.
 
-**When:** It's common practice to copy code from different places in your project or other sources and paste it in to new code. This Quick Action finds missing imports statements for copy-and-pasted code and then prompts you to add them.
+**When:** It's common practice to copy code from different places in your project or other sources and paste it in to new code. This Quick Action finds missing imports directives for copy-and-pasted code and then prompts you to add them.
 
-**Why:** Because the Quick Action automatically adds necessary imports, you don't need to manually copy the `using` statements that your code needs.
+**Why:** Because the Quick Action automatically adds necessary imports, you don't need to manually copy the `using` directives that your code needs.
 
 ## Add missing usings refactoring
 
-1. Copy code from a file and paste it into a new one without including the necessary `using` statements. The resulting error is accompanied by a code fix that adds the missing `using` statements.
+1. Copy code from a file and paste it into a new one without including the necessary `using` directives. The resulting error is accompanied by a code fix that adds the missing `using` directives.
 
     > [!NOTE]
     > You need to enable this suggestion in **Tools > Options > Text Editor > C# > Advanced > Using Directives**.


### PR DESCRIPTION
Address incorrect use of ["using statement"](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-statement) to refer to a ["using directive"](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-directive).
