### PR TITLE
Add dev-langs header

### DIFF
--- a/docs/extensibility/walkthrough-outlining.md
+++ b/docs/extensibility/walkthrough-outlining.md
@@ -10,6 +10,9 @@ ms.author: anthc
 manager: jillfra
 ms.workload:
 - vssdk
+dev_langs:
+  - csharp
+  - vb
 ---
 # Walkthrough: Outlining
 Set up language-based features such as outlining by defining the kinds of text regions you want to expand or collapse. You can define regions in the context of a language service, or define your own file name extension and content type and apply the region definition to only that type, or apply the region definitions to an existing content type (such as "text"). This walkthrough shows how to define and display outlining regions.


### PR DESCRIPTION
This allows the docs site to provide a dropdown to chose between available languages and means the document doesn't display the samples in both C# & VB



<!--
Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for docs.microsoft.com, see the contributor guide at https://docs.microsoft.com/contribute/.
-->
