### PR TITLE
correctly refer to "using directives"

### DIFF
--- a/docs/debugger/walkthrough-writing-a-visualizer-in-csharp.md
+++ b/docs/debugger/walkthrough-writing-a-visualizer-in-csharp.md
@@ -59,7 +59,7 @@ Follow the tasks below to create a visualizer.
 
 5. Click **OK**.
 
-6. In DebuggerSide.cs, add the following statement to the `using` statements:
+6. In DebuggerSide.cs, add the following to the `using` directives:
 
    ```csharp
    using Microsoft.VisualStudio.DebuggerVisualizers;
@@ -93,7 +93,7 @@ Follow the tasks below to create a visualizer.
   }
   ```
 
-  The `Show` method contains the code that actually creates the visualizer dialog box or other user interface and displays the information that has been passed to the visualizer from the debugger. You must add the code that creates the dialog box and displays the information. In this walkthrough, you will do this using a Windows forms message box. First, you must add a reference and `using` statement for System.Windows.Forms.
+  The `Show` method contains the code that actually creates the visualizer dialog box or other user interface and displays the information that has been passed to the visualizer from the debugger. You must add the code that creates the dialog box and displays the information. In this walkthrough, you will do this using a Windows forms message box. First, you must add a reference and `using` directive for System.Windows.Forms.
 
 ### To add System.Windows.Forms
 
@@ -105,7 +105,7 @@ Follow the tasks below to create a visualizer.
 
 3. Click **OK**.
 
-4. In DebuggerSide.cs, add the following statement to the `using` statements:
+4. In DebuggerSide.cs, add the following to the `using` directives:
 
    ```csharp
    using System.Windows.Forms;
@@ -129,7 +129,7 @@ Follow the tasks below to create a visualizer.
 
 ### To add the debuggee-side code
 
-1. Add the following attribute code to DebuggerSide.cs, after the `using` statements but before `namespace MyFirstVisualizer`:
+1. Add the following attribute code to DebuggerSide.cs, after the `using` directives but before `namespace MyFirstVisualizer`:
 
    ```csharp
    [assembly:System.Diagnostics.DebuggerVisualizer(
@@ -199,7 +199,7 @@ Follow the tasks below to create a visualizer.
     > [!NOTE]
     > [!INCLUDE[vsprvs](../code-quality/includes/vsprvs_md.md)] automatically changes the class declaration in TestConsole.cs to match the new file name.
 
-3. In TestConsole.cs, add the following code to the `using` statements:
+3. In TestConsole.cs, add the following code to the `using` directives:
 
    ```csharp
    using MyFirstVisualizer;


### PR DESCRIPTION
Address incorrect use of ["using statement"](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-statement) to refer to a ["using directive"](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-directive).
