### PR TITLE
-b argument missing in git-with-visual-studio.md

### DIFF
--- a/docs/ide/git-with-visual-studio.md
+++ b/docs/ide/git-with-visual-studio.md
@@ -111,7 +111,7 @@ From both locations, you can switch between existing branches.
 
 ### Create a new branch
 
-You can also create a new branch. The equivalent command for this action is `git checkout <branchname>`.
+You can also create a new branch. The equivalent command for this action is `git checkout -b <branchname>`.
 
 Creating a new branch is as simple as entering the branch name and basing it off an existing branch.
 


### PR DESCRIPTION
The section "Create a new branch" contains the following code sample as the equivalent for creating a branch: `git checkout <branchname>`
This command however doesn't create a new branch, it's used to switch to an existing branch. In order to create a branch with the checkout command,
you have to pass the **-b** argument to it like this:
`git checkout -b <branchname>`
This commit fixes this code sample



<!--
Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for docs.microsoft.com, see the contributor guide at https://docs.microsoft.com/contribute/.
-->
