### PR TITLE
Update docs for DockerfileRunArguments

### DIFF
--- a/docs/containers/container-launch-settings.md
+++ b/docs/containers/container-launch-settings.md
@@ -29,7 +29,7 @@ In the *Properties* folder in an ASP.NET Core project, you can find the launchSe
       "commandName": "Docker",
       "launchBrowser": true,
       "launchUrl": "{Scheme}://{ServiceHost}:{ServicePort}",
-      "DockerfileRunArguments": "-v $(pwd)/host-folder:/container-folder:ro",
+      "DockerfileRunArguments": "-l mylabel=value",
       "environmentVariables": {
         "ASPNETCORE_URLS": "https://+:443;http://+:80",
         "ASPNETCORE_HTTPS_PORT": "44360"
@@ -53,12 +53,31 @@ The commandName setting identifies that this section applies to Container Tools.
 
 ::: moniker-end
 
-::: moniker range=">=vs-2019"
+::: moniker range="vs-2019"
 
 | Setting name         | Example                                               | Description                                                                                                             |
 | -------------------- | ----------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
 | commandLineArgs      | "commandLineArgs": "--mysetting myvalue"              | These command-line arguments for starting your app are used when launching your project in the container.                                     |
-|DockerfileRunArguments|"dockerfileRunArguments": "-v $(pwd)/host-folder:/container-folder:ro"|Additional arguments to pass to the [docker run](https://docs.docker.com/engine/reference/commandline/run/) command.|
+|DockerfileRunArguments|"dockerfileRunArguments": "-l mylabel=value"|Additional arguments to pass to the [docker run](https://docs.docker.com/engine/reference/commandline/run/) command.|
+| environmentVariables | "environmentVariables": {<br/>   "ASPNETCORE_URLS": "https://+:443;http://+:80", <br/>   "ASPNETCORE_HTTPS_PORT": "44381" <br/> }                    | These environment variable values are passed to the process when it is launched in the container.                       |
+| httpPort             | "httpPort": 24051                                     | This port on the host is mapped to the container's port 80 when launching the container. |
+| launchBrowser        | "launchBrowser": true                                 | Indicates whether to launch the browser after successfully launching the project.                                       |
+| launchBrowserTimeout | "launchBrowserTimeout": 1                             | The maximum amount of time (in seconds) to wait for the app to be ready before launching the browser. |
+| launchUrl            | "launchUrl": "{Scheme}://{ServiceHost}:{ServicePort}" | This URL is used when launching the browser. Supported replacement tokens for this string are: <br/><br/> - {Scheme} - Replaced with either "http" or "https" depending on whether SSL is used. <br/><br/> - {ServiceHost} - Usually replaced with "localhost". <br/> When targeting Windows containers on Windows 10 RS3 or older, though, it is replaced with the container's IP. <br/><br/> - {ServicePort} - Usually replaced with either sslPort or httpPort, depending on whether SSL is used. <br/> When targeting Windows containers on Windows 10 RS3 or older, though, it is replaced with either "443" or "80", depending on whether SSL is used. |
+| sslPort              | "sslPort": 44381                                      | This port on the host is mapped to the container's port 443 when launching the container. |
+| useSSL               | "useSSL": true                                        | Indicates whether to use SSL when launching the project. If useSSL is not specified, then SSL is used when sslPort > 0. |
+
+> [!NOTE]
+> If the same settings, for example, DockerfileRunArguments, is found in both the project file and in the launch settings file, the value in the launch settings file takes precedence.
+
+::: moniker-end
+
+::: moniker range=">=vs-2022"
+
+| Setting name         | Example                                               | Description                                                                                                             |
+| -------------------- | ----------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| commandLineArgs      | "commandLineArgs": "--mysetting myvalue"              | These command-line arguments for starting your app are used when launching your project in the container.                                     |
+|DockerfileRunArguments|"dockerfileRunArguments": "-l mylabel=value"|Additional arguments to pass to the [docker run](https://docs.docker.com/engine/reference/commandline/run/) command. Starting in VS 17.3 Preview 2 support for replacement tokens has been added:<br/><br/> - {ProjectDir} - Full path to the project directory. <br/><br/> - {OutDir} - The value of the MSBuild property OutDir.|
 | environmentVariables | "environmentVariables": {<br/>   "ASPNETCORE_URLS": "https://+:443;http://+:80", <br/>   "ASPNETCORE_HTTPS_PORT": "44381" <br/> }                    | These environment variable values are passed to the process when it is launched in the container.                       |
 | httpPort             | "httpPort": 24051                                     | This port on the host is mapped to the container's port 80 when launching the container. |
 | launchBrowser        | "launchBrowser": true                                 | Indicates whether to launch the browser after successfully launching the project.                                       |

--- a/docs/containers/container-msbuild-properties.md
+++ b/docs/containers/container-msbuild-properties.md
@@ -58,7 +58,7 @@ The following project file shows examples of some of these settings.
          set to the same folder as the Dockerfile. -->
     <DockerfileContext>.</DockerfileContext>
     <!-- Set `docker run` arguments to mount a volume -->
-    <DockerfileRunArguments>-v $(pwd)/host-folder:/container-folder:ro</DockerfileRunArguments>
+    <DockerfileRunArguments>-v $(MSBuildProjectDirectory)/host-folder:/container-folder:ro</DockerfileRunArguments>
     <!-- Set `docker build` arguments to add a custom tag -->
     <DockerfileBuildArguments>-t contoso/front-end:v2.0</DockerfileBuildArguments>
   </PropertyGroup>


### PR DESCRIPTION
Update docs for DockerfileRunArguments to remove references to $(pwd) and introduce new tokens available in the launch profile.