### PR TITLE
Provide documentation for `/TfsLink` (fixes #1903)

### DIFF
--- a/docs/ide/reference/devenv-command-line-switches.md
+++ b/docs/ide/reference/devenv-command-line-switches.md
@@ -73,6 +73,7 @@ The following command-line switches display the IDE and do the described task.
 |[/Run or /R](run-devenv-exe.md)|Compiles and runs the specified solution.<br /><br /> `devenv /run mysln.sln`|
 |[/RunExit](runexit-devenv-exe.md)|Compiles and runs the specified solution, minimizes the IDE when the solution is run, and closes the IDE after the solution has finished running.<br /><br /> `devenv /runexit mysln.sln`|
 |[/SafeMode](safemode-devenv-exe.md)|Starts Visual Studio in safe mode. This switch loads only the default environment, the default services, and the shipped versions of third-party packages.<br /><br /> This switch takes no arguments.|
+|/TfsLink|Opens Team Explorer and launches a viewer for the provided artifact URI if one is registered.|
 |[/UseEnv](useenv-devenv-exe.md)|Causes the IDE to use PATH, INCLUDE, LIBPATH, and LIB environment variables for C++ compilation. This switch is installed with the **Desktop development with C++** workload. For more information, see [Setting the Path and Environment Variables for Command-Line Builds](/cpp/build/setting-the-path-and-environment-variables-for-command-line-builds).|
 
 The following command-line switches don't display the IDE.


### PR DESCRIPTION
This fixes #1903

`devenv` provides this description for `/TfsLink`:

> Opens Team Explorer and launches a viewer for the provided artifact URI if one is registered.



<!--
Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for docs.microsoft.com, see the contributor guide at https://docs.microsoft.com/contribute/.
-->
