### PR TITLE
correctly refer to "using directives"

### DIFF
--- a/docs/extensibility/extending-the-properties-task-list-output-and-options-windows.md
+++ b/docs/extensibility/extending-the-properties-task-list-output-and-options-windows.md
@@ -55,7 +55,7 @@ You can access any tool window in Visual Studio. This walkthrough shows how to i
 
 ### Customize the constructor
 
-1. In the *TodoWindowControl.xaml.cs* file, add the following using statement:
+1. In the *TodoWindowControl.xaml.cs* file, add the following using directive:
 
     ```csharp
     using System;
@@ -97,7 +97,7 @@ You can access any tool window in Visual Studio. This walkthrough shows how to i
    }
    ```
 
-2. Add the following using statement:
+2. Add the following using directive:
 
    ```csharp
    using Microsoft.VisualStudio.Shell;
@@ -144,7 +144,7 @@ You can access any tool window in Visual Studio. This walkthrough shows how to i
 
      ![Properties Window](../extensibility/media/t5properties.png "T5Properties")
 
-2. Add the following using statements the *TodoItem.cs* file.
+2. Add the following using directives the *TodoItem.cs* file.
 
     ```csharp
     using System.ComponentModel;
@@ -277,7 +277,7 @@ You can access any tool window in Visual Studio. This walkthrough shows how to i
     }
     ```
 
-4. Add the following using statements to *TodoWindowControl.xaml.cs*:
+4. Add the following using directives to *TodoWindowControl.xaml.cs*:
 
     ```csharp
     using System.Runtime.InteropServices;


### PR DESCRIPTION
Address incorrect use of ["using statement"](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-statement) to refer to a ["using directive"](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-directive).
