### PR TITLE
Add Powershell option in build-tools-container.md

### DIFF
--- a/docs/install/build-tools-container.md
+++ b/docs/install/build-tools-container.md
@@ -124,6 +124,27 @@ Save the following example Dockerfile to a new file on your disk. If the file is
    ENTRYPOINT ["C:\\BuildTools\\Common7\\Tools\\VsDevCmd.bat", "&&", "powershell.exe", "-NoLogo", "-ExecutionPolicy", "Bypass"]
    ```
 
+   You can use Powershell as well
+
+   ```Dockerfile
+   # escape=`
+
+   # Use the latest Windows Server Core image with .NET Framework 4.8.
+   FROM mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2019
+
+   # Use Powershell to run this script.
+   SHELL ["powershell", "-command"]
+
+   # Download the Build Tools bootstrapper.
+   ADD https://aka.ms/vs/16/release/vs_buildtools.exe C:\TEMP\vs_buildtools.exe
+
+   # Install Build Tools.
+   RUN "Start-Process -Wait 'C:\TEMP\vs_buildtools.exe' -ArgumentList '--quiet --norestart --nocache --installPath C:\BuildTools --add Microsoft.VisualStudio.Workload.AzureBuildTools' -PassThru"
+
+   # This entry point starts the developer PowerShell and launches the PowerShell shell.
+   ENTRYPOINT "$vsInstallPath = 'C:\BuildTools' ; if($?) { Import-Module C:\BuildTools\Common7\Tools\Microsoft.VisualStudio.DevShell.dll ; if($?) { Enter-VsDevShell -VsInstallPath $vsInstallPath -SkipAutomaticLocation}} ; powershell ; "
+   ```   
+
    > [!TIP]
    > For a list of workloads and components, see the [Visual Studio Build Tools component directory](workload-component-id-vs-build-tools.md).
    >


### PR DESCRIPTION
This is 0.2v of the https://github.com/MicrosoftDocs/visualstudio-docs/pull/6516 patch.

This is a PowerShell alternative for the people who want to use Only PowerShell in a Dockerfile.
It may need a bit of order.

The issue I made before
#6486



<!--
Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for docs.microsoft.com, see the contributor guide at https://docs.microsoft.com/contribute/.
-->
