### PR TITLE
Update finding-memory-leaks-using-the-crt-library.md

### DIFF
--- a/docs/debugger/finding-memory-leaks-using-the-crt-library.md
+++ b/docs/debugger/finding-memory-leaks-using-the-crt-library.md
@@ -66,7 +66,7 @@ By default, `_CrtDumpMemoryLeaks` outputs the memory-leak report to the **Debug*
 You can use `_CrtSetReportMode` to redirect the report to another location, or back to the **Output** window as shown here:
 
 ```cpp
-_CrtSetReportMode( _CRT_ERROR, _CRTDBG_MODE_DEBUG );
+_CrtSetReportMode( _CRT_WARN, _CRTDBG_MODE_DEBUG );
 ```
 
 ## Interpret the memory-leak report


### PR DESCRIPTION
_CrtDumpMemoryLeaks sends a _CRT_WARN message, therefore _CRT_WARN must be redirected instead of _CRT_ERROR

Tested with this file:

```cpp

#include <crtdbg.h>

int
main()
{
	_CrtSetDbgFlag ( _CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF );
	_CrtSetReportMode(_CRT_WARN, _CRTDBG_MODE_FILE);
	_CrtSetReportFile(_CRT_WARN, _CRTDBG_FILE_STDOUT);
	int *p = (int *)_malloc_dbg(4, _NORMAL_BLOCK, __FILE__, __LINE__);
    
        return 0;
}
```

Compiled with
`cl file.cpp /MTd -Od -Zi /link -verbose:lib /debug`

When changing _CRT_WARN to _CRT_ERROR nothing is printed

<!--
Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for docs.microsoft.com, see the contributor guide at https://docs.microsoft.com/contribute/.
-->
