### PR TITLE
Update remote-debugger-port-assignments.md

### DIFF
--- a/docs/debugger/remote-debugger-port-assignments.md
+++ b/docs/debugger/remote-debugger-port-assignments.md
@@ -59,7 +59,7 @@ This port is configurable from the command line: **Msvsmon /wow64port \<port num
 
 ## Remote Debugger Ports on Microsoft Azure App Service
 
-Remote debugger ports are configurable. Currently, Azure App Service does not use the default ports associated with your version of Visual Studio. Azure App Service uses port 4024 (64-bit) and 4025 (for a 32-bit process) for the remote debugger.
+Remote debugger ports are configurable. Currently, Azure App Service does not use the default ports associated with your version of Visual Studio. Azure App Service uses port 4024 for the remote debugger.
 
 ## The Discovery Port
 


### PR DESCRIPTION
Hi, I am the engineer from App Service team and noticed this description is wrong. we use port 4024 for both 32bit and 64bit.



<!--
Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for docs.microsoft.com, see the contributor guide at https://docs.microsoft.com/contribute/.
-->
