### PR TITLE
Add IntermediateOutputPath

### DIFF
--- a/docs/test/live-unit-testing-faq.md
+++ b/docs/test/live-unit-testing-faq.md
@@ -87,13 +87,14 @@ You can get this error if the build process for your solution has custom logic t
 
 Live Unit Testing overrides those variables to ensure that build artifacts are dropped to a Live Unit Testing artifacts folder and will fail if your build process also overrides these variables.
 
-There are a two main approaches to make Live Unit Testing build successfully. For easier build configurations you can base your output paths on `<BaseIntermediateOutputPath>`. For more complex configurations you can base your output paths on `<LiveUnitTestingBuildRootPath>`.
+There are two main approaches to make Live Unit Testing build successfully. For easier build configurations, you can base your output paths on `<BaseIntermediateOutputPath>`. For more complex configurations you can base your output paths on `<LiveUnitTestingBuildRootPath>`.
 
 ### Overriding `<OutputPath>`/`<IntermediateOutputPath>` conditionally based on `<BaseOutputPath>`/ `<BaseIntermediateOutputPath>`.
 
-> Note: To use this approach each project needs to be able to build independently from one another. Do not have one project reference artifacts of another project during build. Do not have one project dynamically load assemblies from another project during runtime (for example call `Assembly.Loadfile("..\..\Project2\Release\Project2.dll")`).
+> [!NOTE]:
+> To use this approach, each project needs to be able to build independently from one another. Do not have one project reference artifacts from another project during build. Do not have one project dynamically load assemblies from another project during runtime (for example call `Assembly.Loadfile("..\..\Project2\Release\Project2.dll")`).
 
-During build Live Unit Testing will automatically override the `<BaseOutputPath>`/`<BaseIntermediateOutputPath>` variables to target the Live Unit Testing artifacts folder.
+During build, Live Unit Testing automatically overrides the `<BaseOutputPath>`/`<BaseIntermediateOutputPath>` variables to target the Live Unit Testing artifacts folder.
 
 For example, if your build overrides the <OutputPath> as shown below:
 
@@ -122,11 +123,12 @@ Do not override `<OutDir>` directly in your build process; override `<OutputPath
 
 ### Overriding your properties based on the `<LiveUnitTestingBuildRootPath>` property.
 
-> Note: In this approach you need to be careful about files added under the artifacts folder that are not generated during build. The example below shows what to do with placing the packages folder under artifacts. Since the contents of this folder are not generated during the build the MSBuild property **should not be changed**.
+> [!NOTE]:
+> In this approach, you need to be careful about files added under the artifacts folder that are not generated during build. The example below shows what to do when placing the packages folder under artifacts. Because the contents of this folder are not generated during the build, the MSBuild property **should not be changed**.
 
-During a Live Unit Testing build the `<LiveUnitTestingBuildRootPath>` property will be set to the location of Live Unit Testing artifacts folder.
+During a Live Unit Testing build, the `<LiveUnitTestingBuildRootPath>` property is set to the location of Live Unit Testing artifacts folder.
 
-For example assume that your project has the structure as shown below.
+For example, assume that your project has the structure shown here.
 
 ```
 .vs\...\lut\0\b
@@ -135,7 +137,7 @@ src\{proj1,proj2,proj3}
 tests\{testproj1,testproj2}
 Solution.sln
 ```
-During the Live Unit Testing build, the `<LiveUnitTestingBuildRootPath>` property will be set to the full path of `.vs\...\lut\0\b`. If the project defines `<ArtifactsRoot>` property that maps to the solution dir, you can update the MSBuild project as follows:
+During the Live Unit Testing build, the `<LiveUnitTestingBuildRootPath>` property is set to the full path of `.vs\...\lut\0\b`. If the project defines `<ArtifactsRoot>` property that maps to the solution dir, you can update the MSBuild project as follows:
 
 ```xml
 <Project>

--- a/docs/test/live-unit-testing-faq.md
+++ b/docs/test/live-unit-testing-faq.md
@@ -81,13 +81,23 @@ For example, there may be a target that produces NuGet packages during a regular
 
 ## Error messages with \<OutputPath>, \<OutDir> or \<IntermediateOutputPath>
 
