### PR TITLE
correctly refer to "using directives"

### DIFF
--- a/docs/extensibility/managed-extensibility-framework-in-the-editor.md
+++ b/docs/extensibility/managed-extensibility-framework-in-the-editor.md
@@ -78,7 +78,7 @@ internal IClassificationTypeRegistryService ClassificationRegistry;
 
 1. Add references to *System.Composition.ComponentModel.dll*, which is in the global assembly cache (GAC), and to the editor assemblies.
 
-2. Add the relevant using statements.
+2. Add the relevant using directives.
 
     ```
     using System.ComponentModel.Composition;


### PR DESCRIPTION
Address incorrect use of ["using statement"](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-statement) to refer to a ["using directive"](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-directive).
