### PR TITLE
Update how VS Build Tools is installed

### DIFF
--- a/docs/install/build-tools-container.md
+++ b/docs/install/build-tools-container.md
@@ -64,18 +64,22 @@ Save the following example Dockerfile to a new file on your disk. If the file is
    # Restore the default Windows shell for correct batch processing.
    SHELL ["cmd", "/S", "/C"]
 
-   # Download the Build Tools bootstrapper.
-   ADD https://aka.ms/vs/15/release/vs_buildtools.exe C:\TEMP\vs_buildtools.exe
-
-   # Install Build Tools with the Microsoft.VisualStudio.Workload.AzureBuildTools workload, excluding workloads and components with known issues.
-   RUN start /wait C:\TEMP\vs_buildtools.exe --quiet --wait --norestart --nocache `
-       --installPath C:\BuildTools `
-       --add Microsoft.VisualStudio.Workload.AzureBuildTools `
-       --remove Microsoft.VisualStudio.Component.Windows10SDK.10240 `
-       --remove Microsoft.VisualStudio.Component.Windows10SDK.10586 `
-       --remove Microsoft.VisualStudio.Component.Windows10SDK.14393 `
-       --remove Microsoft.VisualStudio.Component.Windows81SDK `
-    || IF "%ERRORLEVEL%"=="3010" EXIT 0
+   RUN `
+       # Download the Build Tools bootstrapper.
+       curl -SL --output vs_buildtools.exe https://aka.ms/vs/15/release/vs_buildtools.exe `
+       `
+       # Install Build Tools with the Microsoft.VisualStudio.Workload.AzureBuildTools workload, excluding workloads and components with known issues.
+       && (start /w vs_buildtools.exe --quiet --wait --norestart --nocache `
+           --installPath C:\BuildTools `
+           --add Microsoft.VisualStudio.Workload.AzureBuildTools `
+           --remove Microsoft.VisualStudio.Component.Windows10SDK.10240 `
+           --remove Microsoft.VisualStudio.Component.Windows10SDK.10586 `
+           --remove Microsoft.VisualStudio.Component.Windows10SDK.14393 `
+           --remove Microsoft.VisualStudio.Component.Windows81SDK `
+           || IF "%ERRORLEVEL%"=="3010" EXIT 0) `
+       `
+       # Cleanup
+       && del /q vs_buildtools.exe
 
    # Define the entry point for the Docker container.
    # This entry point starts the developer command prompt and launches the PowerShell shell.
@@ -106,22 +110,26 @@ Save the following example Dockerfile to a new file on your disk. If the file is
    # Restore the default Windows shell for correct batch processing.
    SHELL ["cmd", "/S", "/C"]
 
-   # Download the Build Tools bootstrapper.
-   ADD https://aka.ms/vs/16/release/vs_buildtools.exe C:\TEMP\vs_buildtools.exe
-
-   # Install Build Tools with the Microsoft.VisualStudio.Workload.AzureBuildTools workload, excluding workloads and components with known issues.
-   RUN C:\TEMP\vs_buildtools.exe --quiet --wait --norestart --nocache `
-       --installPath C:\BuildTools `
-       --add Microsoft.VisualStudio.Workload.AzureBuildTools `
-       --remove Microsoft.VisualStudio.Component.Windows10SDK.10240 `
-       --remove Microsoft.VisualStudio.Component.Windows10SDK.10586 `
-       --remove Microsoft.VisualStudio.Component.Windows10SDK.14393 `
-       --remove Microsoft.VisualStudio.Component.Windows81SDK `
-    || IF "%ERRORLEVEL%"=="3010" EXIT 0
+   RUN `
+       # Download the Build Tools bootstrapper.
+       curl -SL --output vs_buildtools.exe https://aka.ms/vs/16/release/vs_buildtools.exe `
+       `
+       # Install Build Tools with the Microsoft.VisualStudio.Workload.AzureBuildTools workload, excluding workloads and components with known issues.
+       && (start /w vs_buildtools.exe --quiet --wait --norestart --nocache modify `
+           --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools" `
+           --add Microsoft.VisualStudio.Workload.AzureBuildTools `
+           --remove Microsoft.VisualStudio.Component.Windows10SDK.10240 `
+           --remove Microsoft.VisualStudio.Component.Windows10SDK.10586 `
+           --remove Microsoft.VisualStudio.Component.Windows10SDK.14393 `
+           --remove Microsoft.VisualStudio.Component.Windows81SDK `
+           || IF "%ERRORLEVEL%"=="3010" EXIT 0) `
+       `
+       # Cleanup
+       && del /q vs_buildtools.exe
 
    # Define the entry point for the docker container.
    # This entry point starts the developer command prompt and launches the PowerShell shell.
-   ENTRYPOINT ["C:\\BuildTools\\Common7\\Tools\\VsDevCmd.bat", "&&", "powershell.exe", "-NoLogo", "-ExecutionPolicy", "Bypass"]
+   ENTRYPOINT ["C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\BuildTools\\Common7\\Tools\\VsDevCmd.bat", "&&", "powershell.exe", "-NoLogo", "-ExecutionPolicy", "Bypass"]
    ```
 
    > [!TIP]


### PR DESCRIPTION
In the VS 2019 example Dockerfile, it creates a separate installation of VS Build Tools rather than modify the existing installation of Build Tools from the sdk base image.  I've updated it to make use of the existing installation instead.

I've also modified the way in which the bootstrapper is downloaded.  The previous way using the `ADD` instruction caused unnecessary bloat in the resulting image because the vs_buildtools.exe is contained in an image layer (even deleting the file in a separate layer wouldn't solve this because the layer in which it was downloaded still exists).  I've modified the pattern to download the bootstrapper with curl and delete the bootstrapper after installation, all in the same layer.  This prevents the bootstrapper exe existing within the built image.  I applied this same pattern to the VS 2017 Dockerfile.

Fixes https://github.com/MicrosoftDocs/visualstudio-docs/issues/6748