### PR TITLE
Incorrect directory reference to run command

### DIFF
--- a/docker/tutorials/use-bind-mounts.md
+++ b/docker/tutorials/use-bind-mounts.md
@@ -41,7 +41,7 @@ To run your container to support a development workflow, you'll do the following
 
 1. Make sure you don't have any previous `getting-started` containers running.
 
-1. In the `getting-started` folder, run the following command (replace the ` \ ` characters with `` ` `` in Windows PowerShell). You'll learn what's going on afterwards:
+1. In the `app` folder, run the following command (replace the ` \ ` characters with `` ` `` in Windows PowerShell). You'll learn what's going on afterwards:
 
     ```bash
     docker run -dp 3000:3000 -w /app -v ${PWD}:/app node:12-alpine sh -c "yarn install && yarn run dev"


### PR DESCRIPTION
When you run the docker run command for the dev container you need to be in the app directory or it will not find the package.json inside of the container



<!--
Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for docs.microsoft.com, see the contributor guide at https://docs.microsoft.com/contribute/.
-->
