### PR TITLE
Clarify the 'SharedFiles' directory is not in 'Shared Project'

### DIFF
--- a/docs/extensibility/migration/update-visual-studio-extension.md
+++ b/docs/extensibility/migration/update-visual-studio-extension.md
@@ -134,7 +134,7 @@ All these steps can be completed with Visual Studio 2019.
 Leave the `source.extension.vsixmanifest` file in the VSIX project.
    ![Shared project contains all source files](media/update-visual-studio-extension/source-files-in-shared-project.png)
 
-1. Metadata files (release notes, license, icons, and so on) and VSCT files should be moved to a shared directory and added as linked files to the VSIX project.
+1. Metadata files (release notes, license, icons, and so on) and VSCT files should be moved to a shared directory and added as linked files to the VSIX project. Note that the shared directory is separate from the shared project.
    ![Add metadata and VSCT files as linked files](media/update-visual-studio-extension/add-linked-items-to-vsix.png)
     - For Metadata files, set BuildAction to `Content` and set Include in VSIX to `true`.
 


### PR DESCRIPTION
I was confused and thought the 'shared directory' was referring to the 'shared project'. I think this should be clarified.



<!--
Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for docs.microsoft.com, see the contributor guide at https://docs.microsoft.com/contribute/.
-->
