### PR TITLE
Update template-parameters.md

### DIFF
--- a/docs/ide/template-parameters.md
+++ b/docs/ide/template-parameters.md
@@ -24,7 +24,7 @@ You can replace values in your template when the template is instantiated. To se
 
 Template parameters are declared in the format $*parameter*$. For example:
 
-- $safeprojectname$
+- $rootnamespace$
 
 - $guid1$
 
@@ -36,10 +36,10 @@ Template parameters are declared in the format $*parameter*$. For example:
 
 1. Set the `ReplaceParameters` attribute of the `ProjectItem` element to `true`.
 
-1. In the code file for the project item, include parameters where appropriate. For example, the following parameter specifies that the safe project name is used for the namespace in a file:
+1. In the code file for the project item, include parameters where appropriate. For example, the following parameter specifies that the root namespace is used for the namespace in a file:
 
    ```csharp
-   namespace $safeprojectname$
+   namespace $rootnamespace$
    ```
 
 ## Reserved template parameters
@@ -53,13 +53,13 @@ The following table lists the reserved template parameters that can be used by a
 |guid[1-10]|A GUID used to replace the project GUID in a project file. You can specify up to 10 unique GUIDs (for example, `guid1`).|
 |itemname|The name of the file in which the parameter is being used.|
 |machinename|The current computer name (for example, Computer01).|
-|projectname|The name provided by the user when the project was created.|
+|projectname|The name provided by the user when the project was created. This parameter applies only to project templates.|
 |registeredorganization|The registry key value from HKLM\Software\Microsoft\Windows NT\CurrentVersion\RegisteredOrganization.|
-|rootnamespace|The root namespace of the current project followed by the subfolder of the current item, with slashes replaced by periods. This parameter applies only to item templates.|
-|defaultnamespace|The root namespace of the current project. This parameter applies only to item templates.|
+|rootnamespace|The root namespace of the current project followed by the subfolder of the current item, with slashes replaced by periods.|
+|defaultnamespace|The root namespace of the current project.|
 |safeitemname|Same as `itemname` but with all unsafe characters and spaces replaced by underscore characters.|
 |safeitemrootname|Same as `safeitemname`.|
-|safeprojectname|The name provided by the user when the project was created but with all unsafe characters and spaces removed.|
+|safeprojectname|The name provided by the user when the project was created but with all unsafe characters and spaces removed. This parameter applies only to project templates.|
 |targetframeworkversion|Current version of the target .NET Framework.|
 |time|The current time in a format that's based on Windows user settings. One example of a time format is DD/MM/YYYY 00:00:00. |
 |specifiedsolutionname|The name of the solution. When "create solution directory" is checked, `specifiedsolutionname` has the solution name. When "create solution directory" is not checked, `specifiedsolutionname` is blank.|


### PR DESCRIPTION
1. \$safeprojectname\$ only works in item template, so change the example in "Declare and enable template parameters" section, use \$rootnamespace\$ instead.
2. \$defaultnamespace\$ and \$rootnamespace\$ works for both item and project templates, so remove "This parameter applies only to item templates."
3. \$safeprojectname\$ and \$projectname\$ only works for project templates, add "This parameter applies only to project templates."



<!--
Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for docs.microsoft.com, see the contributor guide at https://docs.microsoft.com/contribute/.
-->
