### PR TITLE
correctly refer to using directives

### DIFF
--- a/docs/extensibility/managing-universal-windows-projects.md
+++ b/docs/extensibility/managing-universal-windows-projects.md
@@ -23,7 +23,7 @@ Starting in Visual Studio 2015, you do not install the Visual Studio SDK from th
 
 2. Add a reference to *Microsoft.VisualStudio.Shell.Interop.12.1.DesignTime.dll* and *Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime.dll* (in the **Extensions** section).
 
-3. Open *TestUniversalProject.cs* and add the following `using` statements:
+3. Open *TestUniversalProject.cs* and add the following `using` directives:
 
     ```csharp
     using EnvDTE;
@@ -421,7 +421,7 @@ Starting in Visual Studio 2015, you do not install the Visual Studio SDK from th
 
 2. Add an event listener. Add a new class file to the project and call it *HierarchyEventListener.cs*.
 
-3. Open the *HierarchyEventListener.cs* file and add the following using statements:
+3. Open the *HierarchyEventListener.cs* file and add the following using directives:
 
    ```csharp
    using Microsoft.VisualStudio.Shell.Interop;


### PR DESCRIPTION
Address incorrect use of ["using statement"](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-statement) to refer to a ["using directive"](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-directive).
