### PR TITLE
Fixed typo

### DIFF
--- a/docs/extensibility/commandplacement-element.md
+++ b/docs/extensibility/commandplacement-element.md
@@ -40,7 +40,7 @@ The CommandPlacement element enables buttons, groups, and menus to be included i
 |guid|Required. The guid of the command set, as defined in the [Symbols element](../extensibility/symbols-element.md).|
 |id|Required. The id of the menu, group, or command to be placed, as defined in the `Symbols Element`.|
 |priority|Required. Determines the visual position of the item in its parent element.|
-|Condition|Optional. See [Conditional Aattributes](../extensibility/vsct-xml-schema-conditional-attributes.md).|
+|Condition|Optional. See [Conditional Attributes](../extensibility/vsct-xml-schema-conditional-attributes.md).|
 
 ### Child elements
 


### PR DESCRIPTION
Simple typo fix: "Aattributes" -> "Attributes".
<!--
Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for docs.microsoft.com, see the contributor guide at https://docs.microsoft.com/contribute/.
-->
