### PR TITLE
correctly refer to "using directives"

### DIFF
--- a/docs/modeling/updating-shapes-and-connectors-to-reflect-the-model.md
+++ b/docs/modeling/updating-shapes-and-connectors-to-reflect-the-model.md
@@ -12,7 +12,7 @@ ms.workload:
 
 In a domain-specific language in Visual Studio, you can make the appearance of a shape reflect the state of the underlying model.
 
-The code examples in this topic should be added to a `.cs` file in your `Dsl` project. You need these statements in each file:
+The code examples in this topic should be added to a `.cs` file in your `Dsl` project. You need these directives in each file:
 
 ```csharp
 using Microsoft.VisualStudio.Modeling;


### PR DESCRIPTION
Address incorrect use of ["using statement"](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-statement) to refer to a ["using directive"](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-directive).
