### PR TITLE
Cross reference from "Incremental builds" to "How to..."

### DIFF
--- a/docs/msbuild/incremental-builds.md
+++ b/docs/msbuild/incremental-builds.md
@@ -78,3 +78,4 @@ This code creates the property CompileRan and gives it the value `true`, but onl
 ## See also
 
 - [Targets](../msbuild/msbuild-targets.md)
+- [How to: Build Incrementally](../msbuild/how-to-build-incrementally.md)


### PR DESCRIPTION
The "How To" page follows nicely from the "Incremental builds" page.
