### PR TITLE
Project type and targets were used interchangeably

### DIFF
--- a/docs/containers/edit-and-refresh.md
+++ b/docs/containers/edit-and-refresh.md
@@ -18,11 +18,11 @@ Visual Studio provides a consistent way to develop Docker containers and validat
 You can run and debug your apps in Linux or Windows containers running on your local Windows desktop with Docker installed, and you don't have to restart the container each time you make a code change.
 
 :::moniker range="vs-2017"
-This article illustrates how to use Visual Studio to start an app in a local Docker container, make changes, and then refresh the browser to see the changes. This article also shows you how to set breakpoints for debugging for containerized apps. Supported project types include .NET Framework and .NET Core web and console apps. In this article, we use ASP.NET Core web apps and .NET Framework console apps.
+This article illustrates how to use Visual Studio to start an app in a local Docker container, make changes, and then refresh the browser to see the changes. This article also shows you how to set breakpoints for debugging for containerized apps. Supported project types include web app and console app targeting .NET Framework and .NET Core. The examples presented in this article, are an ASP.NET Core web application and a .NET Framework console application.
 :::moniker-end
 
 :::moniker range=">=vs-2019"
-This article illustrates how to use Visual Studio to start an app in a local Docker container, make changes, and then refresh the browser to see the changes. This article also shows you how to set breakpoints for debugging for containerized apps. Supported project types include .NET Framework, .NET Core web and console apps, and Azure Functions. In this article, we use ASP.NET Core web apps and .NET Framework console apps.
+This article illustrates how to use Visual Studio to start an app in a local Docker container, make changes, and then refresh the browser to see the changes. This article also shows you how to set breakpoints for debugging for containerized apps. Supported project types include web app, console app, and Azure Function targeting .NET Framework and .NET Core. The examples presented in this article, are a project of type ASP.NET Core Web App and a project of type Console App (.NET Framework).
 :::moniker-end
 
 If you already have a project of a supported type, Visual Studio can create a Dockerfile and configure your project to run in a container. See [Container Tools in Visual Studio](overview.md).


### PR DESCRIPTION
For VS2017: the sentence was:
Supported project types include .NET Framework and .NET Core web and console apps.

This confused the project type (type web or type console) with the targetted framework (.NET Core/.NET Framework). Using "apps" is confusing as the project templates when selected Visual Studio are App/Application singular (depending on the version) To make this clearer app was used and not apps and the project type was separated from the project target:

Supported project types include web app and console app targeting .NET Framework and .NET Core.

For >=VS2019 the issue was identical to VS2017 except Azure Function was also a project type:

Original:
Supported project types include .NET Framework, .NET Core web and console apps, and Azure Functions.

Updated:
Supported project types include web app, console app, and Azure Function targeting .NET Framework and .NET Core.

The second sentence VS2107 was
In this article, we use ASP.NET Core web apps and .NET Framework console apps.

VS2017 uses the name application the project templates listed in Visual Studio not app and the use of the pronoun "we" was removed -- it is an article singular, not some plural entity :
The examples presented in this article, are an ASP.NET Core web application and a .NET Framework console application.

For >=VS2019 the original sentence was:
In this article, we use ASP.NET Core web apps and .NET Framework console apps.

The above sentence is confusing b/c it uses apps (plural) and there is only a single ASP.NET Core Web App presented and a single Console App (.NET Framework) presented. I used the text associated with the project template demonstrated in the article "ASP.NET Core Web App" and  "Console App (.NET Framework)"):
The examples presented in this article, are a project of type ASP.NET Core Web App and a project of type Console App (.NET Framework).



<!--
Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for docs.microsoft.com, see the contributor guide at https://docs.microsoft.com/contribute/.
-->
