### PR TITLE
Typo "MsBuild.exe"→"MSBuild.exe"

### DIFF
--- a/docs/azure/vs-azure-tools-publishing-using-powershell-scripts.md
+++ b/docs/azure/vs-azure-tools-publishing-using-powershell-scripts.md
@@ -244,7 +244,7 @@ To automate building your project, add code that calls MSBuild to `New-WebDeploy
         #Write a function to build and package your web application
     ```
 
-    To build your web application, use MsBuild.exe. For help, see [MSBuild Command-Line Reference](../msbuild/msbuild-command-line-reference.md)
+    To build your web application, use MSBuild.exe. For help, see [MSBuild Command-Line Reference](../msbuild/msbuild-command-line-reference.md)
 
     ```powershell
     Write-VerboseWithTime 'Build-WebDeployPackage: Start'
@@ -260,7 +260,7 @@ To automate building your project, add code that calls MSBuild to `New-WebDeploy
 $job = Start-Process cmd.exe -ArgumentList('/C "' + $msbuildCmd + '"') -WindowStyle Normal -Wait -PassThru
 
 if ($job.ExitCode -ne 0) {
-    throw('MsBuild exited with an error. ExitCode:' + $job.ExitCode)
+    throw('MSBuild exited with an error. ExitCode:' + $job.ExitCode)
 }
 
 #Obtain the project name


### PR DESCRIPTION
https://docs.microsoft.com/en-us/visualstudio/azure/vs-azure-tools-publishing-using-powershell-scripts?view=vs-2022
https://github.com/MicrosoftDocs/visualstudio-docs/blob/main/docs/azure/vs-azure-tools-publishing-using-powershell-scripts.md
#PingMSFTDocs



<!--
Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for docs.microsoft.com, see the contributor guide at https://docs.microsoft.com/contribute/.
-->
