### PR TITLE
Update memory-usage.md

### DIFF
--- a/docs/profiling/memory-usage.md
+++ b/docs/profiling/memory-usage.md
@@ -113,9 +113,9 @@ To analyze memory usage, click one of the links that opens up a detailed report 
 
  The **Paths to Root** tree in the bottom pane displays the objects that reference the type selected in the upper pane. The .NET Framework garbage collector cleans up the memory for an object only when the last type that references it has been released.
 
- The **Referenced Types** tree displays the references that are held by the type selected in the upper pane.
+ The **Referenced Objects** tree displays the references that are held by the type selected in the upper pane.
 
- ![Managed referenced types report view](../profiling/media/dbgdiag_mem_managedtypesreport_referencedtypes.png "DBGDIAG_MEM_ManagedTypesReport_ReferencedTypes")
+ ![Managed referenced objects report view](../profiling/media/dbgdiag_mem_managedtypesreport_referencedtypes.png "DBGDIAG_MEM_ManagedTypesReport_ReferencedTypes")
 
  To display the instances of a selected type in the upper pane, choose the ![Instance icon](../profiling/media/dbgdiag_mem_instanceicon.png "DBGDIAG_MEM_InstanceIcon") icon.
 


### PR DESCRIPTION
Replaced "Referenced Types" with "Referenced Objects" in order to match the name of the tab pane in the screenshot and avoid confusion.