### PR TITLE
Doc repair

### DIFF
--- a/docs/code-quality/c6054.md
+++ b/docs/code-quality/c6054.md
@@ -45,7 +45,7 @@ void func( _In_z_ wchar_t* wszStr );
 void g( )
 {
     wchar_t wcArray[200];
-    wcArray[0]= '\0';
+    wcArray[199]= '\0';
     func(wcArray);
 }
 ```


### PR DESCRIPTION
'\0' must be the last element of array, because if you make the first element in array '\0' then the array end is on start.

(You can replace all of this text with your description.)

Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for docs.microsoft.com, see the contributor guide at https://docs.microsoft.com/contribute/.
