### PR TITLE
Update warning descriptions and demo for C++ static analysis

### DIFF
--- a/docs/code-quality/c28205.md
+++ b/docs/code-quality/c28205.md
@@ -14,6 +14,40 @@ ms.workload:
   - "multiple"
 ---
 # C28205
-warning C28205: function> : `_Success_` or `_On_failure_` used in an illegal context: \<why>
+warning C28205: function> : `_Success_` or `_On_failure_` used in an illegal context
 
- This warning is reported when there is an error in the annotations.
+ The `_Success_` and `_On_failure_` annotations can only be used on function return values.
+
+## Examples
+
+```cpp
+#include<sal.h>
+
+// Oops, _Success_ is not valid in parameter lists, should be moved to return value.
+bool GetValue( _Success_(return != false) _Out_ int *pInt, bool flag)
+{
+   if(flag) {
+      *pInt = 5;
+      return true;
+   } else {
+      return false;
+   }
+}
+```
+
+```cpp
+#include<sal.h>
+
+_Success_(return != false)
+bool GetValue(_Out_ int *pInt, bool flag)
+{
+   if(flag) {
+      *pInt = 5;
+      return true;
+   } else {
+      return false;
+   }
+}
+```
+
+[Understanding Sal](understanding-sal.md)

--- a/docs/code-quality/c28213.md
+++ b/docs/code-quality/c28213.md
@@ -29,9 +29,9 @@ void example_func(_Out_writes_(n) char* buffer, int n);
 _Use_decl_annotations_ 
 void example_func(_Out_writes_z_(n) char* buffer, int n)
 {
-	buffer = new char[n+1];
-	buffer[n] = '\0';
-	// ...
+    buffer = new char[n+1];
+    buffer[n] = '\0';
+    // ...
 }
 ```
 
@@ -46,8 +46,8 @@ void example_func(_Out_writes_z_(n) char* buffer, int n);
 _Use_decl_annotations_ 
 void example_func(char* buffer, int n)
 {
-	buffer = new char[n+1];
-	buffer[n] = '\0';
-	// ...
+    buffer = new char[n+1];
+    buffer[n] = '\0';
+    // ...
 }
 ```

--- a/docs/code-quality/c28213.md
+++ b/docs/code-quality/c28213.md
@@ -29,9 +29,8 @@ void example_func(_Out_writes_(n) char* buffer, int n);
 _Use_decl_annotations_ 
 void example_func(_Out_writes_z_(n) char* buffer, int n)
 {
-    buffer = new char[n+1];
-    buffer[n] = '\0';
-    // ...
+  // ...
+  buffer[n] = '\0';
 }
 ```
 
@@ -46,8 +45,7 @@ void example_func(_Out_writes_z_(n) char* buffer, int n);
 _Use_decl_annotations_ 
 void example_func(char* buffer, int n)
 {
-    buffer = new char[n+1];
-    buffer[n] = '\0';
-    // ...
+  // ...
+  buffer[n] = '\0';
 }
 ```

--- a/docs/code-quality/c28213.md
+++ b/docs/code-quality/c28213.md
@@ -14,6 +14,40 @@ ms.workload:
   - "multiple"
 ---
 # C28213
-warning C28213: The `_Use_decl_annotations_` annotation must be used to reference, without modification, a prior declaration. \<why>
+warning C28213: The `_Use_decl_annotations_` annotation must be used to reference, without modification, a prior declaration.
 
- This warning is reported when a prior declaration is referenced without the required `_Use_decl_annotations_` annotation.
+`_Use_decl_annotations_` tells the compiler to use the annotations from an earlier declaration of the function.  If no earlier declaration can be found, or if the currect declaration makes changes to the annotations than this warning is emitted.
+
+
+## Example
+
+```cpp
+// from example.h
+void example_func(_Out_writes_(n) char* buffer, int n);
+
+// from example.cpp
+_Use_decl_annotations_ 
+void example_func(_Out_writes_z_(n) char* buffer, int n)
+{
+	buffer = new char[n+1];
+	buffer[n] = '\0';
+	// ...
+}
+```
+
+The `buffer` parameter annotation does not match between the two files.  This can be fixed by either changing the annotation so they match at all locations, or by removing all annotations except `_Use_decl_annotations_` from the function definition.  In this example `_Out_writes_z_` appears to be correct so we will move that to the function declaration in the header file.
+
+```cpp
+
+// from example.h
+void example_func(_Out_writes_z_(n) char* buffer, int n);
+
+// from example.cpp
+_Use_decl_annotations_ 
+void example_func(char* buffer, int n)
+{
+	buffer = new char[n+1];
+	buffer[n] = '\0';
+	// ...
+}
+```

--- a/docs/code-quality/c28213.md
+++ b/docs/code-quality/c28213.md
@@ -16,7 +16,7 @@ ms.workload:
 # C28213
 warning C28213: The `_Use_decl_annotations_` annotation must be used to reference, without modification, a prior declaration.
 
-`_Use_decl_annotations_` tells the compiler to use the annotations from an earlier declaration of the function.  If no earlier declaration can be found, or if the currect declaration makes changes to the annotations than this warning is emitted.
+`_Use_decl_annotations_` tells the compiler to use the annotations from an earlier declaration of the function.  If no earlier declaration can be found, or if the current declaration makes changes to the annotations than this warning is emitted.
 
 
 ## Example

--- a/docs/code-quality/c28220.md
+++ b/docs/code-quality/c28220.md
@@ -16,7 +16,7 @@ ms.workload:
 # C28220
 warning C28220: Integer expression expected for annotation ''
 
- This warning indicates that an integer expression was expected as an annotation parameter, but an incompatable type was used instead.  This can be caused by attempting to use a sal annotation macro that does not fit the current scenario.
+ This warning indicates that an integer expression was expected as an annotation parameter, but an incompatible type was used instead.  This can be caused by attempting to use a sal annotation macro that does not fit the current scenario.
 
 ## Example
 
