### PR TITLE
UWP Extension SDKs must list Toolbox items in SdkManifest.xml starting in VS 2022

### DIFF
--- a/docs/extensibility/creating-a-software-development-kit.md
+++ b/docs/extensibility/creating-a-software-development-kit.md
@@ -195,7 +195,7 @@ The following list gives the elements of the file:
 
 The **ToolBoxItems** element of the *SDKManifest.xml* schema specifies the control names, source assemblies, and toolbox tab names of toolbox items in both platform and extension SDKs. The following examples show various scenarios. This is applicable to either WinMD or DLL references.
 
-Note that in Visual Studio 2019 and earlier, rather than listing toolbox control names in the manifest Visual Studio dynamically enumerated the control types in the SDK's assemblies. Starting in Visual Studio 2022, this is no longer supported; toolbox items must be explicitly listed in the *SDKManifest.xml*.
+Note that in Visual Studio 2019 and earlier, rather than listing toolbox control names in the manifest, Visual Studio dynamically enumerated the control types in the SDK's assemblies. Starting in Visual Studio 2022, this is no longer supported; toolbox items must be explicitly listed in *SDKManifest.xml*.
 
 1. Place controls in the toolbox default category.
 

--- a/docs/extensibility/creating-a-software-development-kit.md
+++ b/docs/extensibility/creating-a-software-development-kit.md
@@ -135,24 +135,23 @@ Extension SDKs have the following installation layout:
 The *SDKManifest.xml* file describes how Visual Studio should consume the SDK. The following is an example:
 
 ```
-<FileList>
-DisplayName = "My SDK"
-ProductFamilyName = "My SDKs"
-TargetFramework = ".NETCore, version=v4.5.1; .NETFramework, version=v4.5.1"
-MinVSVersion = "14.0"
-MaxPlatformVersion = "8.1"
-AppliesTo = "WindowsAppContainer + WindowsXAML"
-SupportPrefer32Bit = "True"
-SupportedArchitectures = "x86;x64;ARM"
-SupportsMultipleVersions = "Error"
-CopyRedistToSubDirectory = "."
-DependsOn = "SDKB, version=2.0"
-MoreInfo = "https://msdn.microsoft.com/MySDK">
-<File Reference = "MySDK.Sprint.winmd" Implementation = "XNASprintImpl.dll">
-<Registration Type = "Flipper" Implementation = "XNASprintFlipperImpl.dll" />
-<Registration Type = "Flexer" Implementation = "XNASprintFlexerImpl.dll" />
-<ToolboxItems VSCategory = "Toolbox.Default" />
-</File>
+<FileList DisplayName = "My SDK"
+          ProductFamilyName = "My SDKs"
+          TargetFramework = ".NETCore, version=v4.5.1; .NETFramework, version=v4.5.1"
+          MinVSVersion = "14.0"
+          MaxPlatformVersion = "8.1"
+          AppliesTo = "WindowsAppContainer + WindowsXAML"
+          SupportPrefer32Bit = "True"
+          SupportedArchitectures = "x86;x64;ARM"
+          SupportsMultipleVersions = "Error"
+          CopyRedistToSubDirectory = "."
+          DependsOn = "SDKB, version=2.0"
+          MoreInfo = "https://msdn.microsoft.com/MySDK">
+  <File Reference = "MySDK.Sprint.winmd" Implementation = "XNASprintImpl.dll">
+    <Registration Type = "Flipper" Implementation = "XNASprintFlipperImpl.dll" />
+    <Registration Type = "Flexer" Implementation = "XNASprintFlexerImpl.dll" />
+    <ToolboxItems VSCategory = "Toolbox.Default" />
+  </File>
 </FileList>
 ```
 
@@ -194,13 +193,18 @@ The following list gives the elements of the file:
 
 ## <a name="ToolboxItems"></a> Specify the location of toolbox items
 
-The **ToolBoxItems** element of the *SDKManifest.xml* schema specifies the category and location of toolbox items in both platform and extension SDKs. The following examples show how to specify different locations. This is applicable to either WinMD or DLL references.
+The **ToolBoxItems** element of the *SDKManifest.xml* schema specifies the control names, source assemblies, and toolbox tab names of toolbox items in both platform and extension SDKs. The following examples show various scenarios. This is applicable to either WinMD or DLL references.
+
+Note that in Visual Studio 2019 and earlier, rather than listing toolbox control names in the manifest Visual Studio dynamically enumerated the control types in the SDK's assemblies. Starting in Visual Studio 2022, this is no longer supported; toolbox items must be explicitly listed in the *SDKManifest.xml*.
 
 1. Place controls in the toolbox default category.
 
     ```xml
     <File Reference = "sample.winmd">
-        <ToolboxItems VSCategory = "Toolbox.Default"/>
+        <ToolboxItems VSCategory = "Toolbox.Default">
+            <Item Type = "Namespace.ControlName1" />
+            <Item Type = "Namespace.ControlName2" />
+        </ToolboxItems>
     </File>
     ```
 
