### PR TITLE
correctly refer to "using directives"

### DIFF
--- a/docs/deployment/walkthrough-creating-a-custom-installer-for-a-clickonce-application.md
+++ b/docs/deployment/walkthrough-creating-a-custom-installer-for-a-clickonce-application.md
@@ -30,7 +30,7 @@ Any ClickOnce application based on an *.exe* file can be silently installed and 
 
 2. Add a new class to your application and specify any name. This walkthrough uses the name `MyInstaller`.
 
-3. Add the following `Imports` or `using` statements to the top of your new class.
+3. Add the following `Imports` or `using` directives to the top of your new class.
 
     ```vb
     Imports System.Deployment.Application


### PR DESCRIPTION
Address incorrect use of ["using statement"](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-statement) to refer to a ["using directive"](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-directive).