@@ -34,7 +34,7 @@ void f(_In_reads_(last) const int *buffer, const int *last)
 ```
 In this example the intent of the developer was to indicate that `buffer` would be read up to the `last` element.  The `_In_reads_` annotation does not fix the scenario because it is used to indicate a buffer size in number of elements.  The correct annotation in this case would be `_In_reads_to_ptr_` which indicates the end of the buffer with a pointer.
 
-If there was no `_to_ptr_` equivelent to the annotation used, then the warning could have been addressed by converting the `last` pointer into a size value with `(buffer - size)` in the annotation.
+If there was no `_to_ptr_` equivalent to the annotation used, then the warning could have been addressed by converting the `last` pointer into a size value with `(buffer - size)` in the annotation.
 ```cpp
 #include <sal.h>
 

--- a/docs/code-quality/c28220.md
+++ b/docs/code-quality/c28220.md
@@ -14,6 +14,35 @@ ms.workload:
   - "multiple"
 ---
 # C28220
-warning C28220: Integer expression expected for annotation the parameter in the annotation
+warning C28220: Integer expression expected for annotation ''
 
- This warning indicates that a parameter to an annotation is expected to be an integer expression, and some other type was encountered. This usually indicates an incorrectly coded annotation macro.
+ This warning indicates that an integer expression was expected as an annotation parameter, but an incompatable type was used instead.  This can be caused by attempting to use a sal annotation macro that does not fit the current scenario.
+
+## Example
+
+```cpp
+#include <sal.h>
+
+// Oops, the _In_reads_ annotation takes an integer type but is being passed a pointer
+void f(_In_reads_(last) const int *buffer, const int *last)
+{
+  for(; buffer < last; ++buffer)
+  {
+    //...
+  }
+}
+```
+In this example the intent of the developer was to indicate that `buffer` would be read up to the `last` element.  The `_In_reads_` annotation does not fix the scenario because it is used to indicate a buffer size in number of elements.  The correct annotation in this case would be `_In_reads_to_ptr_` which indicates the end of the buffer with a pointer.
+
+If there was no `_to_ptr_` equivelent to the annotation used, then the warning could have been addressed by converting the `last` pointer into a size value with `(buffer - size)` in the annotation.
+```cpp
+#include <sal.h>
+
+void f(_In_reads_to_ptr_(last) const int *buffer, const int *last)
+{
+  for(; buffer < last; ++buffer)
+  {
+    //...
+  }
+}
+```

--- a/docs/code-quality/c28220.md
+++ b/docs/code-quality/c28220.md
@@ -14,7 +14,7 @@ ms.workload:
   - "multiple"
 ---
 # C28220
-warning C28220: Integer expression expected for annotation ''
+warning C28220: Integer expression expected for annotation '\<annotation\>'
 
  This warning indicates that an integer expression was expected as an annotation parameter, but an incompatible type was used instead.  This can be caused by attempting to use a sal annotation macro that does not fit the current scenario.
 

--- a/docs/code-quality/c28230.md
+++ b/docs/code-quality/c28230.md
@@ -16,4 +16,40 @@ ms.workload:
 # C28230
 warning C28230: The type of parameter has no member.
 
- This warning indicates that an argument to an annotation attempts to access a `struct`, `class`, or `union` and the named member does not exist.
+ This warning indicates that an argument to an annotation attempts to access a member of a `struct`, `class`, or `union` that does not exist.  This warning will also be emitted if a parameter tries to call a member function of the object.
+
+## Example
+
+```cpp
+#include <sal.h>
+
+struct MyStruct
+{
+  //...
+  int usefulMember;
+};
+
+// Oops, the name of the member is spelled wrong so it will not be found
+void f(_Out_writes_(value.usefullMember) int *buffer, MyStruct value)
+{
+  for(int i = 0 ; i < value.usefulMember; i++)
+  {
+    buffer[i] = i;
+    //...
+  }
+}
+```
+
+In this example the spelling just needs to be corrected.
+
+```cpp
+void f(_Out_writes_(value.usefulMember) int *buffer, MyStruct value)
+{
+  for(int i = 0 ; i < value.usefulMember; i++)
+  {
+    buffer[i] = i;
+    //...
+  }
+}
+```
+

--- a/docs/code-quality/c28285.md
+++ b/docs/code-quality/c28285.md
@@ -14,6 +14,29 @@ ms.workload:
   - "multiple"
 ---
 # C28285
-warning C28285: For function, syntax error in parameter
+warning C28285: For function 'function_name', syntax error in 'annotation'
 
- The Code Analysis tool reports this warning when a probable error is encountered in the model file. A few source file errors can also cause such errors.
+ The Code Analysis tool reports this warning when it has encountered a syntax error in the sal annotation.  The sal parser will recover by discarding the malformed annotation.
+ 
+ ## Example
+ 
+```cpp
+// The argument '(n,2)' is malformed and will cause a C28285 warning after the _Out_writes_z_ macro is expanded.
+void example_func(_Out_writes_z_((2,n)) char* buffer, int n)
+{
+  buffer = new char[n+1];
+  buffer[n] = '\0';
+  // ...
+}
+```
+Double check the documentation to the sal annotations being used and try to simplify the annotation.  You should not use implementation layer sal such as `__declspec("SAL_begin")` directly, if you are using that layer then change them into higher layers such as `_In_`/`_Out_`/`_Ret_`.
+
+```cpp
+void example_func(_Out_writes_z_(n) char* buffer, int n)
+{
+  buffer = new char[n+1];
+  buffer[n] = '\0';
+  // ...
+}
+```
+

