### PR TITLE
correctly refer to "using directives"

### DIFF
--- a/docs/deployment/how-to-retrieve-query-string-information-in-an-online-clickonce-application.md
+++ b/docs/deployment/how-to-retrieve-query-string-information-in-an-online-clickonce-application.md
@@ -40,7 +40,7 @@ The *query string* is the portion of a URL beginning with a question mark (?) th
 
 ### To obtain query string information from a ClickOnce application
 
-1. Place the following code in your project. In order for this code to function, you will have to have a reference to System.Web and add `using` or `Imports` statements for System.Web, System.Collections.Specialized, and System.Deployment.Application.
+1. Place the following code in your project. In order for this code to function, you will have to have a reference to System.Web and add `using` or `Imports` directives for System.Web, System.Collections.Specialized, and System.Deployment.Application.
 
      [!code-csharp[ClickOnceQueryString#1](../deployment/codesnippet/CSharp/how-to-retrieve-query-string-information-in-an-online-clickonce-application_1.cs)]
      [!code-vb[ClickOnceQueryString#1](../deployment/codesnippet/VisualBasic/how-to-retrieve-query-string-information-in-an-online-clickonce-application_1.vb)]


### PR DESCRIPTION
Address incorrect use of ["using statement"](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-statement) to refer to a ["using directive"](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-directive).
