### PR TITLE
correctly refer to "using directives"

### DIFF
--- a/docs/vsto/walkthrough-calling-code-in-a-vsto-add-in-from-vba.md
+++ b/docs/vsto/walkthrough-calling-code-in-a-vsto-add-in-from-vba.md
@@ -65,7 +65,7 @@ ms.workload:
 
      The **AddInUtilities.cs** or **AddInUtilities.vb** file opens in the Code Editor.
 
-3. Add the following statements to the top of the file.
+3. Add the following directives to the top of the file.
 
      [!code-csharp[Trin_AddInInteropWalkthrough#2](../vsto/codesnippet/CSharp/Trin_AddInInteropWalkthrough/AddInUtilities.cs#2)]
      [!code-vb[Trin_AddInInteropWalkthrough#2](../vsto/codesnippet/VisualBasic/Trin_AddInInteropWalkthrough/AddInUtilities.vb#2)]


### PR DESCRIPTION
Address incorrect use of ["using statement"](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-statement) to refer to a ["using directive"](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-directive).
