### PR TITLE
Remove broken link in Toolsversion note

### DIFF
--- a/docs/msbuild/msbuild-toolset-toolsversion.md
+++ b/docs/msbuild/msbuild-toolset-toolsversion.md
@@ -39,7 +39,7 @@ MSBuild uses a Toolset of tasks, targets, and tools to build an application. Typ
 ::: moniker-end
 
 > [!NOTE]
-> Some project types use the `sdk` attribute instead of `ToolsVersion`. For more information, see [Packages, metadata, and frameworks](/dotnet/core/packages) and [Additions to the csproj format for .NET Core](/dotnet/core/tools/csproj).
+> Some project types use the `sdk` attribute instead of `ToolsVersion`. For more information, see [Additions to the csproj format for .NET Core](/dotnet/core/tools/csproj).
 
 ## How the ToolsVersion attribute works
 


### PR DESCRIPTION
The link for Packages, metadata, and frameworks is no longer relevant information is contained on the secondary link provided.

Fixes #5773



<!--
Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for docs.microsoft.com, see the contributor guide at https://docs.microsoft.com/contribute/.
-->
