### PR TITLE
CA2241: Added try_determine_additional_string_formatting_methods_auto…

### DIFF
--- a/docs/code-quality/ca2241.md
+++ b/docs/code-quality/ca2241.md
@@ -68,7 +68,7 @@ Examples:
 
 You can configure this option for just this rule, for all rules, or for all rules in this category (Usage). For more information, see [Configure FxCop analyzers](configure-fxcop-analyzers.md).
 
-Instead of a specifying a long list of additional string formatting methods, you can configure the analyzer to try and determine this automatically. By default, this option is disabled.
+Alternatively, instead of specifying an explicit list of additional string formatting methods, you can configure the analyzer to try and determine this automatically. By default, this option is disabled.
 If enabled, then any method that has a `string format` parameter followed by a `params object[]` parameter is considered a string formatting method.
 
 ```ini

--- a/docs/code-quality/ca2241.md
+++ b/docs/code-quality/ca2241.md
@@ -68,8 +68,8 @@ Examples:
 
 You can configure this option for just this rule, for all rules, or for all rules in this category (Usage). For more information, see [Configure FxCop analyzers](configure-fxcop-analyzers.md).
 
-Instead of a specifying a long list of additional string formatting methods, you can configure the analyzer to try and determine this automatically. By default this is disabled.
-If enabled then any method that has a 'string format' parameter followed by a 'params object[]' parameter is considered a string formatting method.
+Instead of a specifying a long list of additional string formatting methods, you can configure the analyzer to try and determine this automatically. By default, this option is disabled.
+If enabled, then any method that has a `string format` parameter followed by a `params object[]` parameter is considered a string formatting method.
 
 ```ini
 dotnet_code_quality.CA2241.try_determine_additional_string_formatting_methods_automatically = true

--- a/docs/code-quality/ca2241.md
+++ b/docs/code-quality/ca2241.md
@@ -1,6 +1,6 @@
 ---
 title: 'CA2241: Provide correct arguments to formatting methods'
-ms.date: 11/04/2016
+ms.date: 05/28/2020
 ms.topic: reference
 f1_keywords:
 - CA2241
@@ -10,7 +10,6 @@ helpviewer_keywords:
 - ProvideCorrectArgumentsToFormattingMethods
 - CA2241
 ms.assetid: 83639bc4-4c91-4a07-a40e-dc5e49a84494
-author: mikejo5000
 ms.author: mikejo
 manager: jillfra
 dev_langs:
@@ -67,6 +66,13 @@ Examples:
 |`dotnet_code_quality.CA2241.additional_string_formatting_methods = NS1.MyType1.MyFormat1(ParamType)|NS2.MyType2.MyFormat2(ParamType)` | Matches specific methods 'MyFormat1' and 'MyFormat2' with respective fully qualified signature
 
 You can configure this option for just this rule, for all rules, or for all rules in this category (Usage). For more information, see [Configure FxCop analyzers](configure-fxcop-analyzers.md).
+
+Instead of a specifying a long list of additional string formatting methods, you can configure the analyzer to try and determine this automatically. By default this is disabled.
+If enabled then any method that has a 'string format' parameter followed by a 'params object[]' parameter is considered a string formatting method.
+
+```ini
+dotnet_code_quality.CA2241.try_determine_additional_string_formatting_methods_automatically = true
+```
 
 ## Example
 The following example shows two violations of the rule.

--- a/docs/code-quality/ca2241.md
+++ b/docs/code-quality/ca2241.md
@@ -68,8 +68,7 @@ Examples:
 
 You can configure this option for just this rule, for all rules, or for all rules in this category (Usage). For more information, see [Configure FxCop analyzers](configure-fxcop-analyzers.md).
 
-Alternatively, instead of specifying an explicit list of additional string formatting methods, you can configure the analyzer to try and determine this automatically. By default, this option is disabled.
-If enabled, then any method that has a `string format` parameter followed by a `params object[]` parameter is considered a string formatting method.
+Alternatively, instead of specifying an explicit list of additional string formatting methods, you can configure the analyzer to automatically attempt to determine the string formatting method. By default, this option is disabled. If the option is enabled, any method that has a `string format` parameter followed by a `params object[]` parameter is considered a string formatting method:
 
 ```ini
 dotnet_code_quality.CA2241.try_determine_additional_string_formatting_methods_automatically = true

--- a/docs/code-quality/ca2241.md
+++ b/docs/code-quality/ca2241.md
@@ -10,6 +10,7 @@ helpviewer_keywords:
 - ProvideCorrectArgumentsToFormattingMethods
 - CA2241
 ms.assetid: 83639bc4-4c91-4a07-a40e-dc5e49a84494
+author: mikejo5000
 ms.author: mikejo
 manager: jillfra
 dev_langs:


### PR DESCRIPTION
The rule was recently updated with an additional configuration option.
https://github.com/dotnet/roslyn-analyzers/pull/3653
Updated the documentation to include this option.