### PR TITLE
Fix `MatchFileNameOnly` parameter default value

### DIFF
--- a/docs/msbuild/findinlist-task.md
+++ b/docs/msbuild/findinlist-task.md
@@ -35,7 +35,7 @@ In a specified list, finds an item that has the matching itemspec.
 |`ItemFound`|Optional <xref:Microsoft.Build.Framework.ITaskItem>`[]` read-only output parameter.<br /><br /> The first matching item found in the list, if any.|
 |`ItemSpecToFind`|Required `String` parameter.<br /><br /> The itemspec to search for.|
 |`List`|Required <xref:Microsoft.Build.Framework.ITaskItem>`[]` parameter.<br /><br /> The list in which to search for the itemspec.|
-|`MatchFileNameOnly`|Optional `Boolean` parameter.<br /><br /> If `true`, match against just the file name part of the itemspec; otherwise, match against the whole itemspec. Default value is `true`.|
+|`MatchFileNameOnly`|Optional `Boolean` parameter.<br /><br /> If `true`, match against just the file name part of the itemspec; otherwise, match against the whole itemspec. Default value is `false`.|
 
 ## Remarks
 


### PR DESCRIPTION
According to the [FindInList.cs](https://github.com/dotnet/msbuild/blob/b6420ea6bd0a1b4f71cdf9bc49932bbcacdbdc35/src/Tasks/FindInList.cs#L40) file at this point of history, the default value of `MatchFileNameOnly` is false.



<!--
Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for Microsoft Learn, see the [contributor guide](https://learn.microsoft.com/contribute/).

When your PR is ready for review, add a comment with the text #sign-off to the Conversation tab.
-->