--- a/docs/code-quality/c28285.md
+++ b/docs/code-quality/c28285.md
@@ -24,9 +24,8 @@ warning C28285: For function 'function_name', syntax error in 'annotation'
 // The argument '(n,2)' is malformed and will cause a C28285 warning after the _Out_writes_z_ macro is expanded.
 void example_func(_Out_writes_z_((2,n)) char* buffer, int n)
 {
-  buffer = new char[n+1];
-  buffer[n] = '\0';
   // ...
+  buffer[n] = '\0';
 }
 ```
 Double check the documentation to the sal annotations being used and try to simplify the annotation.  You should not use implementation layer sal such as `__declspec("SAL_begin")` directly, if you are using that layer then change them into higher layers such as `_In_`/`_Out_`/`_Ret_`.
@@ -34,9 +33,8 @@ Double check the documentation to the sal annotations being used and try to simp
 ```cpp
 void example_func(_Out_writes_z_(n) char* buffer, int n)
 {
-  buffer = new char[n+1];
-  buffer[n] = '\0';
   // ...
+  buffer[n] = '\0';
 }
 ```
 

--- a/docs/code-quality/c28285.md
+++ b/docs/code-quality/c28285.md
@@ -28,7 +28,7 @@ void example_func(_Out_writes_z_((2,n)) char* buffer, int n)
   buffer[n] = '\0';
 }
 ```
-Double check the documentation to the sal annotations being used and try to simplify the annotation.  You should not use implementation layer sal such as `__declspec("SAL_begin")` directly, if you are using that layer then change them into higher layers such as `_In_`/`_Out_`/`_Ret_`.
+Double check the documentation to the sal annotations being used and try to simplify the annotation.  You should not use implementation layer sal such as `__declspec("SAL_begin")` directly, if you are using that layer then change them into higher layers such as `_In_`/`_Out_`/`_Ret_`.  See [Annotating Function Parameters and Return Values](annotating-function-parameters-and-return-values.md) for more information.
 
 ```cpp
 void example_func(_Out_writes_z_(n) char* buffer, int n)

--- a/docs/code-quality/c28300.md
+++ b/docs/code-quality/c28300.md
@@ -21,32 +21,28 @@ warning C28300: <parameter_name>: Expression operands of incompatible types for 
 ## Example
 
 ```cpp
-struct MyStruct
+union MyUnion
 {
-  operator int() const { return length; }
-  //...
-  private:
   int length;
+  //...
 };
 
-// Oops, expressions in sal annotations only do limited conversions so int and MyStruct
-// are not compatible with the + operator.
-void f(_In_reads_(10 + value) int *buffer, MyStruct value)
+// Oops, int and MyUnion are not compatible with the + operator.
+void f(_In_reads_(10 + value) int *buffer, MyUnion value)
 {
-  for(int i = 0 ; i < (10 + value); i++)
+  for(int i = 0 ; i < (10 + value.length); i++)
   {
     //...
   }
 }
 ```
 
-In this example there is a clear conversion between the incompatible types that can be fixed with a cast.  In other cases you may need to reevaluate your sal annotation to express the intent another way.
+In this example the developer forgot to access the appropriate member variable.  In other cases it may need to be fixed with an explicit cast.
 
 ```cpp
