### PR TITLE
Update container-launch-settings.md

### DIFF
--- a/docs/containers/container-launch-settings.md
+++ b/docs/containers/container-launch-settings.md
@@ -47,7 +47,7 @@ The commandName setting identifies that this section applies to Container Tools.
 |Setting name|Version|Example|Description|
 |------------|-------|-------|---------------|
 |launchBrowser|Visual Studio 2017|"launchBrowser": true|Indicates whether to launch the browser after successfully launching the project.|
-|launchUrl|Visual Studio 2017|"launchUrl": "\<scheme>://\<serviceHost>:\<servicePort>"|This URL is used when launching the browser.  Supported replacement tokens for this string are:<br>   \<scheme> - Replaced with either "http" or "https" depending on whether SSL is used.<br>   \<serviceHost> - Usually replaced with "localhost". When targeting Windows containers on Windows 10 RS3 or older, though, it is replaced with the container's IP.<br>   \<servicePort> - Usually replaced with either sslPort or httpPort, depending on whether SSL is used.  When targeting Windows containers on Windows 10 RS3 or older, though, it is replaced with either "443" or "80", depending on whether SSL is used.|
+|launchUrl|Visual Studio 2017|"launchUrl": "{Scheme}://{ServiceHost}:{ServicePort}"|This URL is used when launching the browser.  Supported replacement tokens for this string are:<br>   {Scheme} - Replaced with either "http" or "https" depending on whether SSL is used.<br>   {ServiceHost} - Usually replaced with "localhost". When targeting Windows containers on Windows 10 RS3 or older, though, it is replaced with the container's IP.<br>   {ServicePort} - Usually replaced with either sslPort or httpPort, depending on whether SSL is used.  When targeting Windows containers on Windows 10 RS3 or older, though, it is replaced with either "443" or "80", depending on whether SSL is used.|
 
 ::: moniker-end
 
@@ -63,11 +63,11 @@ The commandName setting identifies that this section applies to Container Tools.
 | httpPort             | "httpPort": 24051                                     | This port on the host is mapped to the container's port 80 when launching the container.                                |
 |                      |                                                       | If unspecified, the value is taken from the iisSettings value.                                                          |
 | launchBrowser        | "launchBrowser": true                                 | Indicates whether to launch the browser after successfully launching the project.                                       |
-| launchUrl            | "launchUrl": "<scheme>://<serviceHost>:<servicePort>" | This URL is used when launching the browser. Supported replacement tokens for this string are:                          |
-|                      |                                                       | - <scheme> - Replaced with either "http" or "https" depending on whether SSL is used.                                   |
-|                      |                                                       | - <serviceHost> - Usually replaced with "localhost".                                                                    |
+| launchUrl            | "launchUrl": "{Scheme}://{ServiceHost}:{ServicePort}" | This URL is used when launching the browser. Supported replacement tokens for this string are:                          |
+|                      |                                                       | - {Scheme} - Replaced with either "http" or "https" depending on whether SSL is used.                                   |
+|                      |                                                       | - {ServiceHost} - Usually replaced with "localhost".                                                                    |
 |                      |                                                       | When targeting Windows containers on Windows 10 RS3 or older, though, it is replaced with the container's IP.           |
-|                      |                                                       | - <servicePort> - Usually replaced with either sslPort or httpPort, depending on whether SSL is used.                   |
+|                      |                                                       | - {ServicePort} - Usually replaced with either sslPort or httpPort, depending on whether SSL is used.                   |
 |                      |                                                       | When targeting Windows containers on Windows 10 RS3 or older, though, it is replaced with either "443" or "80",         |
 |                      |                                                       | depending on whether SSL is used.                                                                                       |
 | sslPort              | "sslPort": 44381                                      | This port on the host is mapped to the container's port 443 when launching the container.                               |


### PR DESCRIPTION
The documentation for the `launchUrl` settings were not rendering correctly. This may be because they were enclosed in chevrons ("<" and ">") -- I'm not sure. However, in VS2019, the `launchSettings.json` file has these contained within curly braces:
```
    "Docker": {
      "commandName": "Docker",
      "launchBrowser": true,
      "launchUrl": "{Scheme}://{ServiceHost}:{ServicePort}",
      "environmentVariables": {
        "ASPNETCORE_URLS": "https://+:443;http://+:80",
        "ASPNETCORE_HTTPS_PORT": "44391"
      },
      // etc.
```
I have changed this document so that the rendering of the substitutions appears to be correct, and I have corrected the casing of the substitutions to be how they appear with the `launchSettings.json` file.
