### PR TITLE
correctly refer to "using directives"

### DIFF
--- a/docs/extensibility/writing-to-the-user-settings-store.md
+++ b/docs/extensibility/writing-to-the-user-settings-store.md
@@ -16,7 +16,7 @@ User settings are writeable settings like the ones in the **Tools / Options** di
 
 1. Create a VSIX project named UserSettingsStoreExtension and then add a custom command named UserSettingsStoreCommand. For more information about how to create a custom command, see [Creating an Extension with a Menu Command](../extensibility/creating-an-extension-with-a-menu-command.md)
 
-2. In UserSettingsStoreCommand.cs, add the following using statements:
+2. In UserSettingsStoreCommand.cs, add the following using directives:
 
     ```csharp
     using System.Collections.Generic;


### PR DESCRIPTION
Address incorrect use of ["using statement"](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-statement) to refer to a ["using directive"](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-directive).