-**Why do I get the following error when Live Unit Testing tries to build my solution: "...appears to unconditionally set `<OutputPath>` or `<OutDir>`. Live Unit Testing will not execute tests from the output assembly" or "...appears to unconditionally set `<IntermediateOutputPath>`. Code Coverage information may be unavailable."?**
+**Why do I get the following error when Live Unit Testing tries to build my solution: "...appears to unconditionally set `<OutputPath>` or `<OutDir>`. Live Unit Testing will not execute tests from the output assembly"?**
 
-You can get this error if the build process for your solution unconditionally overrides `<OutputPath>`, `<OutDir>` or `<IntermediateOutputPath>` so that it is not a subdirectory of `<BaseOutputPath>` or `<BaseIntermediateOutputPath>`. In such cases, Live Unit Testing will not work because it also overrides these values to ensure that build artifacts are dropped to a folder under `<BaseOutputPath>` or `<BaseIntermediateOutputPath>`. If you must override the location where you want your build artifacts to be dropped in a regular build, override the `<OutputPath>` or `<IntermediateOutputPath>` conditionally based on `<BaseOutputPath>` or `<BaseIntermediateOutputPath>`.
+You can get this error if the build process for your solution has custom logic that specifies where binaries should be generated. By default the location of your binaries depends on `<OutputPath>`, `<OutDir>` or `<IntermediateOutputPath>` as well as `<BaseOutputPath>` or `<BaseIntermediateOutputPath>`.
 
-For example, if your build overrides the `<OutputPath>` as shown below:
+Live Unit Testing overrides those variables to ensure that build artifacts are dropped to a Live Unit Testing artifacts folder and will fail if your build process also overrides these variables.
 
-```xml 
+There are a two main approaches to make Live Unit Testing build successfully. For easier build configurations you can base your output paths on `<BaseIntermediateOutputPath>`. For more complex configurations you can base your output paths on `<LiveUnitTestingBuildRootPath>`.
+
+### Overriding `<OutputPath>`/`<IntermediateOutputPath>` conditionally based on `<BaseOutputPath>`/ `<BaseIntermediateOutputPath>`.
+
+> Note: To use this approach each project needs to be able to build independently from one another. Do not have one project reference artifacts of another project during build. Do not have one project dynamically load assemblies from another project during runtime (for example call `Assembly.Loadfile("..\..\Project2\Release\Project2.dll")`).
+
+During build Live Unit Testing will automatically override the `<BaseOutputPath>`/`<BaseIntermediateOutputPath>` variables to target the Live Unit Testing artifacts folder.
+
+For example, if your build overrides the <OutputPath> as shown below:
+
+```xml
 <Project>
   <PropertyGroup>
     <OutputPath>$(SolutionDir)Artifacts\$(Configuration)\bin\$(MSBuildProjectName)</OutputPath>
@@ -97,7 +107,7 @@ For example, if your build overrides the `<OutputPath>` as shown below:
 
 then you can replace it with the following XML:
 
-```xml 
+```xml
 <Project>
   <PropertyGroup>
     <BaseOutputPath Condition="'$(BaseOutputPath)' == ''">$(SolutionDir)Artifacts\$(Configuration)\bin\$(MSBuildProjectName)\</BaseOutputPath>
@@ -109,6 +119,45 @@ then you can replace it with the following XML:
 This ensures that `<OutputPath>` lies within the `<BaseOutputPath>` folder.
 
 Do not override `<OutDir>` directly in your build process; override `<OutputPath>` instead to drop build artifacts to a specific location.
