### PR TITLE
Adding exit command to the install script

### DIFF
--- a/docs/install/advanced-build-tools-container.md
+++ b/docs/install/advanced-build-tools-container.md
@@ -44,17 +44,17 @@ setlocal enabledelayedexpansion
 
 call %*
 if "%ERRORLEVEL%"=="3010" (
-    exit \b 0
+    exit /b 0
 ) else (
     if not "%ERRORLEVEL%"=="0" (
         set ERR=%ERRORLEVEL%
         call C:\TEMP\collect.exe -zip:C:\vslogs.zip
 
-        exit \b %ERR%
+        exit /b %ERR%
     )
 )
 
-exit \b 0
+exit /b 0
 ```
 
 ## Dockerfile

--- a/docs/install/advanced-build-tools-container.md
+++ b/docs/install/advanced-build-tools-container.md
@@ -2,7 +2,7 @@
 title: Advanced example for containers
 description: Learn about an advanced example for Docker containers. This example Dockerfile uses a specific version tag of the microsoft/dotnet-framework image.
 ms.custom: SEO-VS-2020
-ms.date: 04/27/2022
+ms.date: 04/28/2022
 ms.topic: conceptual
 ms.assetid: e03835db-a616-41e6-b339-92b41d0cfc70
 author: anandmeg

--- a/docs/install/advanced-build-tools-container.md
+++ b/docs/install/advanced-build-tools-container.md
@@ -50,7 +50,7 @@ if "%ERRORLEVEL%"=="3010" (
         set ERR=%ERRORLEVEL%
         call C:\TEMP\collect.exe -zip:C:\vslogs.zip
 
-        exit %ERRORLEVEL%
+        exit %ERR%
     )
 )
 

--- a/docs/install/advanced-build-tools-container.md
+++ b/docs/install/advanced-build-tools-container.md
@@ -67,7 +67,7 @@ In the working directory, create the "Dockerfile" with the following content:
 # escape=`
 
 # Use a specific tagged image.
-ARG FROM_IMAGE=mcr.microsoft.com/dotnet/framework/runtime:4.8
+ARG FROM_IMAGE=mcr.microsoft.com/windows/servercore:ltsc2019
 FROM ${FROM_IMAGE}
 
 # Restore the default Windows shell for correct batch processing.
