### PR TITLE
Fix FxCop.Usage.UseParams code example

### DIFF
--- a/docs/snippets/csharp/VS_Snippets_CodeAnalysis/FxCop.Usage.UseParams/cs/FxCop.Usage.UseParams.cs
+++ b/docs/snippets/csharp/VS_Snippets_CodeAnalysis/FxCop.Usage.UseParams/cs/FxCop.Usage.UseParams.cs
@@ -11,10 +11,9 @@ namespace UsageLibrary
         public void VariableArguments(__arglist) 
         { 
             ArgIterator argumentIterator = new ArgIterator(__arglist);
-            for(int i = 0; i < argumentIterator.GetRemainingCount(); i++) 
+            while (argumentIterator.GetRemainingCount() > 0)
             { 
-                Console.WriteLine(
-                    __refvalue(argumentIterator.GetNextArg(), string));
+                Console.WriteLine(__refvalue(argumentIterator.GetNextArg(), string));
             } 
         }
 


### PR DESCRIPTION
Due to incorrect condition (or iterator), this `for` loop iterates over at most half of the argument list, and also `i` is unnecessary for what the body does. I replaced it with a `while` loop.