### PR TITLE
Change "802x86" to  "80x86"

### DIFF
--- a/docs/msbuild/msbuild-target-framework-and-target-platform.md
+++ b/docs/msbuild/msbuild-target-framework-and-target-platform.md
@@ -11,7 +11,7 @@ ms.workload:
 ---
 # MSBuild target framework and target platform
 
-A project can be built to run on a *target framework*, which is a particular version of the .NET Framework, and a *target platform*, which is a particular software architecture.  For example, you can target an application to run on the .NET Framework 2.0 on a 32-bit platform that is compatible with the 802x86 processor family ("x86"). The combination of target framework and target platform is known as the *target context*.
+A project can be built to run on a *target framework*, which is a particular version of the .NET Framework, and a *target platform*, which is a particular software architecture.  For example, you can target an application to run on the .NET Framework 2.0 on a 32-bit platform that is compatible with the 80x86 processor family ("x86"). The combination of target framework and target platform is known as the *target context*.
 
 > [!IMPORTANT]
 > This article shows the old way to specify a target framework. SDK-style projects enable different TargetFrameworks like netstandard. For more info, see [Target frameworks](/dotnet/standard/frameworks).


### PR DESCRIPTION
There is no such (intel / amd) processor family called "802x86".  It should read either "80386+" or "80x86".  This commit chooses the latter.
