### PR TITLE
MSBuild: Warn on SDK reference refactoring

### DIFF
--- a/docs/msbuild/how-to-use-project-sdk.md
+++ b/docs/msbuild/how-to-use-project-sdk.md
@@ -93,6 +93,9 @@ Explicitly including the imports in your project allows you full control over th
 
 When using the `<Import/>` element, you can specify an optional `Version` attribute as well. For example, you can specify `<Import Project="Sdk.props" Sdk="My.Custom.Sdk" Version="1.2.3" />`.
 
+> [!WARNING]
+> If you are changing project to use `<Import/>` elements, make sure you add both `.props` and `.targets` imports and that you remove the SDK from the `<Project/>` element and `<Sdk/>` elements. Failure to do so will result in doubled imports and an `MSB4011` warning.
+
 ## How project SDKs are resolved
 
 When evaluating the import, MSBuild dynamically resolves the path to the project SDK based on the name and version you specified.  MSBuild also has a list of registered SDK resolvers, which are plug-ins that locate project SDKs on your machine. These plug-ins include:

--- a/docs/msbuild/how-to-use-project-sdk.md
+++ b/docs/msbuild/how-to-use-project-sdk.md
@@ -45,53 +45,53 @@ During evaluation of the project, MSBuild adds implicit imports at the top and b
 
 There are three ways to reference a project SDK:
 
-- Use the `Sdk` attribute on the `<Project/>` element:
+### Use the `Sdk` attribute on the `<Project/>` element
 
-    ```xml
-    <Project Sdk="My.Custom.Sdk">
-        ...
-    </Project>
-    ```
+```xml
+<Project Sdk="My.Custom.Sdk">
+    ...
+</Project>
+```
 
-    An implicit import is added to the top and bottom of the project as discussed previously.
-    
-    To specify a specific version of the SDK, append it to the `Sdk` attribute:
+An implicit import is added to the top and bottom of the project as discussed previously.
 
-    ```xml
-    <Project Sdk="My.Custom.Sdk/1.2.3">
-        ...
-    </Project>
-    ```
+To specify a specific version of the SDK, append it to the `Sdk` attribute:
 
-- Use the top-level `<Sdk/>` element:
+```xml
+<Project Sdk="My.Custom.Sdk/1.2.3">
+    ...
+</Project>
+```
 
-    ```xml
-    <Project>
-        <Sdk Name="My.Custom.Sdk" Version="1.2.3" />
-        ...
-    </Project>
-   ```
+### Use the top-level `<Sdk/>` element
 
-   An implicit import is added to the top and bottom of the project as discussed previously.
-   
-   The `Version` attribute is not required.
+```xml
+<Project>
+    <Sdk Name="My.Custom.Sdk" Version="1.2.3" />
+    ...
+</Project>
+```
 
-- Use the `<Import/>` element anywhere in your project:
+An implicit import is added to the top and bottom of the project as discussed previously.
 
-    ```xml
-    <Project>
-        <PropertyGroup>
-            <MyProperty>Value</MyProperty>
-        </PropertyGroup>
-        <Import Project="Sdk.props" Sdk="My.Custom.Sdk" />
-        ...
-        <Import Project="Sdk.targets" Sdk="My.Custom.Sdk" />
-    </Project>
-   ```
+The `Version` attribute is not required.
 
-   Explicitly including the imports in your project allows you full control over the order.
+### Use the `<Import/>` element anywhere in your project
 
-   When using the `<Import/>` element, you can specify an optional `Version` attribute as well. For example, you can specify `<Import Project="Sdk.props" Sdk="My.Custom.Sdk" Version="1.2.3" />`.
+```xml
+<Project>
+    <PropertyGroup>
+        <MyProperty>Value</MyProperty>
+    </PropertyGroup>
+    <Import Project="Sdk.props" Sdk="My.Custom.Sdk" />
+    ...
+    <Import Project="Sdk.targets" Sdk="My.Custom.Sdk" />
+</Project>
+```
+
+Explicitly including the imports in your project allows you full control over the order.
+
+When using the `<Import/>` element, you can specify an optional `Version` attribute as well. For example, you can specify `<Import Project="Sdk.props" Sdk="My.Custom.Sdk" Version="1.2.3" />`.
 
 ## How project SDKs are resolved
 


### PR DESCRIPTION
I wanted to link to the docs that say this in response to https://github.com/dotnet/msbuild/issues/4038#issuecomment-1240480849 but they didn't exist.

Basically there's an easy-to-imagine error where you do something like

```diff
@@ -5,4 +5,7 @@
     <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+
+  <Target Name="AfterBuild" />
 </Project>
```

When the correct change requires removing the `Project`'s `Sdk` attribute.

```diff
@@ -1,8 +1,12 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project>
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+
+  <Target Name="AfterBuild" />
 </Project>
```

If you do only the former you get an MSB4011.

The diff is mostly whitespace changes, due to unindenting to get subheads instead of a list.

<!--
Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for docs.microsoft.com, see the contributor guide at https://docs.microsoft.com/contribute/.
-->
