### PR TITLE
Update how-to-run-legacy-code-analysis-manually-for-managed-code.md

### DIFF
--- a/docs/code-quality/how-to-run-legacy-code-analysis-manually-for-managed-code.md
+++ b/docs/code-quality/how-to-run-legacy-code-analysis-manually-for-managed-code.md
@@ -22,7 +22,7 @@ The code analysis tool provides information to you about possible defects in you
 1. If you are on Visual Studio 2019 version 16.5 or later, execute the following command on command prompt before starting Visual Studio:
 
 ```
-set EnableLegacyCodeAnalysis = true
+setx EnableLegacyCodeAnalysis true
 ```
 
 2. In **Solution Explorer**, click the project.


### PR DESCRIPTION
fixes #6426: set command is replaced with setx one.



<!--
Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for docs.microsoft.com, see the contributor guide at https://docs.microsoft.com/contribute/.
-->
