### PR TITLE
put grammar in code blocks

### DIFF
--- a/docs/modeling/customize-code-maps-by-editing-the-dgml-files.md
+++ b/docs/modeling/customize-code-maps-by-editing-the-dgml-files.md
@@ -283,29 +283,31 @@ Edit the code map's .dgml file in a text or XML editor. If the map is part of yo
 
     This expression uses the following Backus-Naur Form (BNF) syntax:
 
-    \<Expression> ::= \<BinaryExpression> &#124; \<UnaryExpression> &#124; "("\<Expression>")" &#124; \<MemberBindings> &#124; \<Literal> &#124; \<Number>
+    ```
+    <Expression> ::= <BinaryExpression> | \<UnaryExpression> | "("<Expression>")" | <MemberBindings> | <Literal> | \<Number>
 
-    \<BinaryExpression> ::= \<Expression> \<Operator> \<Expression>
+    <BinaryExpression> ::= <Expression> <Operator> <Expression>
 
-    \<UnaryExpression> ::= "!" \<Expression> &#124; "+" \<Expression> &#124; "-" \<Expression>
+    <UnaryExpression> ::= "!" <Expression> | "+" <Expression> | "-" <Expression>
 
-    \<Operator> ::= "<" &#124; "\<=" &#124; "=" &#124; ">=" &#124; ">" &#124; "!=" &#124; "or" &#124; "and" &#124; "+" &#124; "*" &#124; "/" &#124; "-"
+    <Operator> ::= "<" | "<=" | "=" | ">=" | ">" | "!=" | "or" | "and" | "+" | "*" | "/" | "-"
 
-    \<MemberBindings> ::= \<MemberBindings> &#124; \<MemberBinding> "." \<MemberBinding>
+    <MemberBindings> ::= <MemberBindings> | <MemberBinding> "." <MemberBinding>
 
-    \<MemberBinding> ::= \<MethodCall> &#124; \<PropertyGet>
+    <MemberBinding> ::= <MethodCall> | <PropertyGet>
 
-    \<MethodCall> ::= \<Identifier> "(" \<MethodArgs> ")"
+    <MethodCall> ::= <Identifier> "(" <MethodArgs> ")"
 
-    \<PropertyGet> ::= Identifier
+    <PropertyGet> ::= <Identifier>
 
-    \<MethodArgs> ::= \<Expression> &#124; \<Expression> "," \<MethodArgs> &#124; \<empty>
+    <MethodArgs> ::= <Expression> | <Expression> "," <MethodArgs> | <empty>
 
-    \<Identifier> ::= [^. ]*
+    <Identifier> ::= [^. ]*
 
-    \<Literal> ::= single or double-quoted string literal
+    <Literal> ::= single or double-quoted string literal
 
-    \<Number> ::= string of digits with optional decimal point
+    <Number> ::= string of digits with optional decimal point
+    ```
 
     You can specify multiple `<Condition/>` elements, which must all be true to apply the style.
 


### PR DESCRIPTION

<!--
Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for docs.microsoft.com, see the contributor guide at https://docs.microsoft.com/contribute/.
-->

As far as I am concerned, BNF grammars should be in a code block to be easily readable, but the BNF grammars here aren't, so I fixed it.