### PR TITLE
Adjust article

### DIFF
--- a/docs/extensibility/adding-a-menu-to-the-visual-studio-menu-bar.md
+++ b/docs/extensibility/adding-a-menu-to-the-visual-studio-menu-bar.md
@@ -20,7 +20,7 @@ Before adding a new menu to the Visual Studio menu bar, consider whether your co
 
 Menus are declared in the *.vsct* file of the project. For more information about menus and *.vsct* files, see [Commands, menus, and toolbars](../extensibility/internals/commands-menus-and-toolbars.md).
 
-By completing this walkthrough, you can create a menu named **TestMenu** that contains one command.
+By completing this walkthrough, you can create a menu named **Test Menu** that contains one command.
 
 > [!NOTE]
 > In VS 2019, top level menus contributed by extensions are placed under the **Extensions** menu.
@@ -33,7 +33,17 @@ Starting in Visual Studio 2015, you do not install the Visual Studio SDK from th
 
 1. Create a VSIX project named `TopLevelMenu`. You can find the VSIX project template in the **New Project** dialog by searching for "vsix".  For more information, see [Create an extension with a menu command](../extensibility/creating-an-extension-with-a-menu-command.md).
 
+::: moniker range="vs-2017"
+
 2. When the project opens, add a custom command item template named **TestCommand**. In the **Solution Explorer**, right-click the project node and select **Add** >  **New Item**. In the **Add New Item** dialog, go to **Visual C# / Extensibility** and select **Custom Command**. In the **Name** field at the bottom of the window, change the command file name to *TestCommand.cs*.
+
+::: moniker-end
+
+::: moniker range=">=vs-2019"
+
+2. When the project opens, add a custom command item template named **TestCommand**. In the **Solution Explorer**, right-click the project node and select **Add** >  **New Item**. In the **Add New Item** dialog, go to **Visual C# / Extensibility** and select **Command**. In the **Name** field at the bottom of the window, change the command file name to *TestCommand.cs*.
+
+::: moniker-end
 
 ## Create a menu on the IDE menu bar
 
@@ -41,13 +51,13 @@ Starting in Visual Studio 2015, you do not install the Visual Studio SDK from th
 
 1. In **Solution Explorer**, open *TestCommandPackage.vsct*.
 
-    At the end of the file, there is a \<Symbols> node that contains several \<GuidSymbol> nodes. In the node named guidTestCommandPackageCmdSet, add a new symbol, as follows:
+    At the end of the file, there is a `<Symbols>` node that contains several `<GuidSymbol>` nodes. In the node named `guidTestCommandPackageCmdSet`, add a new symbol, as follows:
 
    ```xml
    <IDSymbol name="TopLevelMenu" value="0x1021"/>
    ```
 
-2. Create an empty \<Menus> node in the \<Commands> node, just before \<Groups>. In the \<Menus> node, add a \<Menu> node, as follows:
+2. Create an empty `<Menus>` node in the `<Commands>` node, just before `<Groups>`. In the `<Menus>` node, add a `<Menu>` node, as follows:
 
    ```xml
    <Menus>
@@ -55,8 +65,7 @@ Starting in Visual Studio 2015, you do not install the Visual Studio SDK from th
            <Parent guid="guidSHLMainMenu"
                    id="IDG_VS_MM_TOOLSADDINS" />
            <Strings>
-             <ButtonText>TestMenu</ButtonText>
-             <CommandName>TestMenu</CommandName>
+             <ButtonText>Test Menu</ButtonText>
            </Strings>
        </Menu>
    </Menus>
@@ -66,9 +75,9 @@ Starting in Visual Studio 2015, you do not install the Visual Studio SDK from th
 
     The `guid` and `id` values of the parent position the menu on the section of the Visual Studio menu bar that contains the Tools and Add-ins menus.
 
-    The value of the `CommandName` string specifies that the text should appear in the menu item.
+    The `<ButtonText>` element specifies that the text should appear in the menu item.
 
-3. In the \<Groups> section, find the \<Group> and change the \<Parent> element to point to the menu we just added:
+3. In the `<Groups>` section, find the `<Group>` and change the `<Parent>` element to point to the menu we just added:
 
    ```xml
    <Groups>
@@ -86,13 +95,13 @@ Starting in Visual Studio 2015, you do not install the Visual Studio SDK from th
 
 1. In **Solution Explorer**, open *TopLevelMenuPackage.vsct*.
 
