### PR TITLE
fix incorrect variable name

### DIFF
--- a/docs/vsto/walkthrough-synchronizing-a-custom-task-pane-with-a-ribbon-button.md
+++ b/docs/vsto/walkthrough-synchronizing-a-custom-task-pane-with-a-ribbon-button.md
@@ -121,7 +121,7 @@ ms.workload:
      :::code language="csharp" source="../vsto/codesnippet/CSharp/Trin_TaskPaneRibbonSynchronize/ThisAddIn.cs" id="Snippet3":::
      :::code language="vb" source="../vsto/codesnippet/VisualBasic/Trin_TaskPaneRibbonSynchronize/ThisAddIn.vb" id="Snippet3":::
 
-6. Add the following property to the `ThisAddIn` class. This property exposes the private `myCustomTaskPane1` object to other classes. Later in this walkthrough, you will add code to the `MyRibbon` class that uses this property.
+6. Add the following property to the `ThisAddIn` class. This property exposes the private `taskPaneValue` object to other classes. Later in this walkthrough, you will add code to the `MyRibbon` class that uses this property.
 
      :::code language="csharp" source="../vsto/codesnippet/CSharp/Trin_TaskPaneRibbonSynchronize/ThisAddIn.cs" id="Snippet4":::
      :::code language="vb" source="../vsto/codesnippet/VisualBasic/Trin_TaskPaneRibbonSynchronize/ThisAddIn.vb" id="Snippet4":::


### PR DESCRIPTION
Hi @John-Hart ,

I found small typo when read this documentation. myCustomTaskPane1 variable was used where the snippet code showing taskPaneValue. I changed it to use taskPaneValue as this is used through all code snippet in this documentation page.
Anywau, this is my first contribution to Microsoft Documentation. Let me know if you have any concerns with my contribution.

Thanks,
Gilang