### PR TITLE
correctly refer to "using directives"

### DIFF
--- a/docs/msbuild/walkthrough-creating-an-inline-task.md
+++ b/docs/msbuild/walkthrough-creating-an-inline-task.md
@@ -79,7 +79,7 @@ To create and run the tasks, use Visual Studio and the **Visual Studio Command P
 
 3. Save the project file.
 
-   This code creates an inline task that is named Hello and has no parameters, references, or `Using` statements. The Hello task contains just one line of code, which displays a hello message on the default logging device, typically the console window.
+   This code creates an inline task that is named Hello and has no parameters, references, or `Using` directives. The Hello task contains just one line of code, which displays a hello message on the default logging device, typically the console window.
 
 ### Run the Hello task
  Run MSBuild by using the **Command Prompt Window** to construct the Hello task and to process the TestBuild target that invokes it.


### PR DESCRIPTION
Address incorrect use of ["using statement"](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-statement) to refer to a ["using directive"](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-directive).
