### PR TITLE
Fix inconsistent function name and typos

### DIFF
--- a/docs/debugger/historical-debugging-inspect-app.md
+++ b/docs/debugger/historical-debugging-inspect-app.md
@@ -26,10 +26,10 @@ Let's start with a simple program that has a bug. In a C# console application, a
 static void Main(string[] args)
 {
     int testInt = 0;
-    int resultInt = AddAll(testInt);
+    int resultInt = AddIterative(testInt);
     Console.WriteLine(resultInt);
 }
-private static int AddAll(int j)
+private static int AddIterative(int j)
 {
     for (int i = 0; i < 20; i++)
     {
@@ -48,7 +48,7 @@ private static int AddInt(int add)
 }
 ```
 
-We'll assume that the expected value of `resultInt` after calling `AddAll()` is 20 (the result of incrementing `testInt` 20 times). (We'll also assume that you can't see the bug in `AddInt()`).But the result is actually 44. How can we find the bug without stepping through `AddAll()` 10 times? We can use historical debugging to find the bug faster and more easily. Here's how:
+We'll assume that the expected value of `resultInt` after calling `AddIterative()` is 20 (the result of incrementing `testInt` 20 times). (We'll also assume that you can't see the bug in `AddInt()`). But the result is actually 44. How can we find the bug without stepping through `AddIterative()` 10 times? We can use historical debugging to find the bug faster and more easily. Here's how:
 
 1. In **Tools > Options > IntelliTrace > General**, make sure that IntelliTrace is enabled, and select **IntelliTrace events and call information**. If you do not select this option, you will not be able to see the navigation gutter (as explained below).
 
@@ -68,7 +68,7 @@ We'll assume that the expected value of `resultInt` after calling `AddAll()` is 
 
     ![code window in historical debugging mode](../debugger/media/historicaldebuggingback.png "HistoricalDebuggingBack")
 
-6. Now you can step into the `AddAll()` method (**F11**, or the **Step Into** button in the navigation gutter. Step forward (**F10**, or **Go to Next Call** in the navigation gutter. The pink line is now on the `j = AddInt(j);` line. **F10** in this case does not step to the next line of code. Instead, it steps to the next function call. Historical debugging navigates from call to call, and it skips lines of code that do not include a function call.
+6. Now you can step into the `AddIterative()` method (**F11**, or the **Step Into** button in the navigation gutter). Step forward (**F10**, or **Go to Next Call** in the navigation gutter). The pink line is now on the `j = AddInt(j);` line. **F10** in this case does not step to the next line of code. Instead, it steps to the next function call. Historical debugging navigates from call to call, and it skips lines of code that do not include a function call.
 
 7. Now step into the `AddInt()` method. You should see the bug in this code immediately.
 


### PR DESCRIPTION
In the page "[Inspect your app with IntelliTrace historical debugging in Visual Studio (C#, Visual Basic, C++)](https://docs.microsoft.com/en-us/visualstudio/debugger/historical-debugging-inspect-app)",
there's a sample code with the function `AddAll()`,
but on [line 65 here](https://github.com/MicrosoftDocs/visualstudio-docs/blob/main/docs/debugger/historical-debugging-inspect-app.md?plain=1#L65),
it is named `AddIterative()`.
And, in the screenshots, it is also named `AddIterative()`.
So, there's inconsistency here.

I renamed all occurrences of `AddAll` to `AddIterative` to match the screenshots,
and also fixed a few typos.