### PR TITLE
Correct link text of links

### DIFF
--- a/docs/ide/managing-application-resources-dotnet.md
+++ b/docs/ide/managing-application-resources-dotnet.md
@@ -25,7 +25,7 @@ Resource files are files that are part of an application but are not compiled, f
 > [!NOTE]
 > This topic applies to Visual Studio on Windows. For Visual Studio for Mac, see [Managing app resources (Visual Studio for Mac)](/visualstudio/mac/managing-app-resources).
 
-For more information about resources in .NET desktop apps, see [Resources in desktop apps](/dotnet/framework/resources/index).
+For more information about resources in .NET apps, see [Resources in .NET apps](/dotnet/framework/resources/index).
 
 ## Work with resources
 
@@ -46,5 +46,5 @@ Resources are managed differently in .NET projects than in other project types. 
 
 ## See also
 
-- [Resources in desktop apps (.NET Framework)](/dotnet/framework/resources/index)
+- [Resources in .NET apps (.NET Framework)](/dotnet/framework/resources/index)
 - [Managing app resources (Visual Studio for Mac)](/visualstudio/mac/managing-app-resources)


### PR DESCRIPTION
This is a very minor update that replaces the word "Desktop" with the ".NET" for the .NET Resources page, which was renamed some time ago.