### PR TITLE
Add missing editorconfig setting value

### DIFF
--- a/docs/ide/editorconfig-language-conventions.md
+++ b/docs/ide/editorconfig-language-conventions.md
@@ -1552,7 +1552,7 @@ csharp_prefer_braces = true:silent
 | **Rule name** | csharp_prefer_braces |
 | **Rule ID** | IDE0011 |
 | **Applicable languages** | C# |
-| **Values** | `true` - Prefer curly braces even for one line of code<br /><br />`false` - Prefer no curly braces if allowed |
+| **Values** | `true` - Prefer curly braces even for one line of code<br /><br />`false` - Prefer no curly braces if allowed<br /><br />`when_multiline` - Prefer curly braces on multiple lines |
 | **Visual Studio default** | `true:silent` |
 
 Code examples:


### PR DESCRIPTION
The `csharp_prefer_braces` value `when_multiline` was introduced in 16.0 as per Roslyn IDE README https://github.com/dotnet/roslyn/blob/d0eda9f43bbc0edf044b0c97d1a4343eeebfdaae/docs/ide/README.md#-160-release-notes
