### PR TITLE
Networking parameter missing dev container command

### DIFF
--- a/docker/tutorials/multi-container-apps.md
+++ b/docker/tutorials/multi-container-apps.md
@@ -151,6 +151,7 @@ With all of that explained, start your dev-ready container!
 
     ```bash hl_lines="3 4 5 6 7"
     docker run -dp 3000:3000 \
+      --network todo-app \
       -w /app -v ${PWD}:/app \
       --network todo-app \
       -e MYSQL_HOST=mysql \


### PR DESCRIPTION
The container will error out because it is not deployed to the same docker network as the container



<!--
Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for docs.microsoft.com, see the contributor guide at https://docs.microsoft.com/contribute/.
-->
