### PR TITLE
Update parameter rootnamespace in template-parameters.md

### DIFF
--- a/docs/ide/template-parameters.md
+++ b/docs/ide/template-parameters.md
@@ -53,7 +53,7 @@ The following table lists the reserved template parameters that can be used by a
 |machinename|The current computer name (for example, Computer01).|
 |projectname|The name provided by the user when the project was created.|
 |registeredorganization|The registry key value from HKLM\Software\Microsoft\Windows NT\CurrentVersion\RegisteredOrganization.|
-|rootnamespace|The root namespace of the current project. This parameter applies only to item templates.|
+|rootnamespace|The root namespace of the current project followed by the subfolder of the current item, with slashes replaced by periods. This parameter applies only to item templates.|
 |safeitemname|Same as `itemname` but with all unsafe characters and spaces replaced by underscore characters.|
 |safeitemrootname|Same as `safeitemname`.|
 |safeprojectname|The name provided by the user when the project was created but with all unsafe characters and spaces removed.|

--- a/docs/ide/template-parameters.md
+++ b/docs/ide/template-parameters.md
@@ -36,9 +36,9 @@ Template parameters are declared in the format $*parameter*$. For example:
 
 1. In the code file for the project item, include parameters where appropriate. For example, the following parameter specifies that the safe project name is used for the namespace in a file:
 
-    ```csharp
-    namespace $safeprojectname$
-    ```
+   ```csharp
+   namespace $safeprojectname$
+   ```
 
 ## Reserved template parameters
 
@@ -47,7 +47,7 @@ The following table lists the reserved template parameters that can be used by a
 |Parameter|Description|
 |---------------|-----------------|
 |clrversion|Current version of the common language runtime (CLR).|
-|ext_*|Add the `ext_` prefix to any parameter to refer to the variables of the parent template. For example, `ext_safeprojectname`.|
+|ext_\*|Add the `ext_` prefix to any parameter to refer to the variables of the parent template. For example, `ext_safeprojectname`.|
 |guid[1-10]|A GUID used to replace the project GUID in a project file. You can specify up to 10 unique GUIDs (for example, `guid1`).|
 |itemname|The name of the file in which the parameter is being used.|
 |machinename|The current computer name (for example, Computer01).|


### PR DESCRIPTION
Make the description of $rootnamespace$ reflect the real value from VS. 
I will add a new parameter $defaultnamespace$ to take "The root namespace of the current project" value in VS 17.2 Preview 1



<!--
Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for docs.microsoft.com, see the contributor guide at https://docs.microsoft.com/contribute/.
-->
