### PR TITLE
remove confusion between statement and directive

### DIFF
--- a/docs/sharepoint/walkthrough-import-a-sharepoint-designer-reusable-workflow-into-visual-studio.md
+++ b/docs/sharepoint/walkthrough-import-a-sharepoint-designer-reusable-workflow-into-visual-studio.md
@@ -204,7 +204,7 @@ ms.workload:
 
     - In the **Properties** window for **CodeActivity1**, set the value of the **ExecuteCode** property to **codeActivity_ExecuteCode**.
 
-15. Add the following under the existing **using** or **Imports** statements:
+15. Add the following under the existing **using** or **Imports** directives:
 
      [!code-csharp[SP_SPDWFImport#1](../sharepoint/codesnippet/CSharp/workflowimportproject1/workflows/spd_task_workflowft/spd task workflow.xoml.cs#1)]
      [!code-vb[SP_SPDWFImport#1](../sharepoint/codesnippet/VisualBasic/workflowimportproject1/workflows/spd_task_workflowft/spd task workflow.xoml.vb#1)]


### PR DESCRIPTION
Address incorrect use of ["using statement"](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-statement) to refer to a ["using directive"](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-directive).
