### PR TITLE
Add link to recommended MSBuild Properties

### DIFF
--- a/docs/test/configure-unit-tests-by-using-a-dot-runsettings-file.md
+++ b/docs/test/configure-unit-tests-by-using-a-dot-runsettings-file.md
@@ -55,7 +55,7 @@ There are three ways of specifying a run settings file in Visual Studio 2019 ver
     ```xml
     <Project Sdk="Microsoft.NET.Sdk">
       <PropertyGroup>
-        <RunSettingsFilePath>$(SolutionDir)\example.runsettings</RunSettingsFilePath>
+        <RunSettingsFilePath>$(MSBuildProjectDirectory)\example.runsettings</RunSettingsFilePath>
       </PropertyGroup>
       ...
     </Project>

--- a/docs/test/configure-unit-tests-by-using-a-dot-runsettings-file.md
+++ b/docs/test/configure-unit-tests-by-using-a-dot-runsettings-file.md
@@ -44,10 +44,11 @@ The file appears on the Test menu, and you can select or deselect it. While sele
 
 There are three ways of specifying a run settings file in Visual Studio 2019 version 16.4 and later:
 
-- Add a build property to a project through either the project file or a Directory.Build.props file. The run settings file for a project is specified by the property **RunSettingsFilePath**. 
+- Add a build property to a project through either the project file or a Directory.Build.props file. The run settings file for a project is specified by the property **RunSettingsFilePath**.
 
     - Project-level run settings is currently supported in C#, VB, C++, and F# projects.
     - A file specified for a project overrides any other run settings file specified in the solution.
+    - [These MSBuild properties](https://docs.microsoft.com/en-us/visualstudio/msbuild/msbuild-reserved-and-well-known-properties?view=vs-2019) can be used to specify the path to the runsettings file. 
 
     Example of specifying a *.runsettings* file for a project:
     

--- a/docs/test/configure-unit-tests-by-using-a-dot-runsettings-file.md
+++ b/docs/test/configure-unit-tests-by-using-a-dot-runsettings-file.md
@@ -48,7 +48,7 @@ There are three ways of specifying a run settings file in Visual Studio 2019 ver
 
     - Project-level run settings is currently supported in C#, VB, C++, and F# projects.
     - A file specified for a project overrides any other run settings file specified in the solution.
-    - [These MSBuild properties](https://docs.microsoft.com/en-us/visualstudio/msbuild/msbuild-reserved-and-well-known-properties?view=vs-2019) can be used to specify the path to the runsettings file. 
+    - [These MSBuild properties](https://docs.microsoft.com/visualstudio/msbuild/msbuild-reserved-and-well-known-properties?view=vs-2019) can be used to specify the path to the runsettings file. 
 
     Example of specifying a *.runsettings* file for a project:
     


### PR DESCRIPTION
.`runsettings` File paths can be specified with an MSBuild property, but only the ones mentioned in the linked doc work in all cases.