@@ -208,7 +212,10 @@ The **ToolBoxItems** element of the *SDKManifest.xml* schema specifies the categ
 
     ```xml
     <File Reference = "sample.winmd">
-        <ToolboxItems VSCategory= "MyCategoryName"/>
+        <ToolboxItems VSCategory= "MyCategoryName">
+            <Item Type = "Namespace.ControlName1" />
+            <Item Type = "Namespace.ControlName2" />
+        </ToolboxItems>
     </File>
     ```
 
@@ -217,9 +224,11 @@ The **ToolBoxItems** element of the *SDKManifest.xml* schema specifies the categ
     ```xml
     <File Reference = "sample.winmd">
         <ToolboxItems VSCategory = "Graph">
-        <ToolboxItems/>
+            <Item Type = "Namespace.ControlName1" />
+        </ToolboxItems>
         <ToolboxItems VSCategory = "Data">
-        <ToolboxItems />
+            <Item Type = "Namespace.ControlName2" />
+        </ToolboxItems>
     </File>
     ```
 
@@ -229,7 +238,9 @@ The **ToolBoxItems** element of the *SDKManifest.xml* schema specifies the categ
     // Blend accepts a slightly different structure for the category name because it allows a path rather than a single category.
     <File Reference = "sample.winmd">
         <ToolboxItems VSCategory = "Graph" BlendCategory = "Controls/sample/Graph">
-        <ToolboxItems />
+            <Item Type = "Namespace.ControlName1" />
+            <Item Type = "Namespace.ControlName2" />
+        </ToolboxItems>
     </File>
     ```
 
@@ -238,9 +249,11 @@ The **ToolBoxItems** element of the *SDKManifest.xml* schema specifies the categ
     ```xml
     <File Reference = "sample.winmd">
         <ToolboxItems VSCategory = "Graph">
-        <ToolboxItems/>
+            <Item Type = "Namespace.ControlName1" />
+        </ToolboxItems>
         <ToolboxItems BlendCategory = "Controls/sample/Graph">
-        <ToolboxItems/>
+            <Item Type = "Namespace.ControlName2" />
+        </ToolboxItems>
     </File>
     ```
 
@@ -249,9 +262,11 @@ The **ToolBoxItems** element of the *SDKManifest.xml* schema specifies the categ
     ```xml
     <File Reference = "sample.winmd">
         <ToolboxItems VSCategory = "Toolbox.Common">
-        <ToolboxItems />
+            <Item Type = "Namespace.ControlName1" />
+        </ToolboxItems>
         <ToolboxItems VSCategory = "Toolbox.All">
-        <ToolboxItems />
+            <Item Type = "Namespace.ControlName2" />
+        </ToolboxItems>
     </File>
     ```
 
@@ -260,7 +275,9 @@ The **ToolBoxItems** element of the *SDKManifest.xml* schema specifies the categ
     ```xml
     <File Reference = "sample.winmd">
         <ToolboxItems VSCategory = "Toolbox.ChooseItemsOnly">
-        <ToolboxItems />
+            <Item Type = "Namespace.ControlName1" />
+            <Item Type = "Namespace.ControlName2" />
+        </ToolboxItems>
     </File>
     ```
 

--- a/docs/extensibility/creating-a-software-development-kit.md
+++ b/docs/extensibility/creating-a-software-development-kit.md
@@ -201,10 +201,10 @@ Note that in Visual Studio 2019 and earlier, rather than listing toolbox control
 
     ```xml
     <File Reference = "sample.winmd">
-        <ToolboxItems VSCategory = "Toolbox.Default">
-            <Item Type = "Namespace.ControlName1" />
-            <Item Type = "Namespace.ControlName2" />
-        </ToolboxItems>
+      <ToolboxItems VSCategory = "Toolbox.Default">
+        <Item Type = "Namespace.ControlName1" />
+        <Item Type = "Namespace.ControlName2" />
+      </ToolboxItems>
     </File>
     ```
 
@@ -212,10 +212,10 @@ Note that in Visual Studio 2019 and earlier, rather than listing toolbox control
 
     ```xml
     <File Reference = "sample.winmd">
-        <ToolboxItems VSCategory= "MyCategoryName">
-            <Item Type = "Namespace.ControlName1" />
-            <Item Type = "Namespace.ControlName2" />
-        </ToolboxItems>
+      <ToolboxItems VSCategory= "MyCategoryName">
+        <Item Type = "Namespace.ControlName1" />
+        <Item Type = "Namespace.ControlName2" />
+      </ToolboxItems>
     </File>
     ```
 
@@ -223,12 +223,12 @@ Note that in Visual Studio 2019 and earlier, rather than listing toolbox control
 
     ```xml
     <File Reference = "sample.winmd">
