### PR TITLE
chore: Add GitHub Action for Markdownlint

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,0 +1,25 @@
+name: Markdownlint
+
+on:
+  push:
+    paths:
+      - "**/*.md"
+  pull_request:
+    paths:
+      - "**/*.md"
+
+jobs:
+  lint:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: 12.x
+    - name: Run Markdownlint
+      run: |
+        npm i -g markdownlint-cli
+        markdownlint "**/*.md"


### PR DESCRIPTION
This is the setup currently being used over on the dotent/docs repo to validate their Markdown content.
Note that this is currently failing https://github.com/nschonni/visualstudio-docs/runs/418742464?check_suite_focus=true#step:4:8