### PR TITLE
Docker Toolbox

### DIFF
--- a/docs/containers/edit-and-refresh.md
+++ b/docs/containers/edit-and-refresh.md
@@ -35,7 +35,7 @@ To debug apps in a local Docker container, the following tools must be installed
 
 ::: moniker-end
 
-To run Docker containers locally, you must have a local Docker client. You can use the [Docker Toolbox](https://www.docker.com/products/docker-toolbox), which requires Hyper-V to be disabled. You also can use [Docker for Windows](https://www.docker.com/get-docker), which uses Hyper-V and requires Windows 10.
+To run Docker containers locally, you must have a local Docker client. You can use [Docker for Windows](https://www.docker.com/get-docker), which uses Hyper-V and requires Windows 10.
 
 Docker containers are available for .NET Framework and .NET Core projects. Let's look at two examples. First, we look at a .NET Core web app. Then, we look at a .NET Framework console app.
 


### PR DESCRIPTION
Docker Toolbox is legacy and the link in this page redirects to Docker for Windows now.  I think it is confusing to list the legacy one first and so I think it should be removed.
