### PR TITLE
We don't GAC MSBuild assemblies

### DIFF
--- a/docs/msbuild/msbuild-inline-tasks.md
+++ b/docs/msbuild/msbuild-inline-tasks.md
@@ -44,7 +44,7 @@ MSBuild tasks are typically created by compiling a class that implements the <xr
 
 - The `TaskFactory` attribute names the class that implements the inline task factory.
 
-- The `AssemblyFile` attribute gives the location of the inline task factory. Alternatively, you can use the `AssemblyName` attribute to specify the fully qualified name of the inline task factory class, which is typically located in the global assembly cache (GAC).
+- The `AssemblyFile` attribute gives the location of the inline task factory. Alternatively, you can use the `AssemblyName` attribute to specify the fully qualified name of the inline task factory class, which is typically located in `$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll`.
 
 The remaining elements of the `DoNothing` task are empty and are provided to illustrate the order and structure of an inline task. A more robust example is presented later in this topic.
 


### PR DESCRIPTION
We shouldn't tell customers that MSBuild is in the GAC. They put it there anyway, and it causes problems.