### PR TITLE
Update quick-start to use Assert.ThrowsException

### DIFF
--- a/docs/test/quick-start-test-driven-development-with-test-explorer.md
+++ b/docs/test/quick-start-test-driven-development-with-test-explorer.md
@@ -157,18 +157,10 @@ To improve our confidence that the code works in all cases, add tests that try a
 
     ```csharp
     [TestMethod]
-    public void RooterTestNegativeInputx()
+    public void RooterTestNegativeInput()
     {
         Rooter rooter = new Rooter();
-        try
-        {
-            rooter.SquareRoot(-10);
-        }
-        catch (System.ArgumentOutOfRangeException)
-        {
-            return;
-        }
-        Assert.Fail();
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => rooter.SquareRoot(-1));
     }
     ```
 


### PR DESCRIPTION
In Walkthrough: Test-driven development using Test Explorer, replaces try/catch pattern with `Assert.ThrowsException`.
