### PR TITLE
Fix API typo

### DIFF
--- a/docs/extensibility/toc.yml
+++ b/docs/extensibility/toc.yml
@@ -23,7 +23,7 @@
       href: migration/breaking-api-list.md
     - name: Removed API list
       href: migration/removed-api-list.md
-    - name: Migrated PIA
+    - name: Migrated API
       href: migration/migrated-assemblies.md
     - name: VS SDK messages
       href: vssdk-messages/index.md

--- a/docs/extensibility/vssdk-messages/index.md
+++ b/docs/extensibility/vssdk-messages/index.md
@@ -29,4 +29,4 @@ The following resources might be useful:
 
 - [Update a Visual Studio extension](../migration/update-visual-studio-extension.md)
 - [Breaking API list](../migration/breaking-api-list.md)
-- [Migrated PIA](../migration/migrated-assemblies.md)
+- [Migrated API](../migration/migrated-assemblies.md)


### PR DESCRIPTION
Fixing a typo in the navigation bar for updating an extension for VS 2022.
