### PR TITLE
Add the last 3 releases of Python 2.7

### DIFF
--- a/docs/python/debugging-symbols-for-mixed-mode-c-cpp-python.md
+++ b/docs/python/debugging-symbols-for-mixed-mode-c-cpp-python.md
@@ -70,6 +70,9 @@ If you downloaded symbols separately, follow the steps below to make Visual Stud
 | 3.3.2 | [32-bit](https://www.python.org/ftp/python/3.3.2/python-3.3.2-pdb.zip) - [64-bit](https://www.python.org/ftp/python/3.3.2/python-3.3.2.amd64-pdb.zip) |
 | 3.3.1 | [32-bit](https://www.python.org/ftp/python/3.3.1/python-3.3.1-pdb.zip) - [64-bit](https://www.python.org/ftp/python/3.3.1/python-3.3.1.amd64-pdb.zip) |
 | 3.3.0 | [32-bit](https://www.python.org/ftp/python/3.3.0/python-3.3.0-pdb.zip) - [64-bit](https://www.python.org/ftp/python/3.3.0/python-3.3.0.amd64-pdb.zip) |
+| 2.7.18 | [32-bit](https://www.python.org/ftp/python/2.7.18/python-2.7.18-pdb.zip) - [64-bit](https://www.python.org/ftp/python/2.7.18/python-2.7.18.amd64-pdb.zip) |
+| 2.7.17 | [32-bit](https://www.python.org/ftp/python/2.7.17/python-2.7.17-pdb.zip) - [64-bit](https://www.python.org/ftp/python/2.7.17/python-2.7.17.amd64-pdb.zip) |
+| 2.7.16 | [32-bit](https://www.python.org/ftp/python/2.7.16/python-2.7.16-pdb.zip) - [64-bit](https://www.python.org/ftp/python/2.7.16/python-2.7.16.amd64-pdb.zip) |
 | 2.7.15 | [32-bit](https://www.python.org/ftp/python/2.7.15/python-2.7.15-pdb.zip) - [64-bit](https://www.python.org/ftp/python/2.7.15/python-2.7.15.amd64-pdb.zip) |
 | 2.7.14 | [32-bit](https://www.python.org/ftp/python/2.7.14/python-2.7.14-pdb.zip) - [64-bit](https://www.python.org/ftp/python/2.7.14/python-2.7.14.amd64-pdb.zip) |
 | 2.7.13 | [32-bit](https://www.python.org/ftp/python/2.7.13/python-2.7.13-pdb.zip) - [64-bit](https://www.python.org/ftp/python/2.7.13/python-2.7.13.amd64-pdb.zip) |


### PR DESCRIPTION
The page only included links through 2.7.15, but the last release of 2.7 is actually 2.7.18. The format of the links is the same as the previous versions, so I added them. To test, I clicked through and verified that each of the updated links is valid.
