### PR TITLE
using directives are not using statements

### DIFF
--- a/docs/test/how-to-create-a-diagnostic-data-adapter.md
+++ b/docs/test/how-to-create-a-diagnostic-data-adapter.md
@@ -62,7 +62,7 @@ For a complete example diagnostic data adapter project, including a custom confi
 
    3. Choose **OK**.
 
-4. Add the following `using` statements to your class file:
+4. Add the following `using` directives to your class file:
 
    ```csharp
    using Microsoft.VisualStudio.TestTools.Common;


### PR DESCRIPTION
Address incorrect use of ["using statement"](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-statement) to refer to a ["using directive"](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-directive).