-// explicitly convert value to an integer to make it compatible.
-void f(_In_reads_(10 + static_cast<int>(value)) int *buffer, MyStruct value)
+void f(_In_reads_(10 + value.length) int *buffer, MyUnion value)
 {
-  for(int i = 0 ; i < (10 + value); i++)
+  for(int i = 0 ; i < (10 + value.length); i++)
   {
     //...
   }

--- a/docs/code-quality/c28300.md
+++ b/docs/code-quality/c28300.md
@@ -16,4 +16,39 @@ ms.workload:
 # C28300
 warning C28300: <parameter_name>: Expression operands of incompatible types for operator <operator_name>
 
- This warning is reported when operand types in a parameter are not compatible with the operator.
+ This warning is emitted when a sal annotation contains an expression containing incompatible types.
+
+## Example
+
+```cpp
+struct MyStruct
+{
+  operator int() const { return length; }
+  //...
+  private:
+  int length;
+};
+
+// Oops, expressions in sal annotations only do limited conversions so int and MyStruct
+// are not compatible with the + operator.
+void f(_In_reads_(10 + value) int *buffer, MyStruct value)
+{
+  for(int i = 0 ; i < (10 + value); i++)
+  {
+    //...
+  }
+}
+```
+
+In this example there is a clear conversion between the incompatible types that can be fixed with a cast.  In other cases you may need to reevaluate your sal annotation to express the intent another way.
+
+```cpp
+// explicitly convert value to an integer to make it compatible.
+void f(_In_reads_(10 + static_cast<int>(value)) int *buffer, MyStruct value)
+{
+  for(int i = 0 ; i < (10 + value); i++)
+  {
+    //...
+  }
+}
+```

--- a/docs/code-quality/c28302.md
+++ b/docs/code-quality/c28302.md
@@ -16,8 +16,23 @@ ms.workload:
 # C28302
 warning C28302: For C++ reference-parameter <parameter_name>, an extra `_Deref_` operator was found on \<annotation>.
 
- This warning is reported when an extra level of `_Deref_` is used on a parameter.
+ This warning is reported when an extra level of `_Deref_` is used on a parameter of a reference type such as `T &a`.  A common mistake when using SAL1 annotations is to use `__deref` on a reference type.  Reference types are understood by SAL so all annotations are already applied to the underlying type.  This is typically not an issue in SAL2 because the free-floating `__deref` annotation was removed.  If the intention is to apply an annotation to a sub-type then you should instead use the SAL2 `_AT_` or `_Outref_` annotations.
+ 
+## Example
 
- SAL2 does not require the use of an extra level of `_Deref_` when dealing with reference parameters. This particular annotation is unambiguous and is interpreted correctly, but should be corrected.
+```cpp
+// Oops, trying to apply __elem_writableTo to the pointer being referenced
+void f( __deref __elem_writableTo(size) int *& buffer, int size);
 
- Frequently this can be corrected by simply removing the older `__deref` annotation and using SAL2 syntax. Sometimes may be necessary to use `_At_` to reference the specific object to be annotated.
+void func()
+{
+	int buffer[100] = {};
+	int *pbuffer = buffer;
+	f(pbuffer, 100);
+}
+```
+
+```cpp
+// Fix warning switching to SAL2 syntax which has annotations that better describe what the function does.
+void f( _Outref_result_buffer_(size) int *& buffer);
+```

--- a/docs/code-quality/c28302.md
+++ b/docs/code-quality/c28302.md
@@ -26,9 +26,9 @@ void f( __deref __elem_writableTo(size) int *& buffer, int size);
 
 void func()
 {
-	int buffer[100] = {};
-	int *pbuffer = buffer;
-	f(pbuffer, 100);
+  int buffer[100] = {};
+  int *pbuffer = buffer;
+  f(pbuffer, 100);
 }
 ```
 

--- a/docs/code-quality/c6216.md
+++ b/docs/code-quality/c6216.md
@@ -16,7 +16,7 @@ ms.workload:
 # C6216
 warning C6216: compiler-inserted cast between semantically different integral types: a Boolean type to HRESULT
 
- This warning indicates that a Boolean is being used as an `HRESULT` without being explicitly cast. Boolean types indicate success by a non-zero value; success (`S_OK`) in `HRESULT` is indicated by a value of 0. The typical failure value for functions that return a Boolean false is a success status when it is tested as an `HRESULT`. This is likely to lead to incorrect results.
+ A Boolean type is being used as an `HRESULT` without being explicitly cast. Boolean types indicate success by a non-zero value; success (`S_OK`) in `HRESULT` is indicated by a value of 0.  This means a Boolean false value used as an `HRESULT` would indicate `S_OK`, which is frequently a mistake.
 
 ## Example
  The following code generates this warning:
@@ -27,12 +27,13 @@ BOOL IsEqual(REFGUID, REFGUID);
 
 HRESULT f( REFGUID riid1, REFGUID riid2 )
 {
-  // code ...
+  // Oops, f() should return S_OK when the values are equal but will 
+  // return E_FAIL instead because IsEqual returns a c-style boolean values TRUE or FALSE
   return IsEqual(riid1, riid2);
 }
 ```
 
- To correct this warning, use the following code:
+ To correct this warning, either add the appropriate conversion between the two types or add an explicit cast.
 
 ```cpp
 #include <windows.h>
@@ -40,16 +41,8 @@ BOOL IsEqual(REFGUID, REFGUID);
 
 HRESULT f( REFGUID riid1, REFGUID riid2 )
 {
-  if (IsEqual(riid1, riid2) == TRUE)
-  {
-    // code ...
-    return S_OK;
-  }
-  else
-  {
-    // code ...
-    return E_FAIL;
-  }
+  // converting because IsEqual returns a c-style TRUE or FALSE
+  return IsEqual(riid1, riid2) ? S_OK : E_FAIL;
 }
 ```
 

--- a/docs/code-quality/c6284.md
+++ b/docs/code-quality/c6284.md
@@ -14,44 +14,45 @@ ms.workload:
   - "multiple"
 ---
 # C6284
-warning C6284: object passed as parameter '%d' when string is required in call to \<function>.
+warning C6284: object passed as parameter when string is required in call to \<function
 
- This warning indicates that the format string specifies a string, for example, a `%s` specification for `printf` or `scanf`, but a C++ object has been passed instead.
+ This warning indicates that there is a mismatch between the format specifier and the type being used in a `printf`-style function.  The format specifier is a C style String type such as `%s` or `%ws`, and the argument matched with it is an object type.
 
- This defect might produce incorrect output or crashes.
+ This defect might produce incorrect output or crash.
 
- This message is often reported due to passing a C++ object implementing some string type, for example, `std::string`, `CComBSTR` or `bstr_t`, into a C `printf`-style call. Depending on the implementation of the C++ class, that is, if the proper cast operators are defined, C++ string objects can often be used transparently whenever C strings are required; however, because parameters to `printf`-style functions are essentially untyped, no conversion to a string occurs.
-
- Depending on the object, it might be appropriate to insert a `static_cast` operator to the appropriate string type, for example, `char *` or `TCHAR``*`, or to call a member function which returns a string, for example, `c_str()`, on instances of `std::string`.
+ This is frequently due to forgetting to convert an object string type such as `std::string`, `CComBSTR` or `bstr_t` into the C style string the `printf`-style function expects.  If this is the case then the fix is to add the appropriate conversion to the type.  This is needed because the parameters to `printf`-style functions are essentially untyped so no automatic conversion occurs.
 
 ## Example
- The following code generates this warning because a `CComBSTR` is passed to the `sprintf` function:
 
 ```cpp
 #include <atlbase.h>
-#include <stdlib.h>
+#include <string>
+#include <cstdlib>
 
 void f()
 {
   char buff[50];
-  CComBSTR bstrValue("Bye");
+  CComBSTR bstrValue{"Hello"};
+  std::string str{"World"};
 
-  sprintf(buff,"%ws",bstrValue);
+  // Oops, %ws and %s require C-style strings but CComBSTR and std::strings are being passed instead
+  sprintf(buff,"%ws %s",bstrValue, str);
 }
 ```
-
- The following code uses static cast to correct this warning:
-
+Fix the warning by adding the appropriate conversions:
 ```cpp
 #include <atlbase.h>
-#include <stdlib.h>
+#include <string>
+#include <cstdlib>
 
 void f()
 {
   char buff[50];
-  CComBSTR bstrValue("Bye");
+  CComBSTR bstrValue{"Hello"};
+  std::string str{"World"};
 
-  sprintf_s(buff,50,"%ws",static_cast<wchar_t *>(bstrValue));
+  // Fixed by adding a static_cast to the CComBSTR and calling c_str() on the std::string
+  sprintf(buff,"%ws %s",static_cast<wchar_t*>(bstrValue), str.c_str());
 }
 ```
 

--- a/docs/code-quality/c6284.md
+++ b/docs/code-quality/c6284.md
@@ -14,7 +14,7 @@ ms.workload:
   - "multiple"
 ---
 # C6284
-warning C6284: object passed as parameter when string is required in call to \<function
+warning C6284: object passed as parameter when string is required in call to \<function\>
 
  This warning indicates that there is a mismatch between the format specifier and the type being used in a `printf`-style function.  The format specifier is a C style String type such as `%s` or `%ws`, and the argument matched with it is an object type.
 

--- a/docs/code-quality/c6287.md
+++ b/docs/code-quality/c6287.md
@@ -16,23 +16,19 @@ ms.workload:
 # C6287
 warning C6287: redundant code: the left and right sub-expressions are identical
 
- This warning indicates that a redundant element was detected in an expression.
+ This warning is emitted when an expression contains redundant logic.  This can indicate a logic error due to the developer accidently using the wrong variable, or it could also be a redundant test that can be removed.  The code should be inspected to verify that there is no logic error.
 
- It is difficult to judge the severity of this problem without examining the code. A duplicate test on its own is harmless, but the consequences of deleting the second test can be severe. The code should be inspected to ensure that a test was not omitted.
 
 ## Example
  The following code generates this warning:
 
 ```cpp
-void f(int x)
+void f(int x, int y)
 {
+  // comparing against x twice is suspicious, should the second comparison use y?
   if ((x == 1) && (x == 1))
   {
-    //logic
-  }
-  if ((x != 1) || (x != 1))
-  {
-    //logic
+    //...
   }
 }
 ```
@@ -42,23 +38,16 @@ void f(int x)
 ```cpp
 void f(int x, int y)
 {
-  /* Remove the redundant sub-expression: */
-  if (x == 1)
-  {
-     // logic
-  }
-  if (x != 1)
-  {
-    // logic
-  }
-  /* or test the missing variable: */
+  // Fixed the second comparison to use y
   if ((x == 1) && (y == 1))
   {
-     // logic
+     // ...
   }
-  if ((x != 1) || (y != 1))
+  
+  // If the second comparison was unnecessary it could be removed
+  if (x == 1)
   {
-     // logic
+     // ...
   }
 }
 ```

--- a/docs/code-quality/c6302.md
+++ b/docs/code-quality/c6302.md
@@ -16,7 +16,7 @@ ms.workload:
 # C6302
 warning C6302: format string mismatch: character string passed as parameter \<number> when wide character string is required in call to \<function>
 
-  This warning indicates that the format string specifies a wide character string is expected. However, a character string is being passed. This will likely cause the output to be malformed or for the program to crash at runtime.
+ This warning indicates that the format string specifies a wide character string is expected. However, a character string is being passed. This will likely cause the output to be malformed or for the program to crash at runtime.
 
 ## Example
 

--- a/docs/code-quality/c6302.md
+++ b/docs/code-quality/c6302.md
@@ -16,10 +16,9 @@ ms.workload:
 # C6302
 warning C6302: format string mismatch: character string passed as parameter \<number> when wide character string is required in call to \<function>
 
- This warning indicates that the format string specifies that a wide character string is required. However, a character string is being passed. This defect is likely to cause a crash or a corruption of some form.
+  This warning indicates that the format string specifies a wide character string is expected. However, a character string is being passed. This will likely cause the output to be malformed or for the program to crash at runtime.
 
 ## Example
- The following sample code generates this warning because a character string is passed to `wprintf` function:
 
 ```cpp
 #include <stdio.h>
@@ -28,11 +27,12 @@ void f()
 {
   char buff[5] = "hi";
 
-  wprintf(L"%s", buff);
+  // Oops, because this is wprintf, the %s format specifier will interpret the argument as a wide string.
+  wprintf_s(L"%s", buff);
 }
 ```
 
- The following sample code uses `%hs` to specify a single-byte character string with `wprintf` function:
+The following sample code uses `%hs` to specify a single-byte character string with `wprintf_s` function:
 
 ```cpp
 #include <stdio.h>
@@ -41,19 +41,7 @@ void f()
 {
   char buff[5] = "hi";
 
-  wprintf(L"%hs", buff);
-}
-```
-
- The following sample code uses safe string manipulation function `wprintf_s` to correct this warning:
-
-```cpp
-#include <stdio.h>
-
-void f()
-{
-  char buff[5] = "hi";
-
+  // Use %hs format specifier so wprintf_s will interpret the argument correctly as a character string
   wprintf_s(L"%hs", buff);
 }
 ```

--- a/docs/code-quality/c6504.md
+++ b/docs/code-quality/c6504.md
@@ -16,10 +16,9 @@ ms.workload:
 # C6504
 warning C6504: invalid annotation: property may only be used on values of pointer, pointer-to-member, or array type
 
- This warning indicates the use of a property on an incompatible data type. For more information about data types supported by properties, see [Annotation Properties](using-sal-annotations-to-reduce-c-cpp-code-defects.md).
+ This warning indicates the use of a pointer specific sal annotation on a non-pointer data type. For more information about what data types are supported by properties, see [Annotation Properties].
 
 ## Example
- The following code generates this warning because the `_Null_` property cannot be used on the reference data type.
 
 ```cpp
 #include<sal.h>
@@ -30,13 +29,20 @@ public:
     //  members
 };
 
-void f(_Pre_ _Null_ Point& pt)
+// Oops, according to this annotation, pt may be null which does not make sense for a reference types
+void f(_Pre_ _Maybenull_ Point& pt)
+{
+    // code ...
+}
+
+// Oops, according to this annotation, pt cannot be null which does not make sense for a reference types
+void g(_Pre_ _Notnull_ Point& pt)
 {
     // code ...
 }
 ```
 
- To correct this warning, use the following code:
+ To correct this warning remove the annotation if if does not make sense.  You could also change to an annotation to be applicable to the type used, or change to type to match the annotation.
 
 ```cpp
 #include<sal.h>
@@ -47,10 +53,18 @@ public:
     //  members
 };
 
-void f(_Pre_ _Null_  Point* pt)
+// Changed to pointer type because it may be null
+void f(_Pre_ _Maybenull_  Point* pt)
+{
+    // code ...
+}
+
+// Removed annotation because it did not apply to reference types.
+void g(Point& pt)
 {
     // code ...
 }
 ```
 
- The defective code shown earlier also generates warning [C6516](../code-quality/c6516.md) because property conflicts resulted in an invalid annotation.
+
+[Annotation Properties]:using-sal-annotations-to-reduce-c-cpp-code-defects.md

--- a/docs/code-quality/c6504.md
+++ b/docs/code-quality/c6504.md
@@ -42,7 +42,7 @@ void g(_Pre_ _Notnull_ Point& pt)
 }
 ```
 
- To correct this warning remove the annotation if if does not make sense.  You could also change to an annotation to be applicable to the type used, or change to type to match the annotation.
+ To correct this warning remove the annotation if it does not make sense.  You could also change to an annotation to be applicable to the type used, or change to type to match the annotation.
 
 ```cpp
 #include<sal.h>

