### PR TITLE
Matched the items to name and order in Visual Studio

### DIFF
--- a/docs/extensibility/how-to-use-wizards-with-project-templates.md
+++ b/docs/extensibility/how-to-use-wizards-with-project-templates.md
@@ -57,11 +57,11 @@ This procedure shows how to create a custom wizard that opens a Windows Form bef
 
 2. In **Solution Explorer**, select the VSIX project node. Below **Solution Explorer**, you should see the **Properties** window. If you do not, select **View** > **Properties Window**, or press **F4**. In the **Properties** window, select the following fields to `true`:
 
-   - **Include Assembly In VSIX Container**
+   - **Include Assembly in VSIX Container**
 
-   - **Include Debug Symbols In VSIX Container**
+   - **Include Debug Symbols in Local VSIX Deployment**
 
-   - **Include Debug Symbols In Local VSIX Deployment**
+   - **Include Debug Symbols in VSIX Container**
 
 3. Add the assembly as an asset to the VSIX project. Open the *source.extension.vsixmanifest* file and select the **Assets** tab. In the **Add New Asset** window, for **Type** select **Microsoft.VisualStudio.Assembly**, for **Source** select **A project in current solution**, and for **Project** select **MyProjectWizard**.
 


### PR DESCRIPTION
Matched the following items in this article to the name and display order in the Visual Studio Properties window.

- Include Assembly in VSIX Container
- Include Debug Symbols in Local VSIX Deployment
- Include Debug Symbols in VSIX Container

In the current article:

<img width="1506" alt="Screen Shot 2021-12-20 at 11 41 46" src="https://user-images.githubusercontent.com/359823/146704322-3bc75826-0770-4da4-aa5a-ad97a3f499f1.png">

In the Visual Studio:

![figure1](https://user-images.githubusercontent.com/359823/146704145-d65979d6-4b35-4c98-b78d-cd9ec76ed4fc.jpg)

