### PR TITLE
Add defaultnamespace

### DIFF
--- a/docs/ide/template-parameters.md
+++ b/docs/ide/template-parameters.md
@@ -54,6 +54,7 @@ The following table lists the reserved template parameters that can be used by a
 |projectname|The name provided by the user when the project was created.|
 |registeredorganization|The registry key value from HKLM\Software\Microsoft\Windows NT\CurrentVersion\RegisteredOrganization.|
 |rootnamespace|The root namespace of the current project followed by the subfolder of the current item, with slashes replaced by periods. This parameter applies only to item templates.|
+|defaultnamespace|The root namespace of the current project. This parameter applies only to item templates.| 
 |safeitemname|Same as `itemname` but with all unsafe characters and spaces replaced by underscore characters.|
 |safeitemrootname|Same as `safeitemname`.|
 |safeprojectname|The name provided by the user when the project was created but with all unsafe characters and spaces removed.|


### PR DESCRIPTION
Add defaultnamespace to Reserved template parameters. This parameter is supported since 17.2 Preview 1.



<!--
Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for docs.microsoft.com, see the contributor guide at https://docs.microsoft.com/contribute/.
-->
