### PR TITLE
Removed two near duplicate sentences

### DIFF
--- a/docs/containers/edit-and-refresh.md
+++ b/docs/containers/edit-and-refresh.md
@@ -51,8 +51,6 @@ To debug apps in a local Docker container, the following tools must be installed
 
 To run Docker containers locally, you must have a local Docker client. You can use [Docker Desktop](https://www.docker.com/get-docker), which requires Windows 10 or later.
 
-Docker containers are available for .NET Framework and .NET Core projects. Let's look at two examples. First, we look at a .NET Core web app. Then, we look at a .NET Framework console app.
-
 ## Create a web app
 
 If you have a project and you've added Docker support as described in the [overview](overview.md), skip this section.


### PR DESCRIPTION
From the second section, Prerequisites, I removed the following sentences:
Docker containers are available for .NET Framework and .NET Core projects. Let's look at two examples. First, we look at a .NET Core web app. Then, we look at a .NET Framework console app.

From the intro paragraph, in the documentation for Visual Studio 2017 here are the original (retained) sentences:
Supported project types include web app and console app targeting .NET Framework and .NET Core. The examples presented in this article, are an ASP.NET Core web application and a .NET Framework console application.

From the intro paragraph, in the documentation for Visual Studio 2019 (and greater) here are the original (retained) sentences:
Supported project types include web app, console app, and Azure Function targeting .NET Framework and .NET Core. The examples presented in this article, are a project of type ASP.NET Core Web App and a project of type Console App (.NET Framework).



<!--
Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for docs.microsoft.com, see the contributor guide at https://docs.microsoft.com/contribute/.
-->