--- a/docs/code-quality/demo-sample.md
+++ b/docs/code-quality/demo-sample.md
@@ -58,27 +58,21 @@ The procedures also provide the code for the header and *.cpp* files for the sta
 
 4. Copy the following code and paste it into the *Bug.h* file in the editor.
 
-    ```cpp
-    #pragma once
-    
-    #include <windows.h>
+```cpp
+#pragma once
 
-    //
-    //These 3 functions are consumed by the sample
-    //  but are not defined. This project cannot be linked!
-    //
+#include <windows.h>
 
-    bool CheckDomain( LPCSTR );
-    HRESULT ReadUserAccount();
+// These functions are consumed by the sample
+// but are not defined. This project cannot be linked!
+bool CheckDomain(LPCTSTR);
+HRESULT ReadUserAccount();
 
-    //
-    //These constants define the common sizes of the
-    //  user account information throughout the program
-    //
-
-    const int USER_ACCOUNT_LEN = 256;
-    const int ACCOUNT_DOMAIN_LEN = 128;
-    ```
+// These constants define the common sizes of the
+// user account information throughout the program
+const int USER_ACCOUNT_LEN = 256;
+const int ACCOUNT_DOMAIN_LEN = 128;
+```
 
 5. In Solution Explorer, right-click **Source Files**, point to **New**, and then click **New Item**.
 
