### PR TITLE
Correction in base image name in description

### DIFF
--- a/docs/containers/container-build.md
+++ b/docs/containers/container-build.md
@@ -26,7 +26,7 @@ EXPOSE 80
 EXPOSE 443
 ```
 
-The lines in the Dockerfile begin with the Debian image from Microsoft Container Registry (mcr.microsoft.com) and create an intermediate image `base` that exposes ports 80 and 443, and sets the working directory to `/app`.
+The lines in the Dockerfile begin with the ASP.Net Core 3.1 image from Microsoft Container Registry (mcr.microsoft.com) and create an intermediate image `base` that exposes ports 80 and 443, and sets the working directory to `/app`.
 
 The next stage is `build`, which appears as follows:
 


### PR DESCRIPTION
It looks like the description for the initial part of Dockerfile contains a typo error. The base image referenced is an ASP.Net core 3.1 image while the description refers to it as Debian image.



<!--
Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for docs.microsoft.com, see the contributor guide at https://docs.microsoft.com/contribute/.
-->
