### PR TITLE
reference "using directives" correctly

### DIFF
--- a/docs/ide/how-to-specify-build-events-csharp.md
+++ b/docs/ide/how-to-specify-build-events-csharp.md
@@ -66,7 +66,7 @@ The following procedure shows how to set the minimum operating system version in
 
 1. Create a new **Console App** project for the command. Name the project **ChangeOSVersionCS**.
 
-2. In *Program.cs*, add the following line to the other `using` statements at the top of the file:
+2. In *Program.cs*, add the following line to the other `using` directives at the top of the file:
 
    ```csharp
    using System.Xml;


### PR DESCRIPTION
Address incorrect use of ["using statement"](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-statement) to refer to a ["using directive"](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-directive).
