### PR TITLE
Fix creating-an-extension-with-a-menu-command.md

### DIFF
--- a/docs/extensibility/creating-an-extension-with-a-menu-command.md
+++ b/docs/extensibility/creating-an-extension-with-a-menu-command.md
@@ -26,7 +26,17 @@ Starting in Visual Studio 2015, you do not install the Visual Studio SDK from th
 
 1. Create a VSIX project named **FirstMenuCommand**. You can find the VSIX project template in the **New Project** dialog by searching for "vsix".
 
+::: moniker range="vs-2017"
+
 2. When the project opens, add a custom command item template named **FirstCommand**. In the **Solution Explorer**, right-click the project node and select **Add** > **New Item**. In the **Add New Item** dialog, go to **Visual C#** > **Extensibility** and select **Custom Command**. In the **Name** field at the bottom of the window, change the command file name to *FirstCommand.cs*.
+
+::: moniker-end
+
+::: moniker range=">=vs-2019"
+
+2. When the project opens, add a custom command item template named **FirstCommand**. In the **Solution Explorer**, right-click the project node and select **Add** > **New Item**. In the **Add New Item** dialog, go to **Visual C#** > **Extensibility** and select **Command**. In the **Name** field at the bottom of the window, change the command file name to *FirstCommand.cs*.
+
+::: moniker-end
 
 3. Build the project and start debugging.
 
@@ -44,7 +54,7 @@ Starting in Visual Studio 2015, you do not install the Visual Studio SDK from th
 
 ::: moniker-end
 
-Now go to the **Tools** menu in the experimental instance. You should see **Invoke FirstCommand** command. At this point, the command brings up a message box that says **FirstCommandPackage Inside FirstMenuCommand.FirstCommand.MenuItemCallback()**. We'll see how to actually start Notepad from this command in the next section.
+Now go to the **Tools** menu in the experimental instance. You should see **Invoke FirstCommand** command. At this point, the command brings up a message box that says **FirstCommand Inside FirstMenuCommand.FirstCommand.MenuItemCallback()**. We'll see how to actually start Notepad from this command in the next section.
 
 ## Change the menu command handler
 
@@ -71,11 +81,13 @@ Now let's update the command handler to start Notepad.
     }
     ```
 
-3. Remove the `MenuItemCallback` method and add a `StartNotepad` method, which will just start Notepad:
+3. Remove the `Execute` method and add a `StartNotepad` method, which will just start Notepad:
 
     ```csharp
     private void StartNotepad(object sender, EventArgs e)
     {
+        ThreadHelper.ThrowIfNotOnUIThread();
+
         Process proc = new Process();
         proc.StartInfo.FileName = "notepad.exe";
         proc.Start();
@@ -96,7 +108,7 @@ You can get to this script in one of two ways:
 
 2. From the command line, run the following:
 
-    ```xml
+    ```cmd
     <VSSDK installation>\VisualStudioIntegration\Tools\Bin\CreateExpInstance.exe /Reset /VSInstance=<version> /RootSuffix=Exp && PAUSE
 
     ```
@@ -107,7 +119,7 @@ Now that you have your tool extension running the way you want, it's time to thi
 
 You can find the *.vsix* file for this extension in the *FirstMenuCommand* bin directory. Specifically, assuming you have built the Release configuration, it will be in:
 
-*\<code directory>\FirstMenuCommand\FirstMenuCommand\bin\Release\ FirstMenuCommand.vsix*
+*\<code directory>\FirstMenuCommand\FirstMenuCommand\bin\Release\FirstMenuCommand.vsix*
 
 To install the extension, your friend needs to close all open instances of Visual Studio, then double-click the *.vsix* file, which brings up the **VSIX Installer**. The files are copied to the *%LocalAppData%\Microsoft\VisualStudio\<version>\Extensions* directory.
 


### PR DESCRIPTION
- Fix typos.

- Fix name of command callback function: current template of the custom command item adds handler named Execute.