### PR TITLE
Outdated method

### DIFF
--- a/docs/python/learn-django-in-visual-studio-step-04-full-django-project-template.md
+++ b/docs/python/learn-django-in-visual-studio-step-04-full-django-project-template.md
@@ -111,7 +111,7 @@ Templates are located in the app's *templates/app* folder (and you typically wan
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ title }} - My Django Application</title>
 
-    {% load staticfiles %}
+    {% load static %}
     <link rel="stylesheet" type="text/css" href="{% static 'app/content/bootstrap.min.css' %}" />
     <link rel="stylesheet" type="text/css" href="{% static 'app/content/site.css' %}" />
     <script src="{% static 'app/scripts/modernizr-2.6.2.js' %}"></script>


### PR DESCRIPTION
hello
{% load static %} Django documents use this method.
{% load staticfiles %} This method is obsolete.
https://django.readthedocs.io/en/stable/howto/static-files/
https://docs.djangoproject.com/en/3.1/howto/static-files/

Unfortunately, this method does not work in newer versions of Django and causes errors.
The error is as follows:
TemplateSyntaxError at /
'staticfiles' is not a registered tag library



<!--
Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for docs.microsoft.com, see the contributor guide at https://docs.microsoft.com/contribute/.
-->
