### PR TITLE
Change quoting in TrimEnd example

### DIFF
--- a/docs/msbuild/msbuild-conditions.md
+++ b/docs/msbuild/msbuild-conditions.md
@@ -43,7 +43,7 @@ You can use string methods in conditions, as shown in the following example, in 
         <TargetFrameworks>net45;net48;netstandard2.1;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     </PropertyGroup>
 
-    <PropertyGroup Condition="'$(TargetFramework.TrimEnd('0123456789.'))' == 'net'">
+    <PropertyGroup Condition="'$(TargetFramework.TrimEnd(`0123456789.`))' == 'net'">
         <!-- Properties for .NET Framework -->
     </PropertyGroup>
 


### PR DESCRIPTION
Fixes #5110 by changing the inner quoting around the characters to be trimmed so that it doesn't conflict with the conditional equality quoting.

@ghogen