### PR TITLE
Provide Clearer Error Message for Bad Delimiters

### DIFF
--- a/docs/msbuild/errors/msb3644.md
+++ b/docs/msbuild/errors/msb3644.md
@@ -35,7 +35,7 @@ The first thing to check is that there are no spelling or typographical errors i
 
 The issue is that the `TargetFrameworkIdentifier` is misspelled. It should be `.NETCOREAPP`.
 
-When leveraging the `TargetFrameworks` property and multiple target frameworks, ensure that they are separated with the correct delimter `;`. MSB3644 will occur, for example, by trying to separate frameworks via the `,` delimter:
+When leveraging the `TargetFrameworks` property and multiple target frameworks, ensure that they are separated with the correct delimiter `;`. MSB3644 will occur, for example, by trying to separate frameworks via the `,` delimiter:
 
 ```xml
 	<PropertyGroup>

--- a/docs/msbuild/errors/msb3644.md
+++ b/docs/msbuild/errors/msb3644.md
@@ -35,7 +35,7 @@ The first thing to check is that there are no spelling or typographical errors i
 
 The issue is that the `TargetFrameworkIdentifier` is misspelled. It should be `.NETCOREAPP`.
 
-When leveraging the `TargetFrameworks` property and multiple target frameworks, ensure that they are separated with the correct delimiter `;`. MSB3644 will occur, for example, by trying to separate frameworks via the `,` delimiter:
+When leveraging the `TargetFrameworks` property and multiple target frameworks, ensure that they are separated with the correct delimiter `;`. MSB3644 will occur, for example, by trying to separate frameworks using the `,` delimiter:
 
 ```xml
 	<PropertyGroup>

--- a/docs/msbuild/errors/msb3644.md
+++ b/docs/msbuild/errors/msb3644.md
@@ -24,7 +24,7 @@ This error occurs when the .NET reference assemblies are not found for the versi
 
 ## Project file framework identifier and version
 
-The first thing to check is that there are no spelling or typographical errors in the project file in the `TargetFramework`, `TargetFrameworkIdentifier`, or `TargetFrameworkVersion` properties. For example, the following code in project file generates MSB3644:
+The first thing to check is that there are no spelling or typographical errors in the project file in the `TargetFramework`, `TargetFrameworks`, `TargetFrameworkIdentifier`, or `TargetFrameworkVersion` properties. For example, the following code in project file generates MSB3644:
 
 ```xml
 	<PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == ''">
@@ -34,6 +34,14 @@ The first thing to check is that there are no spelling or typographical errors i
 ```
 
 The issue is that the `TargetFrameworkIdentifier` is misspelled. It should be `.NETCOREAPP`.
+
+When leveraging the `TargetFrameworks` property and multiple target frameworks, ensure that they are separated with the correct delimter `;`. MSB3644 will occur, for example, by trying to separate frameworks via the `,` delimter:
+
+```xml
+	<PropertyGroup>
+		    <TargetFrameworks>net6.0,net5.0,netcoreapp3.1</TargetFrameworks>
+	</PropertyGroup>
+```
 
 ## Reference assemblies folder
 

--- a/docs/msbuild/errors/msb3644.md
+++ b/docs/msbuild/errors/msb3644.md
@@ -35,11 +35,11 @@ The first thing to check is that there are no spelling or typographical errors i
 
 The issue is that the `TargetFrameworkIdentifier` is misspelled. It should be `.NETCOREAPP`.
 
-When leveraging the [`TargetFrameworks`](/dotnet/core/project-sdk/msbuild-props#targetframeworks) property and multiple target frameworks, ensure that they are separated with the correct delimiter `;`. MSB3644 will occur, for example, when trying to separate frameworks using the `,` delimiter:
+When leveraging the [`TargetFrameworks`](/dotnet/core/project-sdk/msbuild-props#targetframeworks) property and multiple target frameworks, ensure that they are separated with the correct delimiter `;`. MSB3644 will occur, for example, when trying to separate frameworks using the `,` delimiter. Here's an example of the correct syntax:
 
 ```xml
 	<PropertyGroup>
-		    <TargetFrameworks>net6.0,net5.0,netcoreapp3.1</TargetFrameworks>
+		    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
 	</PropertyGroup>
 ```
 

--- a/docs/msbuild/errors/msb3644.md
+++ b/docs/msbuild/errors/msb3644.md
@@ -35,7 +35,7 @@ The first thing to check is that there are no spelling or typographical errors i
 
 The issue is that the `TargetFrameworkIdentifier` is misspelled. It should be `.NETCOREAPP`.
 
-When leveraging the `TargetFrameworks` property and multiple target frameworks, ensure that they are separated with the correct delimiter `;`. MSB3644 will occur, for example, by trying to separate frameworks using the `,` delimiter:
+When leveraging the [`TargetFrameworks`](/dotnet/core/project-sdk/msbuild-props#targetframeworks) property and multiple target frameworks, ensure that they are separated with the correct delimiter `;`. MSB3644 will occur, for example, when trying to separate frameworks using the `,` delimiter:
 
 ```xml
 	<PropertyGroup>


### PR DESCRIPTION
Referencing https://github.com/dotnet/sdk/issues/25191#event-6723920747, a scenario where a user tried to separate target frameworks via comma. This error may be particularly confusing in this case, so adding some clarity here.