### PR TITLE
Use the correct path to the .targets file for v17

### DIFF
--- a/docs/modeling/code-generation-in-a-build-process.md
+++ b/docs/modeling/code-generation-in-a-build-process.md
@@ -68,7 +68,15 @@ In the .vbproj or .csproj file, find a line like this:
 
 After that line, insert the Text Templating import:
 
-::: moniker range=">=vs-2019"
+::: moniker range=">=vs-2022"
+
+```xml
+<Import Project="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v17.0\TextTemplating\Microsoft.TextTemplating.targets" />
+```
+
+::: moniker-end
+
+::: moniker range="vs-2019"
 
 ```xml
 <Import Project="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v16.0\TextTemplating\Microsoft.TextTemplating.targets" />


### PR DESCRIPTION
Just a quick simple change so the right path is shown when viewing this document for use with VS2022

<!--
Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for docs.microsoft.com, see the contributor guide at https://docs.microsoft.com/contribute/.
-->
