### PR TITLE
correctly refer to "using directives"

### DIFF
--- a/docs/sharepoint/walkthrough-creating-a-silverlight-web-part-that-displays-odata-for-sharepoint.md
+++ b/docs/sharepoint/walkthrough-creating-a-silverlight-web-part-that-displays-odata-for-sharepoint.md
@@ -97,7 +97,7 @@ ms.workload:
     ```
 
     ```csharp
-    // Add the following three using statements.
+    // Add the following three using directives.
     using SLApplication.ServiceReference1;
     using System.Windows.Data;
     using System.Data.Services.Client;


### PR DESCRIPTION
Address incorrect use of ["using statement"](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-statement) to refer to a ["using directive"](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-directive).
