### PR TITLE
Revert "Fix bug with allowed symbols"

### DIFF
--- a/docs/ide/editorconfig-naming-conventions.md
+++ b/docs/ide/editorconfig-naming-conventions.md
@@ -49,7 +49,7 @@ The following list shows the allowable values, and you can specify multiple valu
 - parameter
 - type_parameter
 - local
-- local_functions
+- local_function
 
 > [!NOTE] 
 > Tuple members aren't currently supported.


### PR DESCRIPTION
Reverts MicrosoftDocs/visualstudio-docs#5790 per https://github.com/MicrosoftDocs/visualstudio-docs/pull/5790#issuecomment-683178281

cc: @sharwell