### PR TITLE
Update the remote debugger 32-bit service port

### DIFF
--- a/docs/debugger/remote-debugger-port-assignments.md
+++ b/docs/debugger/remote-debugger-port-assignments.md
@@ -49,7 +49,7 @@ In other words, the number of the port assigned to the remote debugger is increm
 
 ## The Remote Debugger Port on 64-bit Operating Systems
 ::: moniker range=">=vs-2022"
- When the 64-bit version of the remote debugger is started, it uses the main port (4026) by default.  If you debug a 32-bit process, the 64-bit version of the remote debugger starts a 32-bit version of the remote debugger on port 4025. If you run the 32-bit remote debugger, it uses 4026, and 4025 is not used.
+ When the 64-bit version of the remote debugger is started, it uses the main port (4026) by default.  If you debug a 32-bit process, the 64-bit version of the remote debugger starts a 32-bit version of the remote debugger on port 4025 in most cases. If you run the 32-bit remote debugger, it uses 4026, and 4025 is not used. The exception to this if Remote Tools for Visual Studio 2022 version 17.2 or newer is installed, and the Remote Debugger Configuration Wizard is used to start the remote debugger as a service, then the default 32-bit debugging port will be 4040 instead of 4025.
 ::: moniker-end
 ::: moniker range="vs-2019"
  When the 64-bit version of the remote debugger is started, it uses the main port (4024) by default.  If you debug a 32-bit process, the 64-bit version of the remote debugger starts a 32-bit version of the remote debugger on port 4025 (the main port number incremented by 1). If you run the 32-bit remote debugger, it uses 4024, and 4025 is not used.


### PR DESCRIPTION
As part of addressing a bug for 17.2, the 32-bit remote debugger **service** port will change from 4025 to 4040. This updates the documentation to match.
