### PR TITLE
Corrected mod1/mod2 values from Ctrl to Control

### DIFF
--- a/docs/extensibility/keybinding-element.md
+++ b/docs/extensibility/keybinding-element.md
@@ -18,7 +18,7 @@ ms.workload:
 # KeyBinding element
 The KeyBinding element specifies keyboard shortcuts for the commands.
 
- Commands can have both single and dual key bindings associated with them. An example of a single key binding is **Ctrl**+**S** for the **Save** command. Dual key bindings require two successive key combinations to trigger a command. An example of a dual key binding is <strong>Ctrl*+</strong>K<strong>,</strong>Ctrl<strong>+</strong>K** to set a bookmark.
+ Commands can have both single and dual key bindings associated with them. An example of a single key binding is **Ctrl**+**S** for the **Save** command. Dual key bindings require two successive key combinations to trigger a command. An example of a dual key binding is **Ctrl+K**,**Ctrl+K** to set a bookmark.
 
 ## Syntax
 
@@ -37,9 +37,9 @@ The KeyBinding element specifies keyboard shortcuts for the commands.
 |id|Required.|
 |editor|Required. The editor GUID indicates the editing context for which this keyboard shortcut will be active. The global binding scope value is "guidVSStd97".|
 |key1|Required. Valid values include all typable alphanumerics, and also two-digit hexadecimal values preceded by 0x and [VK_constants](/windows/desktop/inputdev/virtual-key-codes).|
-|mod1|Optional. Any combination of **Ctrl**, **Alt**, and **Shift** separated by space.|
+|mod1|Optional. Any combination of **Control**, **Alt**, and **Shift** separated by space.|
 |key2|Optional. Valid values include all typable alphanumerics, and also two-digit hexadecimal values preceded by 0x and [VK_constants](/windows/desktop/inputdev/virtual-key-codes).|
-|mod2|Optional. Any combination of **Ctrl**, **Alt**, and **Shift** separated by space.|
+|mod2|Optional. Any combination of **Control**, **Alt**, and **Shift** separated by space.|
 |emulator|Optional.|
 |Condition|Optional. See [Conditional attributes](../extensibility/vsct-xml-schema-conditional-attributes.md).|
 


### PR DESCRIPTION
The `mod1` and `mod2` properties listed the valid values as `Ctrl`, `Alt` and `Shift`. `Ctrl` is not valid. The correct value is `Control`.

I've also fixed the bold formatting of the dual keybinding example which was messed up.



<!--
Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for docs.microsoft.com, see the contributor guide at https://docs.microsoft.com/contribute/.
-->
