### PR TITLE
Fix typo in msbuild-well-known-item-metadata.md

### DIFF
--- a/docs/msbuild/msbuild-well-known-item-metadata.md
+++ b/docs/msbuild/msbuild-well-known-item-metadata.md
@@ -22,7 +22,7 @@ ms.workload:
 ---
 # MSBuild well-known item metadata
 
-Item metadata are values attached to items. Some are assigned by MSBuild to items when items are create, but you can also define any metadata you need. Some user-defined metadata values have meaning to MSBuild, specific tasks tasks, or SDKs such as the .NET SDK.
+Item metadata are values attached to items. Some are assigned by MSBuild to items when items are create, but you can also define any metadata you need. Some user-defined metadata values have meaning to MSBuild, specific tasks, or SDKs such as the .NET SDK.
 
 The first table in this article describes the metadata assigned to every item upon creation. The next table shows some optional metadata that has meaning for MSBuild, which you can define to control build behavior. In each example, the following item declaration was used to include the file *C:\MyProject\Source\Program.cs* in the project.
 


### PR DESCRIPTION
The following sentence has duplicated the word **tasks**:

> Some user-defined metadata values have meaning to MSBuild, specific **tasks tasks**, ...

It should read:

> Some user-defined metadata values have meaning to MSBuild, specific **tasks**, ...



<!--
Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for docs.microsoft.com, see the contributor guide at https://docs.microsoft.com/contribute/.
-->
