### PR TITLE
Check for Xamarin.Interactive existency during uninstall

### DIFF
--- a/mac/resources/uninstall-vsmac.sh
+++ b/mac/resources/uninstall-vsmac.sh
@@ -42,7 +42,9 @@ rm -rf ~/Library/Xamarin.Mac
 # Uninstall Workbooks and Inspector
 echo "Uninstalling Workbooks and Inspector..."
 
-sudo /Library/Frameworks/Xamarin.Interactive.framework/Versions/Current/uninstall
+if [ -f "/Library/Frameworks/Xamarin.Interactive.framework/Versions/Current/uninstall" ]; then
+    sudo /Library/Frameworks/Xamarin.Interactive.framework/Versions/Current/uninstall
+fi
 
 
 # Uninstall the Visual Studio for Mac Installer


### PR DESCRIPTION
The bug:
Run Uninstall script, while Xamarin.Interactive wasn't installed results in the script error message (while it still completes).

Implemented fix:
Check if it is installed before calling its uninstallation.

STR:
1. Install VSfM with Xamarin Workbooks unchecked
2. Run uninstall script

Actual Result:

script reports with:
```
Uninstalling Workbooks and Inspector...
sudo: /Library/Frameworks/Xamarin.Interactive.framework/Versions/Current/uninstall: command not found
```
Expected result:
Script passes without error message.