### PR TITLE
Update xmlpeek-task.md

### DIFF
--- a/docs/msbuild/xmlpeek-task.md
+++ b/docs/msbuild/xmlpeek-task.md
@@ -115,3 +115,4 @@ The output includes the following from the `TestPeek` target:
 - [Tasks](../msbuild/msbuild-tasks.md)
 - [Task reference](../msbuild/msbuild-task-reference.md)
 - [XPath query syntax](https://wikipedia.org/wiki/XPath)
+- [XPath Queries and Namespaces](https://docs.microsoft.com/en-us/dotnet/standard/data/xml/xpath-queries-and-namespaces)

--- a/docs/msbuild/xmlpeek-task.md
+++ b/docs/msbuild/xmlpeek-task.md
@@ -115,4 +115,4 @@ The output includes the following from the `TestPeek` target:
 - [Tasks](../msbuild/msbuild-tasks.md)
 - [Task reference](../msbuild/msbuild-task-reference.md)
 - [XPath query syntax](https://wikipedia.org/wiki/XPath)
-- [XPath Queries and Namespaces](https://docs.microsoft.com/en-us/dotnet/standard/data/xml/xpath-queries-and-namespaces)
+- [XPath Queries and Namespaces](/dotnet/standard/data/xml/xpath-queries-and-namespaces)


### PR DESCRIPTION
Every single time I try to use XPath on an XML file it doesn't work.  This is because all the XML files I've ever needed to use it on just happen to make use of a default namespace.  There is a caveat that needs to be understood when the default namespace is being used, which this article does not cover.  It would be nice if the examples were updated to include it explicitly, but in the very least, this additional "See also" link should be referenced.  It wasn't until I stumbled upon this other article that I finally figured out how to make XPath work properly.



<!--
Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for docs.microsoft.com, see the contributor guide at https://docs.microsoft.com/contribute/.
-->
