### PR TITLE
Justifying container orchestration

### DIFF
--- a/docs/containers/edit-and-refresh.md
+++ b/docs/containers/edit-and-refresh.md
@@ -148,7 +148,11 @@ Often, changes require further inspection. You can use the debugging features of
 
 ## Create a .NET Framework console app
 
-When you use .NET Framework console app projects, the option to add Docker support without orchestration isn't supported. You can still use the following procedure, even if you're using only a single Docker project.
+This section presents how to debug .NET Framework console app project in a local Docker container by first presenting how to add Docker support to the project. It is important to recognize that different project types have different levels of Docker support. There are even different levels of Docker support for .NET Core console app projects versus .NET Framework console app projects. 
+
+When a .NET Framework console app project is created, there is no option to enable Docker support. After creating such a project, there is no way to explicitly add Docker support to the project. For a .NET Framework console app project, it is possible to add support for container orchestration. A side effect of adding orchestration support to the .NET Framework console app project is that it adds Docker support to the project, 
+
+The following procedure demonstrates how to add orchestration support to a .NET Framework console app project which subsequently adds Docker support to the project and allows the project to be debugged in a local Docker container.
 
 1. Create a new .NET Framework Console app project.
 1. In Solution Explorer, right-click the project node, and then select **Add** > **Container Orchestration Support**.  In the dialog box that appears, select **Docker Compose**. A Dockerfile is added to your project and a Docker Compose project with associated support files is added.

--- a/docs/containers/edit-and-refresh.md
+++ b/docs/containers/edit-and-refresh.md
@@ -148,11 +148,11 @@ Often, changes require further inspection. You can use the debugging features of
 
 ## Create a .NET Framework console app
 
-This section presents how to debug a .NET Framework console app project in a local Docker container by first presenting how to add Docker support to the project. It is important to recognize that different project types have different levels of Docker support. There are even different levels of Docker support for .NET Core (including .NET 5 and later) console app projects versus .NET Framework console app projects. 
+This section presents how to debug a .NET Framework console app project in a local Docker container by first showing how to add Docker support to the project. It's important to recognize that different project types have different levels of Docker support. There are even different levels of Docker support for .NET Core (including .NET 5 and later) console app projects versus .NET Framework console app projects. 
 
-When a .NET Framework console app project is created, there is no option to enable Docker support. After creating such a project, there is no way to explicitly add Docker support to the project. For a .NET Framework console app project, it is possible to add support for container orchestration. A side effect of adding orchestration support to the .NET Framework console app project is that it adds Docker support to the project, 
+When a .NET Framework console app project is created, there's no option to enable Docker support. After creating such a project, there's no way to explicitly add Docker support to the project. For a .NET Framework console app project, it's possible to add support for container orchestration. A side effect of adding orchestration support to the .NET Framework console app project is that it adds Docker support to the project, 
 
-The following procedure demonstrates how to add orchestration support to a .NET Framework console app project which subsequently adds Docker support to the project and allows the project to be debugged in a local Docker container.
+The following procedure demonstrates how to add orchestration support to a .NET Framework console app project, which subsequently adds Docker support to the project and allows the project to be debugged in a local Docker container.
 
 1. Create a new .NET Framework Console app project.
 1. In Solution Explorer, right-click the project node, and then select **Add** > **Container Orchestration Support**.  In the dialog box that appears, select **Docker Compose**. A Dockerfile is added to your project and a Docker Compose project with associated support files is added.

--- a/docs/containers/edit-and-refresh.md
+++ b/docs/containers/edit-and-refresh.md
@@ -148,7 +148,7 @@ Often, changes require further inspection. You can use the debugging features of
 
 ## Create a .NET Framework console app
 
-This section presents how to debug .NET Framework console app project in a local Docker container by first presenting how to add Docker support to the project. It is important to recognize that different project types have different levels of Docker support. There are even different levels of Docker support for .NET Core console app projects versus .NET Framework console app projects. 
+This section presents how to debug a .NET Framework console app project in a local Docker container by first presenting how to add Docker support to the project. It is important to recognize that different project types have different levels of Docker support. There are even different levels of Docker support for .NET Core (including .NET 5 and later) console app projects versus .NET Framework console app projects. 
 
 When a .NET Framework console app project is created, there is no option to enable Docker support. After creating such a project, there is no way to explicitly add Docker support to the project. For a .NET Framework console app project, it is possible to add support for container orchestration. A side effect of adding orchestration support to the .NET Framework console app project is that it adds Docker support to the project, 
 


### PR DESCRIPTION
The original intro to this section read:
When you use .NET Framework console app projects, the option to add Docker support without orchestration isn't supported. You can still use the following procedure, even if you're using only a single Docker project.

There text to guide the reader as to what is orchestration and how it relates to debugging a .NET Framework console app in a local Docker container. The reader is not told that if they add orchestration, it also enables Docker support for the project which allows the project to be debugged in a local Docker container (the title of this help topic).

The other thing that should be reinforced is that this approach applies to .NET Framework console app projects. VS2022 supports adding Docker support to .NET Core console app project for example. Adding docker support by adding support for orchestration applies to a very small number scenarios.



<!--
Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for docs.microsoft.com, see the contributor guide at https://docs.microsoft.com/contribute/.
-->
