### PR TITLE
Update how-to-use-rule-based-ui-context-for-visual-studio-extensions.md

### DIFF
--- a/docs/extensibility/how-to-use-rule-based-ui-context-for-visual-studio-extensions.md
+++ b/docs/extensibility/how-to-use-rule-based-ui-context-for-visual-studio-extensions.md
@@ -99,7 +99,7 @@ Rule-based UI Context can be used in various ways:
     name: "Test auto load",
     expression: "(SingleProject | MultipleProjects) & DotConfig",
     termNames: new[] { "SingleProject", "MultipleProjects","DotConfig" },
-    termValues: new[] { VSConstants.UICONTEXT_SolutionHasSingleProject_string , VSConstants.UICONTEXT_SolutionHasMultipleProjects_string , "HierSingleSelectionName:.config$" })]
+    termValues: new[] { VSConstants.UICONTEXT.SolutionHasSingleProject_string , VSConstants.UICONTEXT.SolutionHasMultipleProjects_string , "HierSingleSelectionName:.config$" })]
 ```
 
  Now the expression references three terms. The first two terms, "SingleProject" and "MultipleProjects", refer to other well-known UI Contexts (by their GUIDs). The third term, "DotConfig" is the rule-based UI Context defined earlier in this article.


### PR DESCRIPTION
Fix VSConstants.UICONTEXT_SolutionHasSingleProject_string to VSConstants.UICONTEXT.SolutionHasSingleProject_string (dot after UICONTEXT).



