### PR TITLE
VSMac 2022 is stable

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -76,7 +76,8 @@
       "monikers": [],
       "moniker_ranges": [
         "vsmac-2017",
-        ">=vsmac-2019"
+        "vsmac-2019",
+        ">=vsmac-2022"
       ],
       "open_to_public_contributors": true,
       "type_mapping": {

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -40,7 +40,7 @@ productDirectory:
           text: Visual Studio 2019 for Mac
         - url: /previous-versions/visualstudio/mac/
           text: Visual Studio 2017 for Mac
-        - url: /visualstudio/releasenotes/vs2019-mac-relnotes
+        - url: /visualstudio/releases/2022/mac-release-notes
           text: Release notes
         - url: https://visualstudio.microsoft.com/vs/mac/
           text: Product page

--- a/mac/index.yml
+++ b/mac/index.yml
@@ -21,7 +21,7 @@ highlightedContent:
       url: ~/ide-tour.md
     - title: Visual Studio for Mac Release Notes
       itemType: whats-new
-      url: /visualstudio/releasenotes/vs2019-mac-relnotes
+      url: /visualstudio/releases/2022/mac-release-notes
     - title: Improve your development skills
       itemType: learn
       url: /learn/

--- a/mac/install-preview.md
+++ b/mac/install-preview.md
@@ -18,7 +18,7 @@ Before a new version of Visual Studio for Mac is officially released, it's avail
 
 Preview releases of Visual Studio for Mac are distributed as an update, rather than through a separate download. Visual Studio for Mac has two updater channels, as described in the [update](update.md) article: **Stable** and **Preview**.
 
-Most preview releases will be available through both the **Preview** channel, but always check the [Preview Release Notes](/visualstudio/releasenotes/vs2019-mac-preview-relnotes) for the most accurate information.
+Most preview releases will be available through both the **Preview** channel, but always check the [Preview Release Notes](/visualstudio/releases/2022/mac-release-notes-preview) for the most accurate information.
 
 To install the preview of Visual Studio for Mac, use the following steps:
 


### PR DESCRIPTION
Point release notes links to it, and make it the default moniker.