### PR TITLE
Make CA1063 suggested pseudo-code in line with standards

### DIFF
--- a/docs/code-quality/ca1063.md
+++ b/docs/code-quality/ca1063.md
@@ -97,6 +97,7 @@ The following pseudo-code provides a general example of how Dispose(bool) should
 ```csharp
 public class Resource : IDisposable
 {
+    private isDisposed = false;
     private IntPtr nativeResource = Marshal.AllocHGlobal(100);
     private AnotherResource managedResource = new AnotherResource();
 
@@ -107,6 +108,27 @@ public class Resource : IDisposable
         GC.SuppressFinalize(this);
     }
 
+    // The bulk of the clean-up code is implemented in Dispose(bool)
+    protected virtual void Dispose(bool disposing)
+    {
+        if (isDisposed) return;
+        
+        if (disposing)
+        {
+            // free managed resources
+            managedResource.Dispose();
+        }
+        
+        // free native resources if there are any.
+        if (nativeResource != IntPtr.Zero)
+        {
+            Marshal.FreeHGlobal(nativeResource);
+            nativeResource = IntPtr.Zero;
+        }
+        
+        isDisposed = true;
+    }
+    
     // NOTE: Leave out the finalizer altogether if this class doesn't
     // own unmanaged resources, but leave the other methods
     // exactly as they are.
@@ -114,26 +136,6 @@ public class Resource : IDisposable
     {
         // Finalizer calls Dispose(false)
         Dispose(false);
-    }
-
-    // The bulk of the clean-up code is implemented in Dispose(bool)
-    protected virtual void Dispose(bool disposing)
-    {
-        if (disposing)
-        {
-            // free managed resources
-            if (managedResource != null)
-            {
-                managedResource.Dispose();
-                managedResource = null;
-            }
-        }
-        // free native resources if there are any.
-        if (nativeResource != IntPtr.Zero)
-        {
-            Marshal.FreeHGlobal(nativeResource);
-            nativeResource = IntPtr.Zero;
-        }
     }
 }
 ```

--- a/docs/code-quality/ca1063.md
+++ b/docs/code-quality/ca1063.md
@@ -97,7 +97,7 @@ The following pseudo-code provides a general example of how Dispose(bool) should
 ```csharp
 public class Resource : IDisposable
 {
-    private isDisposed = false;
+    private bool isDisposed;
     private IntPtr nativeResource = Marshal.AllocHGlobal(100);
     private AnotherResource managedResource = new AnotherResource();
 


### PR DESCRIPTION
This makes some improvements to make the suggestion in line with the pattern suggested in Standards docs at https://docs.microsoft.com/en-us/dotnet/standard/garbage-collection/implementing-dispose:

- Refrains from `null`ing a reference as a way of checking if disposal has been performed, which suggests that's a required or preferred pattern for disposing managed resources.
- Moves the Dispose(bool) method above the finalizer, as that's the more semantically important method.
