### PR TITLE
Fix typo in build-process-overview.md

### DIFF
--- a/docs/msbuild/build-process-overview.md
+++ b/docs/msbuild/build-process-overview.md
@@ -82,7 +82,7 @@ In this phase, [item definitions](item-definitions.md) are interpreted and an in
 
 ### Evaluate items
 
-Items defined inside a target are handled differently from items outside any target. In this phase, items outside any target, and their associated metadata, are processed.  Metadata set by item definitions is overridden by metadata setting on items. Because items are processed in the order that they appear, you can reference items that have been defined earlier, but not ones that appear later. Because the items pass is after the properties pass, items can access any property if defined outside any targets, regardless of whether the property definition appears later.
+Items defined inside a target are handled differently from items outside any target. In this phase, items outside any target, and their associated metadata, are processed.  Metadata set by item definitions is overridden by metadata set on items. Because items are processed in the order that they appear, you can reference items that have been defined earlier, but not ones that appear later. Because the items pass is after the properties pass, items can access any property if defined outside any targets, regardless of whether the property definition appears later.
 
 ### Evaluate `UsingTask` elements
 


### PR DESCRIPTION
The following sentence:

> Metadata set by item definitions is overridden by metadata **setting** on items.

Should read:

> Metadata set by item definitions is overridden by metadata **set** on items.



<!--
Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for docs.microsoft.com, see the contributor guide at https://docs.microsoft.com/contribute/.
-->
