### PR TITLE
Update managing-python-environments-in-visual-studio.md

### DIFF
--- a/docs/python/managing-python-environments-in-visual-studio.md
+++ b/docs/python/managing-python-environments-in-visual-studio.md
@@ -256,7 +256,7 @@ To correct an environment you wish to keep, first try using its installer's **Re
 To correct an environment that doesn't have a repair option, or to remove an invalid environment, use the following steps to modify the registry directly. Visual Studio automatically updates the **Python Environments** window when you make changes to the registry.
 
 1. Run *regedit.exe*.
-1. Navigate to **HKEY_LOCAL_MACHINE\SOFTWARE\Python**. For IronPython, look for **IronPython** instead.
+1. Navigate to **HKEY_LOCAL_MACHINE\SOFTWARE\Python** or **HKEY_CURRENT_USER\SOFTWARE\Python**. For IronPython, look for **IronPython** instead.
 1. Expand the node that matches the distribution, such as **Python Core** for CPython or **ContinuumAnalytics** for Anaconda. For IronPython, expand the version number node.
 1. Inspect the values under the **InstallPath** node:
 
@@ -264,7 +264,8 @@ To correct an environment that doesn't have a repair option, or to remove an inv
 
     - If the environment still exists on your computer, change the value of **ExecutablePath** to the correct location. Also correct the **(Default)** and **WindowedExecutablePath** values as necessary.
     - If the environment no longer exists on your computer and you want to remove it from the **Python Environments** window, delete the parent node of **InstallPath**, such as **3.6** in the image above.
-
+    - Invalid settings in **HKEY_CURRENT_USER\SOFTWARE\Python** overide the settings in **HKEY_LOCAL_MACHINE\SOFTWARE\Python**
+    
 ## See also
 
 - [Install Python interpreters](installing-python-interpreters.md)

--- a/docs/python/managing-python-environments-in-visual-studio.md
+++ b/docs/python/managing-python-environments-in-visual-studio.md
@@ -264,7 +264,7 @@ To correct an environment that doesn't have a repair option, or to remove an inv
 
     - If the environment still exists on your computer, change the value of **ExecutablePath** to the correct location. Also correct the **(Default)** and **WindowedExecutablePath** values as necessary.
     - If the environment no longer exists on your computer and you want to remove it from the **Python Environments** window, delete the parent node of **InstallPath**, such as **3.6** in the image above.
-    - Invalid settings in **HKEY_CURRENT_USER\SOFTWARE\Python** overide the settings in **HKEY_LOCAL_MACHINE\SOFTWARE\Python**
+    - Invalid settings in **HKEY_CURRENT_USER\SOFTWARE\Python** override the settings in **HKEY_LOCAL_MACHINE\SOFTWARE\Python**
     
 ## See also
 


### PR DESCRIPTION
Add HKEY_CURRENT_USER documentation.
Official documentation is missing HKEY_CURRENT_USER\SOFTWARE\Python can also exist.

If this is there it overrides what is stored under HKEY_LOCAL_MACHINE\SOFTWARE\Python and the broken python version will still show up even if fixed using the VS installer.

https://stackoverflow.com/questions/55361358/how-to-get-rid-of-broken-python-environments-in-visual-studio-2017
This site mentions this doc is missing the path, so I added it.