### PR TITLE
correctly refer to "using directives"

### DIFF
--- a/docs/extensibility/getting-service-information-from-the-settings-store.md
+++ b/docs/extensibility/getting-service-information-from-the-settings-store.md
@@ -16,7 +16,7 @@ You can use the settings store to find all available services or to determine wh
 
 1. Create a VSIX project named `FindServicesExtension` and then add a custom command named `FindServicesCommand`. For more information about how to create a custom command, see [Create an extension with a menu command](../extensibility/creating-an-extension-with-a-menu-command.md)
 
-2. In *FindServicesCommand.cs*, add the following using statements:
+2. In *FindServicesCommand.cs*, add the following using directives:
 
     ```vb
     using System.Collections.Generic;


### PR DESCRIPTION
Address incorrect use of ["using statement"](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-statement) to refer to a ["using directive"](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-directive).
