### PR TITLE
correct reference to using directives

### DIFF
--- a/docs/modeling/how-to-add-a-drag-and-drop-handler.md
+++ b/docs/modeling/how-to-add-a-drag-and-drop-handler.md
@@ -18,7 +18,7 @@ This topic discusses drag-and-drop gestures that originate on other diagrams. Fo
 
 `OnDragDrop`, `OnDoubleClick`, `OnDragOver`, and other methods can be overridden.
 
-Add a new code file to your DSL project. For a gesture handler, you usually must have at least the following `using` statements:
+Add a new code file to your DSL project. For a gesture handler, you usually must have at least the following `using` directives:
 
 ```csharp
 using Microsoft.VisualStudio.Modeling;


### PR DESCRIPTION
Address incorrect use of ["using statement"](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-statement) to refer to a ["using directive"](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-directive).
