### PR TITLE
correctly refer to "using directives"

### DIFF
--- a/docs/extensibility/subscribing-to-an-event.md
+++ b/docs/extensibility/subscribing-to-an-event.md
@@ -39,7 +39,7 @@ This walkthrough explains how to create a tool window that responds to events in
     </Grid>
     ```
 
-2. Open the RDTExplorerWindow.cs file in code view. Add the following using statements to the start of the file.
+2. Open the RDTExplorerWindow.cs file in code view. Add the following using directives to the start of the file.
 
     ```csharp
     using Microsoft.VisualStudio;


### PR DESCRIPTION
Address incorrect use of ["using statement"](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-statement) to refer to a ["using directive"](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-directive).