@@ -88,63 +82,61 @@ The procedures also provide the code for the header and *.cpp* files for the sta
 
 8. Copy the following code and paste it into the *Bug.cpp* file in the editor.
 
-    ```cpp
-    #include <stdlib.h>
-    #include "Bug.h"
+```cpp
+#include "Bug.h"
 
-    // the user account
-    TCHAR g_userAccount[USER_ACCOUNT_LEN] = "";
-    int len = 0;
+// the user account
+TCHAR g_userAccount[USER_ACCOUNT_LEN] = {};
+int len = 0;
 
-    bool ProcessDomain()
+bool ProcessDomain()
+{
+    TCHAR* domain = new TCHAR[ACCOUNT_DOMAIN_LEN];
+    // ReadUserAccount gets a 'domain\user' input from
+    //the user into the global 'g_userAccount'
+    if (ReadUserAccount())
     {
-        TCHAR* domain = new TCHAR[ACCOUNT_DOMAIN_LEN];
-        // ReadUserAccount gets a 'domain\user' input from
-        //the user into the global 'g_userAccount'
-        if (ReadUserAccount() )
+        // Copies part of the string prior to the '\'
+        // character onto the 'domain' buffer
+        for (len = 0; (len < ACCOUNT_DOMAIN_LEN) && (g_userAccount[len] != L'\0'); len++)
         {
-
-            // Copies part of the string prior to the '\'
-            // character onto the 'domain' buffer
-            for( len = 0 ; (len < ACCOUNT_DOMAIN_LEN) && (g_userAccount[len] != '\0') ; len++ )
+            if (g_userAccount[len] == '\\')
             {
-                if ( g_userAccount[len] == '\\' )
-                {
-                    // Stops copying on the domain and user separator ('\')
-                    break;
-                }
-                domain[len] = g_userAccount[len];
+                // Stops copying on the domain and user separator ('\')
+                break;
             }
-            if((len= ACCOUNT_DOMAIN_LEN) || (g_userAccount[len] != '\\'))
-            {
-                // '\' was not found. Invalid domain\user string.
-                delete [] domain;
-                return false;
-            }
-            else
-            {
-                domain[len]='\0';
-            }
-            // Process domain string
-            bool result = CheckDomain( domain );
-
-            delete[] domain;
-            return result;
+            domain[len] = g_userAccount[len];
         }
-        return false;
-    }
-
-    int path_dependent(int n)
-    {
-        int i;
-        int j;
-        if (n == 0)
-            i = 1;
+        if ((len = ACCOUNT_DOMAIN_LEN) || (g_userAccount[len] != '\\'))
+        {
+            // '\' was not found. Invalid domain\user string.
+            delete[] domain;
+            return false;
+        }
         else
-            j = 1;
-        return i+j;
+        {
+            domain[len] = '\0';
+        }
+        // Process domain string
+        bool result = CheckDomain(domain);
+
+        delete[] domain;
+        return result;
     }
-    ```
+    return false;
+}
+
+int path_dependent(int n)
+{
+    int i;
+    int j;
+    if (n == 0)
+        i = 1;
+    else
+        j = 1;
+    return i + j;
+}
+```
 
 9. Click the **File** menu, and then click **Save All**.
 
@@ -175,21 +167,20 @@ The procedures also provide the code for the header and *.cpp* files for the sta
 
 4. Copy the following code and paste it into the *annotations.h* file in the editor.
 
-    ```cpp
-    #pragma once
-    #include <sal.h>
+```cpp
+#pragma once
+#include <sal.h>
 
-    struct LinkedList
-    {
-        struct LinkedList* next;
-        int data;
-    };
+struct LinkedList
+{
+    struct LinkedList* next;
+    int data;
+};
 
-    typedef struct LinkedList LinkedList;
+typedef struct LinkedList LinkedList;
 
-    _Ret_maybenull_ LinkedList* AllocateNode();
-
-    ```
+_Ret_maybenull_ LinkedList* AllocateNode();
+```
 
 5. In Solution Explorer, right-click **Source Files**, point to **New**, and then click **New Item**.
 
@@ -199,31 +190,30 @@ The procedures also provide the code for the header and *.cpp* files for the sta
 
 8. Copy the following code and paste it into the *annotations.cpp* file in the editor.
 
-    ```cpp
-    #include <CodeAnalysis/SourceAnnotations.h>
-    #include <windows.h>
-    #include <stdlib.h>
-    #include "annotations.h"
+```cpp
+#include "annotations.h"
 
-    LinkedList* AddTail( LinkedList *node, int value )
+LinkedList* AddTail(LinkedList* node, int value)
+{
+    LinkedList* newNode = nullptr;
+
+    // finds the last node
+    while (node->next != nullptr)
     {
-        LinkedList *newNode = NULL;
-
-        // finds the last node
-        while ( node->next != NULL )
-        {
-            node = node->next;
-        }
-
-        // appends the new node
-        newNode = AllocateNode();
-        newNode->data = value;
-        newNode->next = 0;
-        node->next = newNode;
-
-        return newNode;
+        node = node->next;
     }
 
-    ```
+    // appends the new node
+    newNode = AllocateNode();
+    newNode->data = value;
+    newNode->next = 0;
+    node->next = newNode;
+
+    return newNode;
+}
+```
 
 9. Click the **File** menu, and then click **Save All**.
+
+
+The solution is now complete and should build without errors.

--- a/docs/code-quality/demo-sample.md
+++ b/docs/code-quality/demo-sample.md
@@ -16,7 +16,7 @@ ms.workload:
 
 This following procedures show you how to create the sample for [Walkthrough: Analyze C/C++ code for defects](../code-quality/walkthrough-analyzing-c-cpp-code-for-defects.md). The procedures create:
 
-- A Visual Studio solution named CppDemo.
+- A [!INCLUDEvsprvs] solution named CppDemo.
 
 - A static library project named CodeDefects.
 
@@ -26,19 +26,17 @@ The procedures also provide the code for the header and *.cpp* files for the sta
 
 ## Create the CppDemo solution and the CodeDefects project
 
-1. Click the **File** menu, point to **New**, and then click **New Project**.
+1. Open [!INCLUDEvsprvs] and select **Create a new project**
 
-2. In the **Project types** tree list, if C++ is not your default language in VS expand **Other Languages**.
+2. Change language filter to **C++**
 
-3. Expand **Visual C++**, and then click **General**.
+3. Select **Empty Project** and click **Next**
 
-4. In **Templates**, click **Empty Project**.
+4. In the **Project Name** text box, type **CodeDefects**
 
-5. In the **Name** text box, type **CodeDefects**.
+5. In the **Solution name** text box, type **CppDemo**
 
-6. Select the **Create directory for solution** check box.
-
-7. In the **Solution Name** text box, type **CppDemo**.
+6. Click **Create**
 
 ## Configure the CodeDefects project as a static library
 
@@ -46,9 +44,9 @@ The procedures also provide the code for the header and *.cpp* files for the sta
 
 2. Expand **Configuration Properties** and then click **General**.
 
-3. In the **General** list, select the text in the column next to **Target Extension**, and then type **.lib**.
+3. In the **General** list, change **Configuration Type**, to **Static library (.lib)**.
 
-4. In **Project Defaults**, click the column next to **Configuration Type**, and then click **Static Lib (.lib)**.
+4. In the **Advanced** list, change **Target File Extension** to **.lib**
 
 ## Add the header and source file to the CodeDefects project
 
@@ -58,9 +56,11 @@ The procedures also provide the code for the header and *.cpp* files for the sta
 
 3. In the **Name** box, type **Bug.h** and then click **Add**.
 
-4. Copy the following code and paste it into the *Bug.h* file in the Visual Studio editor.
+4. Copy the following code and paste it into the *Bug.h* file in the editor.
 
     ```cpp
+    #pragma once
+    
     #include <windows.h>
 
     //
@@ -86,7 +86,7 @@ The procedures also provide the code for the header and *.cpp* files for the sta
 
 7. In the **Name** box, type **Bug.cpp** and then click **Add**.
 
-8. Copy the following code and paste it into the *Bug.cpp* file in the Visual Studio editor.
+8. Copy the following code and paste it into the *Bug.cpp* file in the editor.
 
     ```cpp
     #include <stdlib.h>
@@ -106,7 +106,7 @@ The procedures also provide the code for the header and *.cpp* files for the sta
 
             // Copies part of the string prior to the '\'
             // character onto the 'domain' buffer
-            for( len = 0 ; (len < ACCOUNT_DOMAIN_LEN) && (g_userAccount[len] != '\0') ; len++  )
+            for( len = 0 ; (len < ACCOUNT_DOMAIN_LEN) && (g_userAccount[len] != '\0') ; len++ )
             {
                 if ( g_userAccount[len] == '\\' )
                 {
@@ -152,17 +152,18 @@ The procedures also provide the code for the header and *.cpp* files for the sta
 
 1. In Solution Explorer, click **CppDemo**, point to **Add**, and then click **New Project**.
 
-2. In the **Add New Project** dialog box, expand Visual C++, click **General**, and then click **Empty Project**.
+2. In the **Add a new project** dialog box, Change language filter to **C++** and select **Empty Project** then click **Next**.
 
-3. In the **Name** text box, type **Annotations**, and then click **Add**.
+3. In the **Project name** text box, type **Annotations**, and then click **Create**.
 
 4. In Solution Explorer, right-click **Annotations** and then click **Properties**.
 
 5. Expand **Configuration Properties** and then click **General**.
 
-6. In the **General** list, select the text in the column next to **Target Extension**, and then type **.lib**.
+6. In the **General** list, change **Configuration Type**, to and then click **Static library (.lib)**.
 
-7. In **Project Defaults**, click the column next to **Configuration Type**, and then click **Static Lib (.lib)**.
+7. In the **Advanced** list, select the text in the column next to **Target File extension**, and then type **.lib**.
+
 
 ## Add the header file and source file to the Annotations project
 
@@ -172,10 +173,11 @@ The procedures also provide the code for the header and *.cpp* files for the sta
 
 3. In the **Name** box, type **annotations.h** and then click **Add**.
 
-4. Copy the following code and paste it into the *annotations.h* file in the Visual Studio editor.
+4. Copy the following code and paste it into the *annotations.h* file in the editor.
 
     ```cpp
-    #include <CodeAnalysis/SourceAnnotations.h>
+    #pragma once
+    #include <sal.h>
 
     struct LinkedList
     {
@@ -185,7 +187,7 @@ The procedures also provide the code for the header and *.cpp* files for the sta
 
     typedef struct LinkedList LinkedList;
 
-    [returnvalue:SA_Post( Null=SA_Maybe )] LinkedList* AllocateNode();
+    _Ret_maybenull_ LinkedList* AllocateNode();
 
     ```
 
@@ -195,7 +197,7 @@ The procedures also provide the code for the header and *.cpp* files for the sta
 
 7. In the **Name** box, type **annotations.cpp** and then click **Add**.
 
-8. Copy the following code and paste it into the *annotations.cpp* file in the Visual Studio editor.
+8. Copy the following code and paste it into the *annotations.cpp* file in the editor.
 
     ```cpp
     #include <CodeAnalysis/SourceAnnotations.h>

--- a/docs/code-quality/demo-sample.md
+++ b/docs/code-quality/demo-sample.md
@@ -195,8 +195,6 @@ _Ret_maybenull_ LinkedList* AllocateNode();
 
 LinkedList* AddTail(LinkedList* node, int value)
 {
-    LinkedList* newNode = nullptr;
-
     // finds the last node
     while (node->next != nullptr)
     {
@@ -204,7 +202,7 @@ LinkedList* AddTail(LinkedList* node, int value)
     }
 
     // appends the new node
-    newNode = AllocateNode();
+    LinkedList* newNode = AllocateNode();
     newNode->data = value;
     newNode->next = 0;
     node->next = newNode;

--- a/docs/code-quality/walkthrough-analyzing-c-cpp-code-for-defects.md
+++ b/docs/code-quality/walkthrough-analyzing-c-cpp-code-for-defects.md
@@ -161,7 +161,7 @@ This walkthrough demonstrates how to analyze C/C++ code for potential code defec
 
 5. Rebuild Annotations project.
 
-     The project builds without any warnings or errors.
+     The project now builds without any warnings or errors.
 
 ## See also
 

--- a/docs/code-quality/walkthrough-analyzing-c-cpp-code-for-defects.md
+++ b/docs/code-quality/walkthrough-analyzing-c-cpp-code-for-defects.md
@@ -61,9 +61,9 @@ This walkthrough demonstrates how to analyze C/C++ code for potential code defec
 
      warning C6230: Implicit cast between semantically different types: using HRESULT in a Boolean context.
 
-     The code editor displays the line that caused the warning in the function `bool ProcessDomain()`. This warning indicates that a HRESULT is being used in an 'if' statement where a Boolean result is expected.
+     The code editor displays the line that caused the warning in the function `bool ProcessDomain()`. This warning indicates that a `HRESULT` is being used in an 'if' statement where a Boolean result is expected.  This is typically a mistake becuase when the `S_OK` HRESULT is returned from it function is indicates success, but when converted into a boolean value it evaluates to `false`.
 
-3. Correct this warning by using the SUCCEEDED macro. Your code should resemble the following code:
+3. Correct this warning by using the `SUCCEEDED` macro, which converts to `true` when a `HRESULT` return value indicates success. Your code should resemble the following code:
 
    ```cpp
    if (SUCCEEDED (ReadUserAccount()) )
@@ -122,11 +122,11 @@ This walkthrough demonstrates how to analyze C/C++ code for potential code defec
 8. To correct this warning, use an 'if' statement to test the return value. Your code should resemble the following code:
 
    ```cpp
-   if (NULL != newNode)
+   if (nullptr != newNode)
    {
-   newNode->data = value;
-   newNode->next = 0;
-   node->next = newNode;
+       newNode->data = value;
+       newNode->next = 0;
+       node->next = newNode;
    }
    ```
 
@@ -136,14 +136,10 @@ This walkthrough demonstrates how to analyze C/C++ code for potential code defec
 
 ### To use source code annotation
 
-1. Annotate formal parameters and return value of the function `AddTail` by using the Pre and Post conditions as shown in this example:
+1. Annotate formal parameters and return value of the function `AddTail` to indicate the pointer values may be null:
 
    ```cpp
-   [returnvalue:SA_Post (Null=SA_Maybe)] LinkedList* AddTail
-   (
-   [SA_Pre(Null=SA_Maybe)] LinkedList* node,
-   int value
-   )
+   _Ret_maybenull_ LinkedList* AddTail(_Maybenull_ LinkedList* node, int value)
    ```
 
 2. Rebuild Annotations project.
@@ -154,15 +150,12 @@ This walkthrough demonstrates how to analyze C/C++ code for potential code defec
 
      This warning indicates that the node passed into the function might be null, and indicates the line number where the warning was raised.
 
-4. To correct this warning, use an 'if' statement to test the return value. Your code should resemble the following code:
+4. To correct this warning, use an 'if' statement at the begining of the function to test the passed in value. Your code should resemble the following code:
 
    ```cpp
-   . . .
-   LinkedList *newNode = NULL;
-   if (NULL == node)
+   if (nullptr == node)
    {
-        return NULL;
-        . . .
+        return nullptr;
    }
    ```
 


### PR DESCRIPTION
Update a few of the warning descriptions that were requested internally.  Tried to rephrase the descriptions to make them more useful to non-experts and improve the examples.

Also updated the demo project description to match VS2019 and better reflect the SAL best practices for annotations.
