### PR TITLE
correctly refer to "using directives"

### DIFF
--- a/docs/extensibility/using-the-settings-store.md
+++ b/docs/extensibility/using-the-settings-store.md
@@ -30,7 +30,7 @@ There are two kinds of settings stores:
 ## Using the Configuration Settings Store
  This section shows how to detect and display configuration settings.
 
-1. In the SettingsStorageCommand.cs file, add the following using statements:
+1. In the SettingsStorageCommand.cs file, add the following using directives:
 
    ```
    using System.Collections.Generic;


### PR DESCRIPTION
Address incorrect use of ["using statement"](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-statement) to refer to a ["using directive"](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-directive).
