### PR TITLE
Correct Typo: "802x86" becomes "80x86"

### DIFF
--- a/docs/msbuild/msbuild-multitargeting-overview.md
+++ b/docs/msbuild/msbuild-multitargeting-overview.md
@@ -30,7 +30,7 @@ By using MSBuild, you can compile an application to run on any one of several ve
 
 ## Target framework and platform
 
- A *target framework* is the version of the .NET Framework that a project is built to run on, and a *target platform* is the system platform that the project is built to run on.  For example, you might want to target a .NET Framework 2.0 application to run on a 32-bit platform that is compatible with the 802x86 processor family (x86). The combination of target framework and target platform is known as the *target context*. For more information, see [Target framework and target platform](../msbuild/msbuild-target-framework-and-target-platform.md).
+ A *target framework* is the version of the .NET Framework that a project is built to run on, and a *target platform* is the system platform that the project is built to run on.  For example, you might want to target a .NET Framework 2.0 application to run on a 32-bit platform that is compatible with the 80x86 processor family (x86). The combination of target framework and target platform is known as the *target context*. For more information, see [Target framework and target platform](../msbuild/msbuild-target-framework-and-target-platform.md).
 
 ## Toolset (ToolsVersion)
 


### PR DESCRIPTION
So weird that this error propagated to ~~several different~~  another page.