### PR TITLE
The 'data' variable isn't being used in the sample

### DIFF
--- a/docs/debugger/get-started-debugging-multithreaded-apps.md
+++ b/docs/debugger/get-started-debugging-multithreaded-apps.md
@@ -67,14 +67,14 @@ You'll first need a multithreaded application project. An example follows.
     public class ServerClass
     {
 
-        static int count = 0;
+        static int count = 0; //<-here
         // The method that will be called when the thread is started.
         public void InstanceMethod()
         {
             Console.WriteLine(
                 "ServerClass.InstanceMethod is running on another thread.");
 
-            int data = count++;
+            int data = count++; //<-here
             // Pause for a moment to provide a delay to make
             // threads more apparent.
             Thread.Sleep(3000);


### PR DESCRIPTION
The 'data' variable isn't being used in the sample.  Not sure if this needs to be removed or append it to the Console.WriteLine statements in InstanceMethod() method.

This isn't a code change, but highlighting variables not being used.  Either use them or remove as it could cause confusion for the reader.