### PR TITLE
Updated create-custom-views-of-native-objects to include the way to install natvis files via VSIX 

### DIFF
--- a/docs/debugger/create-custom-views-of-native-objects.md
+++ b/docs/debugger/create-custom-views-of-native-objects.md
@@ -92,7 +92,7 @@ The Visual Studio debugger loads *.natvis* files in C++ projects automatically, 
 
 A VSIX package can install and register *.natvis* files. No matter where are they installed, all registered *.natvis* files are automatically picked up during debugging.
 
-1. Include the *.natvis* file in the VSIX package. For example in a project file:
+1. Include the *.natvis* file in the VSIX package. For example, for the following project file:
    ```xml
    <?xml version="1.0" encoding="utf-8"?>
    <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="14.0">

--- a/docs/debugger/create-custom-views-of-native-objects.md
+++ b/docs/debugger/create-custom-views-of-native-objects.md
@@ -88,6 +88,30 @@ The Visual Studio debugger loads *.natvis* files in C++ projects automatically, 
 >[!NOTE]
 >Natvis rules loaded from a *.pdb* apply only to the types in the modules that the *.pdb* refers to. For example, if *Module1.pdb* has a Natvis entry for a type named `Test`, it only applies to the `Test` class in *Module1.dll*. If another module also defines a class named `Test`, the *Module1.pdb* Natvis entry does not apply to it.
 
+**To install and register a *.natvis* file via a VSIX package:**
+
+A VSIX package can install and register *.natvis* files. No matter where are they installed, all registered *.natvis* files are automatically picked up during debugging.
+
+1. Include the *.natvis* file in the VSIX package. For example in a project file:
+   ```xml
+   <?xml version="1.0" encoding="utf-8"?>
+   <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="14.0">
+     <ItemGroup>
+       <VSIXSourceItem Include="Visualizer.natvis" />
+     </ItemGroup>
+   </Project>
+   ```
+
+2. Register the *.natvis* file in the *source.extension.vsixmanifest* file:
+   ```xml
+   <?xml version="1.0" encoding="utf-8"?>
+   <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
+     <Assets>
+       <Asset Type="NativeVisualizer" Path="Visualizer.natvis"  />
+     </Assets>
+   </PackageManifest>
+   ```
+
 ### <a name="BKMK_natvis_location"></a> Natvis file locations
 
 You can add *.natvis* files to your user directory or to a system directory, if you want them to apply to multiple projects.
@@ -98,19 +122,21 @@ The *.natvis* files are evaluated in the following order:
 
 2. Any *.natvis* files that are in a loaded C++ project or top-level solution. This group includes all loaded C++ projects, including class libraries, but not projects in other languages.
 
+3. Any *.natvis* files installed and registered via a VSIX package.
+
 ::: moniker range="vs-2017"
 
-3. The user-specific Natvis directory (for example, *%USERPROFILE%\Documents\Visual Studio 2017\Visualizers*).
+4. The user-specific Natvis directory (for example, *%USERPROFILE%\Documents\Visual Studio 2017\Visualizers*).
 
 ::: moniker-end
 
 ::: moniker range=">= vs-2019"
 
-3. The user-specific Natvis directory (for example, *%USERPROFILE%\Documents\Visual Studio 2019\Visualizers*).
+4. The user-specific Natvis directory (for example, *%USERPROFILE%\Documents\Visual Studio 2019\Visualizers*).
 
 ::: moniker-end
 
-4. The system-wide Natvis directory (*%VSINSTALLDIR%\Common7\Packages\Debugger\Visualizers*). This directory has the *.natvis* files that are installed with Visual Studio. If you have administrator permissions, you can add files to this directory.
+5. The system-wide Natvis directory (*%VSINSTALLDIR%\Common7\Packages\Debugger\Visualizers*). This directory has the *.natvis* files that are installed with Visual Studio. If you have administrator permissions, you can add files to this directory.
 
 ## Modify .natvis files while debugging
 


### PR DESCRIPTION
Updated create-custom-views-of-native-objects to include the VSIX manifest NativeVisualizer asset as a method to install a natvis file