### PR TITLE
Fix erroneous suggested nmake command for DIA SDK

### DIFF
--- a/docs/debugger/debug-interface-access/dia2dump-sample.md
+++ b/docs/debugger/debug-interface-access/dia2dump-sample.md
@@ -56,7 +56,7 @@ By default, the installation directory is a protected directory. That means you 
 
 1. In a Developer command prompt window, change to the directory where you copied the sample files. If you didn't copy the sample to another directory, you must use an elevated (run as administrator) Developer command prompt window.
 
-1. Enter the command `nmake makefile` to build the default Debug configuration of dia2dump.exe.
+1. Enter the command `nmake all` to build the default Debug configuration of dia2dump.exe.
 
 ## Run the Dia2Dump sample
 


### PR DESCRIPTION
The suggested command `nmake makefile` results in the following output

```
Microsoft (R) Program Maintenance Utility Version 14.29.30037.0
Copyright (C) Microsoft Corporation.  All rights reserved.

'makefile' is up-to-date
```

I believe it is trying to build the "makefile" target. Just running nmake is enough to have it use the default target.