### PR TITLE
Remove bullet points from section descriptions.

### DIFF
--- a/docs/deployment/building-clickonce-applications-from-the-command-line.md
+++ b/docs/deployment/building-clickonce-applications-from-the-command-line.md
@@ -139,13 +139,13 @@ msbuild /target:publish /property:BootstrapperEnabled=false
 
 - `UpdateUrl` (not shown) is the location from which the application will receive updates. If specified, this value is inserted into the application manifest.
 
-- The following properties are set in the **Publish Options** dialog box, accessed from the **Publish** page.
+  The following properties are set in the **Publish Options** dialog box, accessed from the **Publish** page.
 
 - `PublisherName` specifies the name of the publisher displayed in the prompt shown when installing or running the application. In the case of an installed application, it is also used to specify the folder name on the **Start** menu.
 
 - `ProductName` specifies the name of the product displayed in the prompt shown when installing or running the application. In the case of an installed application, it is also used to specify the shortcut name on the **Start** menu.
 
-- The following properties are set in the **Prerequisites** dialog box, accessed from the **Publish** page.
+  The following properties are set in the **Prerequisites** dialog box, accessed from the **Publish** page.
 
 - `BootstrapperEnabled` determines whether to generate the *setup.exe* bootstrapper.
 


### PR DESCRIPTION
Some of the section description blocks accidentally got laid out as bullet points, making them hard to see.

(You can replace all of this text with your description.)

Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for docs.microsoft.com, see the contributor guide at https://docs.microsoft.com/contribute/.
