### PR TITLE
remove incorrect `\` in C++ .editorconfig example

### DIFF
--- a/docs/ide/cpp-editorconfig-properties.md
+++ b/docs/ide/cpp-editorconfig-properties.md
@@ -25,7 +25,7 @@ The Visual Studio C++ formatter has a rich set of configurable settings that can
 C++ formatting EditorConfig settings are prefixed with `_cpp__`. Here's an example of what your EditorConfig file might look like:
 
 ```ini
-[\*.{c++,cc,cpp,cxx,h,h++,hh,hpp,hxx,inl,ipp,tlh,tli}]
+[*.{c++,cc,cpp,cxx,h,h++,hh,hpp,hxx,inl,ipp,tlh,tli}]
 
 cpp_indent_case_contents_when_block = true
 cpp_new_line_before_open_brace_namespace = same_line


### PR DESCRIPTION
this example is incorrect, fixing it



<!--
Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for docs.microsoft.com, see the contributor guide at https://docs.microsoft.com/contribute/.
-->