-    At the end of the file, there is a \<Symbols> node that contains several \<GuidSymbol> nodes. In the node named guidTopLevelMenuPackageCmdSet, add a new symbol, as follows:
+    At the end of the file, there is a `<Symbols>` node that contains several `<GuidSymbol>` nodes. In the node named `guidTopLevelMenuPackageCmdSet`, add a new symbol, as follows:
 
    ```xml
    <IDSymbol name="TopLevelMenu" value="0x1021"/>
    ```
 
-2. Create an empty \<Menus> node in the \<Commands> node, just before \<Groups>. In the \<Menus> node, add a \<Menu> node, as follows:
+2. Create an empty `<Menus>` node in the `<Commands>` node, just before `<Groups>`. In the `<Menus>` node, add a `<Menu>` node, as follows:
 
    ```xml
    <Menus>
@@ -100,8 +109,7 @@ Starting in Visual Studio 2015, you do not install the Visual Studio SDK from th
            <Parent guid="guidSHLMainMenu"
                    id="IDG_VS_MM_TOOLSADDINS" />
            <Strings>
-             <ButtonText>TestMenu</ButtonText>
-             <CommandName>TestMenu</CommandName>
+             <ButtonText>Test Menu</ButtonText>
            </Strings>
        </Menu>
    </Menus>
@@ -111,9 +119,9 @@ Starting in Visual Studio 2015, you do not install the Visual Studio SDK from th
 
     The `guid` and `id` values of the parent position the menu on the section of the Visual Studio menu bar that contains the Tools and Add-ins menus.
 
-    The value of the `CommandName` string specifies that the text should appear in the menu item.
+    The `<ButtonText>` element specifies that the text should appear in the menu item.
 
-3. In the \<Groups> section, find the \<Group> and change the \<Parent> element to point to the menu we just added:
+3. In the `<Groups>` section, find the `<Group>` and change the `<Parent>` element to point to the menu we just added:
 
    ```xml
    <Groups>
@@ -127,7 +135,9 @@ Starting in Visual Studio 2015, you do not install the Visual Studio SDK from th
 
 ::: moniker-end
 
-4. Find the `Buttons` section. Notice that the [!INCLUDE[vsprvs](../code-quality/includes/vsprvs_md.md)] Package template has generated a `Button` element that has its parent set to `MyMenuGroup`. As a result, this command appears on your menu.
+4. In the `<Buttons>` section, find the `<Button>` node. Then, in the `<Strings>` node, change the `<ButtonText>` element to `Test Command`.
+
+    Notice that the [!INCLUDE[vsprvs](../code-quality/includes/vsprvs_md.md)] Package template has generated a `Button` element that has its parent set to `MyMenuGroup`. As a result, this command appears on your menu.
 
 ## Build and test the extension
 
@@ -135,19 +145,19 @@ Starting in Visual Studio 2015, you do not install the Visual Studio SDK from th
 
 ::: moniker range="vs-2017"
 
-2. The menu bar in the experimental instance should contain a **TestMenu** menu.
+2. The menu bar in the experimental instance should contain a **Test Menu** menu.
 
 ::: moniker-end
 
 ::: moniker range=">=vs-2019"
 
-2. The **Extensions** menu in the experimental instance should contain a **TestMenu** menu.
+2. The **Extensions** menu in the experimental instance should contain a **Test Menu** menu.
 
 ::: moniker-end
 
-3. On the **TestMenu** menu, click **Invoke Test Command**.
+3. On the **Test Menu** menu, click **Test Command**.
 
-     A message box should appear and display the message "TestCommand Package Inside TopLevelMenu.TestCommand.MenuItemCallback()".
+    A message box should appear and display the message "TestCommand Inside TopLevelMenu.TestCommand.MenuItemCallback()".
 
 ## See also
 


### PR DESCRIPTION
- Format inline code elements such as \<Node> to `<Node>`.

- Add moniker to the creation description of the  custom command item: In VS2019 this template named **Command**; in VS2017 named **Custom Command**.

- Remove `<CommandName>` element: This field specifies the text that appears in the keyboard category in the **Commands** tab in the **Customize** dialog.

- Fix note about the text that appears in the menu item: Replace `CommandName` by `ButtonText`.

- Add step to change `Invoke TestCommand` to `Test Command`.
