### PR TITLE
update-spelling-mistake-in-MSB3644-doc

### DIFF
--- a/docs/msbuild/errors/msb3644.md
+++ b/docs/msbuild/errors/msb3644.md
@@ -28,7 +28,7 @@ The first thing to check is that there are no spelling or typographical errors i
 
 ```xml
 	<PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == ''">
-		<TargetFrameworkIdentifier>.NETCORAPP</TargetFrameworkIdentifier>
+		<TargetFrameworkIdentifier>.NETCOREAPP</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion>3.1</TargetFrameworkVersion>
 	</PropertyGroup>
 ```


### PR DESCRIPTION
`TargetFrameworkIdentifier` moniker was NETCORAPP and should be NETCOREAPP



<!--
Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for docs.microsoft.com, see the contributor guide at https://docs.microsoft.com/contribute/.
-->
