### PR TITLE
Fixed Broken 'Download the Zip' Link

### DIFF
--- a/docker/tutorials/your-application.md
+++ b/docker/tutorials/your-application.md
@@ -22,7 +22,7 @@ At this point, your development team is quite small and you're simply building a
 
 Before you can run the application, you need to get the application source code onto your machine. For real projects, you will typically clone the repo. But, for this tutorial, you have created a ZIP file containing the application.
 
-1. [Download the ZIP](/assets/app.zip). Open the ZIP file and make sure you extract the contents.
+1. [Download the ZIP](http://localhost/assets/app.zip). Open the ZIP file and make sure you extract the contents.
 
 1. Once extracted, use your favorite code editor to open the project. If you're in need of an editor, you can use [Visual Studio Code](https://code.visualstudio.com/). You should see the `package.json` and two subdirectories (`src` and `spec`).
 


### PR DESCRIPTION
Changed the link to http://localhost/assets/app.zip.



<!--
Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for docs.microsoft.com, see the contributor guide at https://docs.microsoft.com/contribute/.
-->
