### PR TITLE
correctly refer to "using directives"

### DIFF
--- a/docs/extensibility/walkthrough-using-a-shortcut-key-with-an-editor-extension.md
+++ b/docs/extensibility/walkthrough-using-a-shortcut-key-with-an-editor-extension.md
@@ -57,7 +57,7 @@ Prior to Visual Studio 2017 version 15.6 the only way to handle commands in an e
 
 1. Add a class file and name it `KeyBindingCommandFilter`.
 
-2. Add the following using statements.
+2. Add the following using directives.
 
     ```csharp
     using System;
@@ -129,7 +129,7 @@ Prior to Visual Studio 2017 version 15.6 the only way to handle commands in an e
 ## Add the command filter (prior to Visual Studio 2017 version 15.6)
  The adornment provider must add a command filter to the text view. In this example, the provider implements <xref:Microsoft.VisualStudio.Editor.IVsTextViewCreationListener> to listen to text view creation events. This adornment provider also exports the adornment layer, which defines the Z-order of the adornment.
 
-1. In the KeyBindingTestTextViewCreationListener file, add the following using statements:
+1. In the KeyBindingTestTextViewCreationListener file, add the following using directives:
 
     ```csharp
     using System;
@@ -197,7 +197,7 @@ The command handler is an implementation of <xref:Microsoft.VisualStudio.Command
 
 1. Add a class file and name it `KeyBindingCommandHandler`.
 
-2. Add the following using statements.
+2. Add the following using directives.
 
    ```csharp
    using Microsoft.VisualStudio.Commanding;


### PR DESCRIPTION
Address incorrect use of ["using statement"](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-statement) to refer to a ["using directive"](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-directive).
