### PR TITLE
the typo in the sample was intended

### DIFF
--- a/docs/msbuild/errors/msb3644.md
+++ b/docs/msbuild/errors/msb3644.md
@@ -28,12 +28,12 @@ The first thing to check is that there are no spelling or typographical errors i
 
 ```xml
 	<PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == ''">
-		<TargetFrameworkIdentifier>.NETCOREAPP</TargetFrameworkIdentifier>
+		<TargetFrameworkIdentifier>.NETCORAPP</TargetFrameworkIdentifier>
 		<TargetFrameworkVersion>3.1</TargetFrameworkVersion>
 	</PropertyGroup>
 ```
 
-The issue is that the `TargetFrameworkIdentifier` is misspelled. It should be `.NETCOREAPP`.
+The issue is that the `TargetFrameworkIdentifier` is misspelled. It should be `.NETCOREAPP`, not `.NETCORAPP` (note the missing "e").
 
 When leveraging the [`TargetFrameworks`](/dotnet/core/project-sdk/msbuild-props#targetframeworks) property and multiple target frameworks, ensure that they are separated with the correct delimiter `;`. MSB3644 will occur, for example, when trying to separate frameworks using the `,` delimiter. Here's an example of the correct syntax:
 


### PR DESCRIPTION
There was a recent commit that "fixed" the typo in the TargetFrameworkIdentifier. However, that typo is intended, and fixing it makes that part of the document confusing.