### PR TITLE
"double-click" fix update per PR 5711

### DIFF
--- a/docs/xml-tools/how-to-edit-xml-files.md
+++ b/docs/xml-tools/how-to-edit-xml-files.md
@@ -16,7 +16,7 @@ The XML editor is the new editor for XML files. It can be used on a stand-alone 
 > [!NOTE]
 > XHTML documents are handled by the HTML Editor.
 
-To edit an XML file, select and hold (or double-click) the file you want to edit.
+To edit an XML file, open the file you want to edit.
 
 ## Add a new XML file to a project
 


### PR DESCRIPTION
Replace "double-click" replacement text with "open" per PR https://github.com/MicrosoftDocs/visualstudio-docs/pull/5711

@ghogen Could you review and merge, if you approve the update?