### PR TITLE
Update uninstall-net-2022.md

### DIFF
--- a/mac/uninstall-net-2022.md
+++ b/mac/uninstall-net-2022.md
@@ -26,7 +26,7 @@ On Apple Silicon machines (also known as M1 or ARM) with older x64 SDKs installe
 
     ```bash
     chmod +x dotnet-uninstall-pkgs.sh 
-    sudo ./ dotnet-uninstall-pkgs.sh
+    sudo ./dotnet-uninstall-pkgs.sh
     sudo rm -r /etc/dotnet
     ```  
 


### PR DESCRIPTION
This line doesn't run with a space in it: sudo ./ dotnet-uninstall-pkgs.sh 
It must be: sudo ./dotnet-uninstall-pkgs.sh



<!--
Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for docs.microsoft.com, see the contributor guide at https://docs.microsoft.com/contribute/.
-->
