### PR TITLE
Update the separator string in the Example

### DIFF
--- a/docs/msbuild/how-to-display-an-item-list-separated-with-commas.md
+++ b/docs/msbuild/how-to-display-an-item-list-separated-with-commas.md
@@ -42,7 +42,7 @@ The separator can be either a single character or a string and must be enclosed 
 
 ## Example
 
-In this example, [Exec](../msbuild/exec-task.md) task runs the findstr tool to find specified text strings in the file, *Phrases.txt*. In the findstr command, literal search strings are indicated by the **-c:** switch, so the item separator, `-c:` is inserted between items in the `@(Phrase)` item list.
+In this example, [Exec](../msbuild/exec-task.md) task runs the findstr tool to find specified text strings in the file, *Phrases.txt*. In the findstr command, literal search strings are indicated by the **/c:** switch, so the item separator, ` /c:` is inserted between items in the `@(Phrase)` item list.
 
 For this example, the equivalent command-line command is:
 


### PR DESCRIPTION
Update the example description.

Based on this text `findstr /i /c:hello /c:world /c:msbuild phrases.txt` the separator should be /c:



<!--
Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for docs.microsoft.com, see the contributor guide at https://docs.microsoft.com/contribute/.
-->
