### PR TITLE
Comment out template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,3 +1,5 @@
+
+
 <!--
 Before creating your pull request, please check your content against these quality criteria:
 

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,5 +1,4 @@
-(You can replace all of this text with your description.)
-
+<!--
 Before creating your pull request, please check your content against these quality criteria:
 
 - Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
@@ -9,3 +8,4 @@ Before creating your pull request, please check your content against these quali
 - Should this page be linked to from other pages or Microsoft web sites?
 
 For more information about creating content for docs.microsoft.com, see the contributor guide at https://docs.microsoft.com/contribute/.
+-->


### PR DESCRIPTION
This change makes it so that people can simply write their description above the explanatory text and leave it in the description. It will be hidden from the PR page but still visible when editing the description.

See [this PR](https://github.com/carlin-q-scott/visualstudio-docs/pull/3) for an example of how it works.