+
+### Overriding your properties based on the `<LiveUnitTestingBuildRootPath>` property.
+
+> Note: In this approach you need to be careful about files added under the artifacts folder that are not generated during build. The example below shows what to do with placing the packages folder under artifacts. Since the contents of this folder are not generated during the build the MSBuild property **should not be changed**.
+
+During a Live Unit Testing build the `<LiveUnitTestingBuildRootPath>` property will be set to the location of Live Unit Testing artifacts folder.
+
+For example assume that your project has the structure as shown below.
+
+```
+.vs\...\lut\0\b
+artifacts\{binlog,obj,bin,nupkg,testresults,packages}
+src\{proj1,proj2,proj3}
+tests\{testproj1,testproj2}
+Solution.sln
+```
+During the Live Unit Testing build, the `<LiveUnitTestingBuildRootPath>` property will be set to the full path of `.vs\...\lut\0\b`. If the project defines `<ArtifactsRoot>` property that maps to the solution dir, you can update the MSBuild project as follows:
+
+```xml
+<Project>
+    <PropertyGroup Condition="'$(LiveUnitTestingBuildRootPath)' == ''">
+        <SolutionDir>$([MSBuild]::GetDirectoryNameOfFileAbove(`$(MSBuildProjectDirectory)`, `YOUR_SOLUTION_NAME.sln`))\</SolutionDir>
+
+        <ArtifactsRoot>Artifacts\</ArtifactsRoot>
+        <ArtifactsRoot Condition="'$(LiveUnitTestingBuildRootPath)' != ''">$(LiveUnitTestingBuildRootPath)</ArtifactsRoot>
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <BinLogPath>$(ArtifactsRoot)\BinLog</BinLogPath>
+        <ObjPath>$(ArtifactsRoot)\Obj</ObjPath>
+        <BinPath>$(ArtifactsRoot)\Bin</BinPath>
+        <NupkgPath>$(ArtifactsRoot)\Nupkg</NupkgPath>
+        <TestResultsPath>$(ArtifactsRoot)\TestResults</TestResultsPath>
+
+        <!-- Note: Given that a build doesn't generate packages, the path should be relative to the solution dir, rather than artifacts root, which will change during a Live Unit Testing build. -->
+        <PackagesPath>$(SolutionDir)\artifacts\packages</PackagesPath>
+    </PropertyGroup>
+</Project>
+```
 
 ## Build artifact location
 

--- a/docs/test/live-unit-testing-faq.md
+++ b/docs/test/live-unit-testing-faq.md
@@ -79,11 +79,11 @@ For example, there may be a target that produces NuGet packages during a regular
 </Target>
 ```
 
-## Error messages with \<OutputPath> or \<OutDir>
+## Error messages with \<OutputPath>, \<OutDir> or \<IntermediateOutputPath>
 
-**Why do I get the following error when Live Unit Testing tries to build my solution: "...appears to unconditionally set `<OutputPath>` or `<OutDir>`. Live Unit Testing will not execute tests from the output assembly"?**
+**Why do I get the following error when Live Unit Testing tries to build my solution: "...appears to unconditionally set `<OutputPath>` or `<OutDir>`. Live Unit Testing will not execute tests from the output assembly" or "...appears to unconditionally set `<IntermediateOutputPath>`. Code Coverage information may be unavailable."?**
 
-You can get this error if the build process for your solution unconditionally overrides `<OutputPath>` or `<OutDir>` so that it is not a subdirectory of `<BaseOutputPath>`. In such cases, Live Unit Testing will not work because it also overrides these values to ensure that build artifacts are dropped to a folder under `<BaseOutputPath>`. If you must override the location where you want your build artifacts to be dropped in a regular build, override the `<OutputPath>` conditionally based on `<BaseOutputPath>`.
+You can get this error if the build process for your solution unconditionally overrides `<OutputPath>`, `<OutDir>` or `<IntermediateOutputPath>` so that it is not a subdirectory of `<BaseOutputPath>` or `<BaseIntermediateOutputPath>`. In such cases, Live Unit Testing will not work because it also overrides these values to ensure that build artifacts are dropped to a folder under `<BaseOutputPath>` or `<BaseIntermediateOutputPath>`. If you must override the location where you want your build artifacts to be dropped in a regular build, override the `<OutputPath>` or `<IntermediateOutputPath>` conditionally based on `<BaseOutputPath>` or `<BaseIntermediateOutputPath>`.
 
 For example, if your build overrides the `<OutputPath>` as shown below:
 


### PR DESCRIPTION
Add the explaination for IntermediateOutputPath overriding for Live Unit Testing.
It is related to the [PR](https://github.com/dotnet/testimpact/pull/2847)
