### PR TITLE
Add Razor LSP logs to the "Data we collect" list.

### DIFF
--- a/docs/ide/developer-community-privacy.md
+++ b/docs/ide/developer-community-privacy.md
@@ -63,6 +63,8 @@ If **Report a problem** is initiated from Visual Studio, we collect one or more 
 
 - Python logs, if they exist
 
+- Razor LSP editor logs, if they exist
+
 - Windows Forms logs, if they exist
 
 - A screenshot, if you choose to include it


### PR DESCRIPTION
- In 16.8-Preview3 we will start collecting Razor's experimental (LSP) editor logs if they exist when a user reports a problem.
- Did not update the "updated" date since it's a minor update.

**Note:** This should not be merged until 16.8-Preview3 has been released. This PR is priming the pump for the new data that we're collecting.