-        <ToolboxItems VSCategory = "Graph">
-            <Item Type = "Namespace.ControlName1" />
-        </ToolboxItems>
-        <ToolboxItems VSCategory = "Data">
-            <Item Type = "Namespace.ControlName2" />
-        </ToolboxItems>
+      <ToolboxItems VSCategory = "Graph">
+        <Item Type = "Namespace.ControlName1" />
+      </ToolboxItems>
+      <ToolboxItems VSCategory = "Data">
+        <Item Type = "Namespace.ControlName2" />
+      </ToolboxItems>
     </File>
     ```
 
@@ -237,10 +237,10 @@ Note that in Visual Studio 2019 and earlier, rather than listing toolbox control
     ```xml
     // Blend accepts a slightly different structure for the category name because it allows a path rather than a single category.
     <File Reference = "sample.winmd">
-        <ToolboxItems VSCategory = "Graph" BlendCategory = "Controls/sample/Graph">
-            <Item Type = "Namespace.ControlName1" />
-            <Item Type = "Namespace.ControlName2" />
-        </ToolboxItems>
+      <ToolboxItems VSCategory = "Graph" BlendCategory = "Controls/sample/Graph">
+        <Item Type = "Namespace.ControlName1" />
+        <Item Type = "Namespace.ControlName2" />
+      </ToolboxItems>
     </File>
     ```
 
@@ -248,12 +248,12 @@ Note that in Visual Studio 2019 and earlier, rather than listing toolbox control
 
     ```xml
     <File Reference = "sample.winmd">
-        <ToolboxItems VSCategory = "Graph">
-            <Item Type = "Namespace.ControlName1" />
-        </ToolboxItems>
-        <ToolboxItems BlendCategory = "Controls/sample/Graph">
-            <Item Type = "Namespace.ControlName2" />
-        </ToolboxItems>
+      <ToolboxItems VSCategory = "Graph">
+        <Item Type = "Namespace.ControlName1" />
+      </ToolboxItems>
+      <ToolboxItems BlendCategory = "Controls/sample/Graph">
+        <Item Type = "Namespace.ControlName2" />
+      </ToolboxItems>
     </File>
     ```
 
@@ -261,12 +261,12 @@ Note that in Visual Studio 2019 and earlier, rather than listing toolbox control
 
     ```xml
     <File Reference = "sample.winmd">
-        <ToolboxItems VSCategory = "Toolbox.Common">
-            <Item Type = "Namespace.ControlName1" />
-        </ToolboxItems>
-        <ToolboxItems VSCategory = "Toolbox.All">
-            <Item Type = "Namespace.ControlName2" />
-        </ToolboxItems>
+      <ToolboxItems VSCategory = "Toolbox.Common">
+        <Item Type = "Namespace.ControlName1" />
+      </ToolboxItems>
+      <ToolboxItems VSCategory = "Toolbox.All">
+        <Item Type = "Namespace.ControlName2" />
+      </ToolboxItems>
     </File>
     ```
 
@@ -274,10 +274,10 @@ Note that in Visual Studio 2019 and earlier, rather than listing toolbox control
 
     ```xml
     <File Reference = "sample.winmd">
-        <ToolboxItems VSCategory = "Toolbox.ChooseItemsOnly">
-            <Item Type = "Namespace.ControlName1" />
-            <Item Type = "Namespace.ControlName2" />
-        </ToolboxItems>
+      <ToolboxItems VSCategory = "Toolbox.ChooseItemsOnly">
+        <Item Type = "Namespace.ControlName1" />
+        <Item Type = "Namespace.ControlName2" />
+      </ToolboxItems>
     </File>
     ```
 

--- a/docs/extensibility/creating-a-software-development-kit.md
+++ b/docs/extensibility/creating-a-software-development-kit.md
@@ -2,7 +2,7 @@
 title: Creating a Software Development Kit | Microsoft Docs
 description: Learn about the general infrastructure of SDKs and how to create a platform SDK and an extension SDK.
 ms.custom: SEO-VS-2020
-ms.date: 11/04/2016
+ms.date: 08/31/2021
 ms.topic: how-to
 ms.assetid: 8496afb4-1573-4585-ac67-c3d58b568a12
 author: leslierichardson95


### PR DESCRIPTION
Starting in VS 17.0 Preview 3, UWP Extension SDKs must explicitly list their Toolbox control types in their SdkManifest.xml. Otherwise no Toolbox items will be displayed.

In VS 16.x and earlier, VS would dynamically enumerate the control types in the SDK's assemblies and add all of them to the Toolbox, but that approach is unreliable.

Updated docs to reflect this change. Also fixed some XML syntax errors.