### PR TITLE
correctly refer to "using directives"

### DIFF
--- a/docs/extensibility/getting-project-properties.md
+++ b/docs/extensibility/getting-project-properties.md
@@ -30,7 +30,7 @@ Starting in Visual Studio 2015, you do not install the Visual Studio SDK from th
 
 ### To display project properties in a tool window
 
-1. In the ProjectPropertiesToolWindowCommand.cs file, add the following using statements.
+1. In the ProjectPropertiesToolWindowCommand.cs file, add the following using directives.
 
     ```csharp
     using EnvDTE;


### PR DESCRIPTION
Address incorrect use of ["using statement"](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-statement) to refer to a ["using directive"](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-directive).
