### PR TITLE
Removed note about terminal in VS for Mac

### DIFF
--- a/mac/integrated-terminal.md
+++ b/mac/integrated-terminal.md
@@ -4,16 +4,13 @@ description: "Working with the Integrated Terminal in Visual Studio for Mac."
 author: jmatthiesen
 ms.author: jomatthi
 manager: dominicn
-ms.date: 05/16/2022
+ms.date: 08/15/2022
 ms.topic: how-to
 ms.assetid: EFD53CE9-8174-4FE4-8863-2984D22FD921
 ---
 # Integrated Terminal
 
  [!INCLUDE [Visual Studio for Mac](~/includes/applies-to-version/vs-mac-only.md)]
-
-> [!NOTE] 
-> The Integrated Terminal is currently not available in Simplified Chinese or Traditional Chinese locales. We're fixing bugs related to Chinese character input and this feature  will be available soon. 
 
 You can open an integrated terminal window in Visual Studio for Mac, starting at the root of your solution. The terminal can be useful for different kinds of situations – running front-end tasks (for example: npm, ng, or vue), managing containers, running advanced git commands, executing Entity Framework commands, viewing dotnet CLI output, adding NuGet packages, and more. 
 


### PR DESCRIPTION
Removed note about terminal being missing in Chinese locales. Product was updated to include the feature again in 17.3.
