### PR TITLE
Update idebugengineprogram2-stop.md

### DIFF
--- a/docs/extensibility/debugger/reference/idebugengineprogram2-stop.md
+++ b/docs/extensibility/debugger/reference/idebugengineprogram2-stop.md
@@ -37,7 +37,7 @@ int Stop();
 ## Remarks
  This method is called when this program is being debugged in a multi-program environment. When a stopping event from some other program is received, this method is called on this program. The implementation of this method should be asynchronous; that is, not all threads should be required to be stopped before this method returns. The implementation of this method may be as simple as calling the [CauseBreak](../../../extensibility/debugger/reference/idebugprogram2-causebreak.md) method on this program.
 
- No debug event is sent in response to this method.
+ Implementers should send an [IDebugStopCompleteEvent2](../../../extensibility/debugger/reference/idebugstopcompleteevent2.md) when the program stops.
 
 ## See also
 - [IDebugEngineProgram2](../../../extensibility/debugger/reference/idebugengineprogram2.md)


### PR DESCRIPTION
The text "No debug event is sent in response to this method." contradicts the text on https://docs.microsoft.com/en-us/visualstudio/extensibility/debugger/reference/idebugstopcompleteevent2 which says that a StopCompleteEvent is sent in response to a program being `Stop`ped in a multi-program debugging situation.

(You can replace all of this text with your description.)

Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for docs.microsoft.com, see the contributor guide at https://docs.microsoft.com/contribute/.
