### PR TITLE
Fix tsconfig file name and formatting.

### DIFF
--- a/docs/javascript/compile-typescript-code-npm.md
+++ b/docs/javascript/compile-typescript-code-npm.md
@@ -37,7 +37,7 @@ The [TypeScript npm package](https://www.npmjs.com/package/typescript) adds Type
 
    Check the **npm** option in the **Output** window to see package installation progress. The installed package shows up under the **npm** node in Solution Explorer.
 
-1. If your project doesn't already include it, add a *.tsconfig* file to your project root. To add the file, right-click the project node and choose **Add > New Item**. Choose the **TypeScript JSON Configuration File**, and then click **Add**.
+1. If your project doesn't already include it, add a *tsconfig.json* file to your project root. To add the file, right-click the project node and choose **Add > New Item**. Choose the **TypeScript JSON Configuration File**, and then click **Add**.
 
    Visual Studio adds the *tsconfig.json* file to the project root. You can use this file to [configure options](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html) for the TypeScript compiler.
 

--- a/docs/javascript/compile-typescript-code-nuget.md
+++ b/docs/javascript/compile-typescript-code-nuget.md
@@ -89,10 +89,10 @@ If Visual Studio is installed, then the node.exe bundled with it will automatica
 
    Source map files are required for debugging.
 
-1. If you want to compile every time you save the project, use the *compileOnSave* option in *.tsconfig.
+1. If you want to compile every time you save the project, use the *compileOnSave* option in *tsconfig.json*.
 
    ```json
-   ```{
+   {
       "compileOnSave":  true,
       "compilerOptions": {
       }


### PR DESCRIPTION
1. Correct the file name - `tsconfig.json` - making it consistent with the rest of the pages.

2.  Remove a few redundant backticks.