### PR TITLE
Fix MD link to image in vs-ide-benefit.md

### DIFF
--- a/subscriptions/vs-ide-benefit.md
+++ b/subscriptions/vs-ide-benefit.md
@@ -19,7 +19,7 @@ To download the IDE:
 1. Sign in to [https://my.visualstudio.com/benefits](https://my.visualstudio.com/benefits?wt.mc_id=o~msft~docs).
 2. Locate the Visual Studio IDE tile in the Tools section, and click on the **Download** link at the bottom of the benefit tile.  You can also download it from the [Downloads](https://my.visualstudio.com/downloads?wt.mc_id=o~msft~docs) page.
    > [!div class="mx-imgBorder"]
-   > ![Visual Studio Enterprise tile](_img/vs-ide-experience/vs-ide-tile.png "Click "Download' on the Visual Studio tile to install Visual Studio.")
+   > ![Visual Studio Enterprise tile](_img/vs-ide-experience/vs-ide-tile.png "Click 'Download' on the Visual Studio tile to install Visual Studio.")
 
 3. You’ll be redirected to the Download Results page for Visual Studio, where you’ll have the opportunity to download the IDE and obtain a product key to activate it. You may also claim a product key by clicking on the blue **Get Key** link, or claim a key later on the [Product keys](https://my.visualstudio.com/productkeys) page.
 4. On the Details tab of the Download Results page:


### PR DESCRIPTION
On the [The Visual Studio IDE](https://docs.microsoft.com/en-us/visualstudio/subscriptions/vs-ide-benefit) page, in Activation Step 2, there is a double quote that is closed prematurely (after the word 'Download'), which causes the image to not be shown correctly. The fix is to enclose the word 'Download' in single quotes, similar to what is done in Step 5.

This is a [quick edit](https://docs.microsoft.com/en-us/contribute/#quick-edits-to-existing-documents) according to the [Microsoft Docs contributor guide overview](https://docs.microsoft.com/en-us/contribute).

<!--
Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for docs.microsoft.com, see the contributor guide at https://docs.microsoft.com/contribute/.
-->