@@ -166,9 +166,8 @@ ENTRYPOINT ["C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\BuildTools\
 ```dockerfile
 # escape=`
 
-# Use a specific tagged image. Tags can be changed, though that is unlikely for most images.
-# You could also use the immutable tag @sha256:324e9ab7262331ebb16a4100d0fb1cfb804395a766e3bb1806c62989d1fc1326
-ARG FROM_IMAGE=mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2019
+# Use the latest Windows Server Core 2019 image.
+ARG FROM_IMAGE=mcr.microsoft.com/windows/servercore:ltsc2019
 FROM ${FROM_IMAGE}
 
 # Restore the default Windows shell for correct batch processing.

--- a/docs/install/advanced-build-tools-container.md
+++ b/docs/install/advanced-build-tools-container.md
@@ -44,17 +44,17 @@ setlocal enabledelayedexpansion
 
 call %*
 if "%ERRORLEVEL%"=="3010" (
-    exit 0
+    exit \b 0
 ) else (
     if not "%ERRORLEVEL%"=="0" (
         set ERR=%ERRORLEVEL%
         call C:\TEMP\collect.exe -zip:C:\vslogs.zip
 
-        exit %ERR%
+        exit \b %ERR%
     )
 )
 
-exit 0
+exit \b 0
 ```
 
 ## Dockerfile
@@ -88,7 +88,7 @@ RUN `
     curl -SL --output vs_buildtools.exe https://aka.ms/vs/15/release/vs_buildtools.exe `
     `
     # Install Build Tools with the Microsoft.VisualStudio.Workload.AzureBuildTools workload, excluding workloads and components with known issues.
-    && (start /w C:\TEMP\Install.cmd vs_buildtools.exe --quiet --wait --norestart --nocache `
+    && (call C:\TEMP\Install.cmd vs_buildtools.exe --quiet --wait --norestart --nocache `
         --installPath C:\BuildTools `
         --channelUri C:\TEMP\VisualStudio.chman `
         --installChannelUri C:\TEMP\VisualStudio.chman `

--- a/docs/install/advanced-build-tools-container.md
+++ b/docs/install/advanced-build-tools-container.md
@@ -44,13 +44,13 @@ setlocal enabledelayedexpansion
 
 call %*
 if "%ERRORLEVEL%"=="3010" (
-    exit /b 0
+    exit 0
 ) else (
     if not "%ERRORLEVEL%"=="0" (
         set ERR=%ERRORLEVEL%
         call C:\TEMP\collect.exe -zip:C:\vslogs.zip
 
-        exit /b !ERR!
+        exit %ERRORLEVEL%
     )
 )
 

--- a/docs/install/advanced-build-tools-container.md
+++ b/docs/install/advanced-build-tools-container.md
@@ -2,7 +2,7 @@
 title: Advanced example for containers
 description: Learn about an advanced example for Docker containers. This example Dockerfile uses a specific version tag of the microsoft/dotnet-framework image.
 ms.custom: SEO-VS-2020
-ms.date: 01/11/2022
+ms.date: 04/27/2022
 ms.topic: conceptual
 ms.assetid: e03835db-a616-41e6-b339-92b41d0cfc70
 author: anandmeg
@@ -53,6 +53,8 @@ if "%ERRORLEVEL%"=="3010" (
         exit /b !ERR!
     )
 )
+
+exit 0
 ```
 
 ## Dockerfile

--- a/docs/install/build-tools-container.md
+++ b/docs/install/build-tools-container.md
@@ -2,7 +2,7 @@
 title: Install Visual Studio Build Tools into a container
 titleSuffix: ''
 description: Learn how to install Visual Studio Build Tools into a Windows container to support continuous integration and continuous delivery (CI/CD) workflows.
-ms.date: 06/09/2021
+ms.date: 04/28/2022
 ms.topic: conceptual
 author: anandmeg
 ms.author: meghaanand

--- a/docs/install/build-tools-container.md
+++ b/docs/install/build-tools-container.md
@@ -56,8 +56,8 @@ Save the following example Dockerfile to a new file on your disk. If the file is
    ```dockerfile
    # escape=`
 
-   # Use the latest Windows Server Core image with .NET Framework 4.7.2.
-   FROM mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2019
+   # Use the latest Windows Server Core 2019 image.
+   FROM mcr.microsoft.com/windows/servercore:ltsc2019
 
    # Restore the default Windows shell for correct batch processing.
    SHELL ["cmd", "/S", "/C"]
@@ -102,8 +102,8 @@ Save the following example Dockerfile to a new file on your disk. If the file is
    ```dockerfile
    # escape=`
 
-   # Use the latest Windows Server Core image with .NET Framework 4.8.
-   FROM mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2019
+   # Use the latest Windows Server Core 2019 image.
+   FROM mcr.microsoft.com/windows/servercore:ltsc2019
 
    # Restore the default Windows shell for correct batch processing.
    SHELL ["cmd", "/S", "/C"]
@@ -146,8 +146,8 @@ Save the following example Dockerfile to a new file on your disk. If the file is
    ```dockerfile
    # escape=`
 
-   # Use the latest Windows Server Core image with .NET Framework 4.8.
-   FROM mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2019
+   # Use the latest Windows Server Core 2019 image.
+   FROM mcr.microsoft.com/windows/servercore:ltsc2019
 
    # Restore the default Windows shell for correct batch processing.
    SHELL ["cmd", "/S", "/C"]


### PR DESCRIPTION
Docker setup will get stuck if there is not exit at the end of the install script.
Adding exit command at the end of the script so that the example can work correctly. There are several issues logged because of this.

