### PR TITLE
Remove indentation from paragraph

### DIFF
--- a/docs/debugger/remote-debugger-port-assignments.md
+++ b/docs/debugger/remote-debugger-port-assignments.md
@@ -23,7 +23,7 @@ The Visual Studio Remote Debugger can run as an application or as a background s
 
 - Visual Studio 2012: 4016
 
-  In other words, the number of the port assigned to the remote debugger is incremented by 2 for each release. You can set a different port number of you like. We will explain how to set port numbers in a later section.
+In other words, the number of the port assigned to the remote debugger is incremented by 2 for each release. You can set a different port number of you like. We will explain how to set port numbers in a later section.
 
 ## The Remote Debugger Port on 32-bit Operating Systems
 


### PR DESCRIPTION
The indent was making the paragraph appear to follow on from the last bullet point.

Most paragraphs in this document are indented, which can cause this kind of problem in Markdown.

**Before**

![image](https://user-images.githubusercontent.com/350947/69015820-35564700-09ec-11ea-8bcc-cd957ec828b1.png)
