### PR TITLE
Update Roslyn's Visual Studio version mapping table.

### DIFF
--- a/docs/extensibility/roslyn-version-support.md
+++ b/docs/extensibility/roslyn-version-support.md
@@ -23,8 +23,22 @@ As an example, to ensure that your custom analyzer works on all versions of Visu
 
 | Roslyn package version | Minimum supported Visual Studio version |
 | - | - |
-| 4.x | Visual Studio 2022 |
-| 3.x | Visual Studio 2019 |
+| 4.3.0 | Visual Studio 2022 version 17.3 |
+| 4.2.0 | Visual Studio 2022 version 17.2 |
+| 4.1.0 | Visual Studio 2022 version 17.1 |
+| 4.0.1 | Visual Studio 2022 RTM |
+| 3.11.0 | Visual Studio 2019 version 16.11 |
+| 3.10.0 | Visual Studio 2019 version 16.10 |
+| 3.9.0 | Visual Studio 2019 version 16.9 |
+| 3.8.0 | Visual Studio 2019 version 16.8 |
+| 3.7.0 | Visual Studio 2019 version 16.7 |
+| 3.6.0 | Visual Studio 2019 version 16.6 |
+| 3.5.0 | Visual Studio 2019 version 16.5 |
+| 3.4.0 | Visual Studio 2019 version 16.4 |
+| 3.3.1 | Visual Studio 2019 version 16.3 |
+| 3.2.1 | Visual Studio 2019 version 16.2 |
+| 3.1.0 | Visual Studio 2019 version 16.1 |
+| 3.0.0 | Visual Studio 2019 RTM |
 | 2.10.0 | Visual Studio 2017 version 15.9 |
 | 2.9.0 | Visual Studio 2017 version 15.8 |
 | 2.8.2 | Visual Studio 2017 version 15.7 |


### PR DESCRIPTION
Updates Roslyn version table with specific package numbers for VS2019 and VS2022.

<!--
Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for docs.microsoft.com, see the contributor guide at https://docs.microsoft.com/contribute/.
-->
