### PR TITLE
Fix typo in code snippets (Malacious -> Malicious)

### DIFF
--- a/docs/code-quality/codesnippet/CSharp/ca2100-review-sql-queries-for-security-vulnerabilities_1.cs
+++ b/docs/code-quality/codesnippet/CSharp/ca2100-review-sql-queries-for-security-vulnerabilities_1.cs
@@ -44,7 +44,7 @@ namespace SecurityLibrary
       }
    }
 
-   class MalaciousCode
+   class MaliciousCode
    {
       static void Main(string[] args)
       {

--- a/docs/code-quality/codesnippet/VisualBasic/ca2100-review-sql-queries-for-security-vulnerabilities_1.vb
+++ b/docs/code-quality/codesnippet/VisualBasic/ca2100-review-sql-queries-for-security-vulnerabilities_1.vb
@@ -46,7 +46,7 @@ Namespace SecurityLibrary
 
    End Class 
 
-   Class MalaciousCode
+   Class MaliciousCode
 
       Shared Sub Main(args As String())
       


### PR DESCRIPTION
Updated code snippet files used in https://docs.microsoft.com/en-us/visualstudio/code-quality/ca2100?view=vs-2019 to fix typo.
