### PR TITLE
Update URL name to "Visual Studio Installer Projects Extension and .NET 6.0"

### DIFF
--- a/docs/deployment/deploying-applications-services-and-components.md
+++ b/docs/deployment/deploying-applications-services-and-components.md
@@ -86,7 +86,7 @@ If you require a more complex installation of a desktop application than ClickOn
 
 - An MSI-based installer package can be created by using the [WiX Toolset Visual Studio 2017 Extension](https://marketplace.visualstudio.com/items?itemName=RobMensching.WixToolsetVisualStudio2017Extension). This is a command-line toolset.
 
-- An MSI or EXE installer package can be created by using a Setup project (vdproj). To use this option, see [Visual Studio Installer Projects Extension and .NET Core 3.1 and .NET 5.0](../deployment/installer-projects-net-core.md) or, go directly to the [Visual Studio Installer Projects extension](https://marketplace.visualstudio.com/items?itemName=VisualStudioProductTeam.MicrosoftVisualStudio2017InstallerProjects#overview).
+- An MSI or EXE installer package can be created by using a Setup project (vdproj). To use this option, see [Visual Studio Installer Projects Extension and .NET 6.0](../deployment/installer-projects-net-core.md) or, go directly to the [Visual Studio Installer Projects extension](https://marketplace.visualstudio.com/items?itemName=VisualStudioProductTeam.MicrosoftVisualStudio2017InstallerProjects#overview).
 
 - An MSI or EXE installer package can be created by using [InstallShield](https://www.revenera.com/install/products/installshield/installshield-requirements) from Flexera Software. InstallShield may be used with Visual Studio 2017 and later versions. Community Edition isn't supported.
 

--- a/docs/deployment/toc.yml
+++ b/docs/deployment/toc.yml
@@ -216,7 +216,7 @@
         href: debugging-clickonce-applications-that-use-system-deployment-application.md
   - name: Visual Studio Installer projects
     items:
-    - name: Visual Studio Installer Projects Extension and .NET Core 3.1
+    - name: Visual Studio Installer Projects Extension and .NET 6.0
       href: installer-projects-net-core.md
   - name: Custom bootstrapper
     items:


### PR DESCRIPTION
Update URL name to "Visual Studio Installer Projects Extension and .NET 6.0".
It seems that when the page titles were updated, the table of contents and other modifications were left out.