### PR TITLE
Add two new built-in MSBuild properties

### DIFF
--- a/docs/msbuild/msbuild-reserved-and-well-known-properties.md
+++ b/docs/msbuild/msbuild-reserved-and-well-known-properties.md
@@ -65,7 +65,10 @@ The table in this section shows the MSBuild predefined properties. The example c
 | `MSBuildThisFileName` | Reserved | The file name portion of `MSBuildThisFileFullPath`, without the file name extension. | `ConsoleApp1` |
 | `MSBuildToolsPath` | Reserved | The installation path of the MSBuild version that's associated with the value of `MSBuildToolsVersion`.<br /><br /> Do not include the final backslash in the path.<br /><br /> This property cannot be overridden. | `C:\Program Files (x86)\Microsoft Visual Studio\2019\Preview\MSBuild\Current\Bin` |
 | `MSBuildToolsVersion` | Reserved | The version of the MSBuild Toolset that is used to build the project.<br /><br /> Note: An MSBuild Toolset consists of tasks, targets, and tools that are used to build an application. The tools include compilers such as *csc.exe* and *vbc.exe*. For more information, see [Toolset (ToolsVersion)](../msbuild/msbuild-toolset-toolsversion.md), and [Standard and custom Toolset configurations](../msbuild/standard-and-custom-toolset-configurations.md). | `Current` |
-| `MSBuildVersion` | Reserved | The version of MSBuild used to build the project. <br /><br/> This property can't be overridden, otherwise the error message `MSB4004 - The 'MSBuildVersion' property is reserved, and can not be modified.` is returned. | 16.7.0 |
+| `MSBuildVersion` | Reserved | The version of MSBuild used to build the project. <br /><br/> This property can't be overridden, otherwise the error message `MSB4004 - The 'MSBuildVersion' property is reserved, and can not be modified.` is returned. | 16.11.0 |
+| `MSBuildAssemblyVersion` | Reserved | The version of MSBuild assemblies used to build the project. | 16.0 |
+| `MSBuildFileVersion` | Reserved | The 4 part version of MSBuild assemblies used to build the project. | 16.11.0.30701 |
+| `MSBuildSemanticVersion` | Reserved | The full semver 2.0 version of MSBuild assemblies used to build the project. | 16.11.0-preview-21302-05+5e37cc992 |
 
 ## Names that conflict with MSBuild elements
 


### PR DESCRIPTION
The MSBuild change (https://github.com/dotnet/msbuild/pull/6534) will ship with VS 16.11.



<!--
Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for docs.microsoft.com, see the contributor guide at https://docs.microsoft.com/contribute/.
-->
