### PR TITLE
Added missing line concatenation character

### DIFF
--- a/docs/install/command-line-parameter-examples.md
+++ b/docs/install/command-line-parameter-examples.md
@@ -88,7 +88,7 @@ For lists of the workloads and components that you can install by using the comm
 * Download the Visual Studio core editor (the most minimal Visual Studio configuration). Only include the English language pack:
 
   ```cmd
-   vs_community.exe --layout C:\VS
+   vs_community.exe --layout C:\VS ^
    --lang en-US ^
    --add Microsoft.VisualStudio.Workload.CoreEditor
   ```


### PR DESCRIPTION
The line concatenation character was missing in one code example, the first one under "Using --layout". This ment that the example wasn't working.