### PR TITLE
MSBuild version comparisons

### DIFF
--- a/docs/msbuild/msbuild-conditions.md
+++ b/docs/msbuild/msbuild-conditions.md
@@ -29,7 +29,7 @@ MSBuild supports a specific set of conditions that can be applied wherever a `Co
 |---------------|-----------------|
 |'`stringA`' == '`stringB`'|Evaluates to `true` if `stringA` equals `stringB`.<br /><br /> For example:<br /><br /> `Condition="'$(Configuration)'=='DEBUG'"`<br /><br /> Single quotes are not required for simple alphanumeric strings or boolean values. However, single quotes are required for empty values. This check is case insensitive.|
 |'`stringA`' != '`stringB`'|Evaluates to `true` if `stringA` is not equal to `stringB`.<br /><br /> For example:<br /><br /> `Condition="'$(Configuration)'!='DEBUG'"`<br /><br /> Single quotes are not required for simple alphanumeric strings or boolean values. However, single quotes are required for empty values. This check is case insensitive.|
-|\<, >, \<=, >=|Evaluates the numeric values of the operands. Returns `true` if the relational evaluation is true. Operands must evaluate to a decimal or hexadecimal number. Hexadecimal numbers must begin with "0x". **Note:**  In XML, the characters `<` and `>` must be escaped. The symbol `<` is represented as `&lt;`. The symbol `>` is represented as `&gt;`.|
+|\<, >, \<=, >=|Evaluates the numeric values of the operands. Returns `true` if the relational evaluation is true. Operands must evaluate to a decimal or hexadecimal number or a four-part dotted version. Hexadecimal numbers must begin with "0x". **Note:**  In XML, the characters `<` and `>` must be escaped. The symbol `<` is represented as `&lt;`. The symbol `>` is represented as `&gt;`.|
 |Exists('`stringA`')|Evaluates to `true` if a file or folder with the name `stringA` exists.<br /><br /> For example:<br /><br /> `Condition="!Exists('$(Folder)')"`<br /><br /> Single quotes are not required for simple alphanumeric strings or boolean values. However, single quotes are required for empty values.|
 |HasTrailingSlash('`stringA`')|Evaluates to `true` if the specified string contains either a trailing backward slash (\\) or forward slash (/) character.<br /><br /> For example:<br /><br /> `Condition="!HasTrailingSlash('$(OutputPath)')"`<br /><br /> Single quotes are not required for simple alphanumeric strings or boolean values. However, single quotes are required for empty values.|
 |!|Evaluates to `true` if the operand evaluates to `false`.|
@@ -59,6 +59,15 @@ In MSBuild project files, there's no true Boolean type. Boolean data is represen
 Boolean logic is only evaluated in the context of conditions, so property settings such as `<Prop2>'$(Prop1)' == 'true'</Prop>` are represented as a string (after variable expansion), not evaluated as Boolean values.  
 
 MSBuild implements a few special processing rules to make it easier to work with string properties that are used as Boolean values. Boolean literals are accepted, so `Condition="true"` and `Condition="false"` work as expected. MSBuild also includes special rules to support the Boolean negation operator. So, if `$(Prop)` is 'true', `!$(Prop)` expands to `!true` and this compares equal to `false`, as you would expect.
+
+## Comparing versions
+
+The relational operators `<`, `>`, `<=`, and `>=` support versions as parsed by <xref:System.Version?displayProperty=fullName>, so you can compare versions that have four numeric parts to each other. For instance `'1.2.3.4' < '1.10.0.0'` is `true`.
+
+> [!CAUTION]
+> `System.Version` comparisons can produce surprising results when one or both versions do not specify all four parts. For instance, version 1.1 is older than version 1.1.0.
+
+MSBuild provides [property functions to compare versions](property-functions.md#MSBuild-version-comparison-functions) that have a different set of rules compatible with semantic versioning (semver).
 
 ## See also
 

--- a/docs/msbuild/property-functions.md
+++ b/docs/msbuild/property-functions.md
@@ -338,7 +338,7 @@ Output:
 
 ## MSBuild TargetFramework and TargetPlatform functions
 
-MSBuild defines several functions for handling [TargetFramework and TargetPlatform properties](msbuild-target-framework-and-target-platform.md).
+MSBuild 16.7 and higher define several functions for handling [TargetFramework and TargetPlatform properties](msbuild-target-framework-and-target-platform.md).
 
 |Function signature|Description|
 |------------------------|-----------------|

--- a/docs/msbuild/property-functions.md
+++ b/docs/msbuild/property-functions.md
@@ -379,6 +379,39 @@ Value4 = 7.0
 Value5 = True
 ```
 
+## MSBuild version-comparison functions
+
+MSBuild 16.5 and higher define several functions for comparing strings that represent versions.
+
+> [!Note]
+> Comparison operators in conditions [can compare strings that can be parsed as `System.Version` objects](#msbuild-conditions.md#Comparing-versions), but the comparison can produce unexpected results. Prefer the property functions.
+
+|Function signature|Description|
+|------------------------|-----------------|
+|VersionEquals(string a, string b)|Return `true` if versions `a` and `b` are equivalent according to the below rules.|
+|VersionGreaterThan(string a, string b)|Return `true` if version `a` is greater than `b` according to the below rules.|
+|VersionGreaterThanOrEquals(string a, string b)|Return `true` if version `a` is greater than or equal to `b` according to the below rules.|
+|VersionLessThan(string a, string b)|Return `true` if version `a` is less than `b` according to the below rules.|
+|VersionLessThanOrEquals(string a, string b)|Return `true` if version `a` is less than or equal to `b` according to the below rules.|
+|VersionNotEquals(string a, string b)|Return `false` if versions `a` and `b` are equivalent according to the below rules.|
+
+In these methods, versions are parsed like <xref:System.Version?displayProperty=fullName>, with the following exceptions:
+
+* Leading `v` or `V` is ignored, which allows comparison to `$(TargetFrameworkVersion)`.
+
+* Everything from the first '-' or '+' to the end of the version string is ignored. This allows passing in semantic versions (semver), though the order is not the same as semver. Instead, prerelease specifiers and build metadata do not have any sorting weight. This can be useful, for example, to turn on a feature for `>= x.y` and have it kick in on `x.y.z-pre`.
+
+* Unspecified parts are same as zero value parts. (`x == x.0 == x.0.0 == x.0.0.0`).
+
+* Whitespace is not allowed in integer components.
+
+* Major version only is valid (`3` is equal to `3.0.0.0`)
+
+* `+` is not allowed as positive sign in integer components (it is treated as semver metadata and ignored)
+
+> [!TIP]
+> Comparisons of [TargetFramework properties](msbuild-target-framework-and-target-platform.md) should generally use [IsTargetFrameworkCompatible](#MSBuild-TargetFramework-and-TargetPlatform-functions) instead of extracting and comparing versions. This allows comparing `TargetFramework`s that vary in `TargetFrameworkIdentifier` as well as version.
+
 ## MSBuild condition functions
 
 The functions `Exists` and `HasTrailingSlash` are not property functions. They are available for use with the `Condition` attribute. See [MSBuild conditions](msbuild-conditions.md).


### PR DESCRIPTION
Docs around comparing versions in MSBuild. Includes the old way (silently in conditions using `System.Version.TryParse`) and the new (explicit property function that behaves more like people expect).

Fixes #6127.

<!--
Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for docs.microsoft.com, see the contributor guide at https://docs.microsoft.com/contribute/.
-->
