### PR TITLE
Fix documentation of menu item to reflect current UI

### DIFF
--- a/docs/extensibility/creating-an-extension-with-a-menu-command.md
+++ b/docs/extensibility/creating-an-extension-with-a-menu-command.md
@@ -31,7 +31,7 @@ Starting in Visual Studio 2015, you do not install the Visual Studio SDK from th
 
 1. Create a VSIX project named **FirstMenuCommand**. You can find the VSIX project template in the **New Project** dialog by searching for "vsix".
 
-2. When the project opens, add a custom command item template named **FirstCommand**. In the **Solution Explorer**, right-click the project node and select **Add** > **New Item**. In the **Add New Item** dialog, go to **Visual C#** > **Extensibility** and select **Command**. In the **Name** field at the bottom of the window, change the command file name to *FirstCommand.cs*.
+2. When the project opens, add a custom command item template named **FirstCommand**. In the **Solution Explorer**, right-click the project node and select **Add** > **New Item**. In the **Add New Item** dialog, go to **C# Items** > **Extensibility** and select **Command**. In the **Name** field at the bottom of the window, change the command file name to *FirstCommand.cs*.
 
 3. Build the project and start debugging.
 


### PR DESCRIPTION
This menu item is called "C# items". The formerly mentioned "Visual C#" still exists, but contains different subitems

<img width="521" alt="image" src="https://user-images.githubusercontent.com/3852580/202244594-e93e6e8a-8eac-4125-85fe-ccb618212c53.png">


<!--
Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for Microsoft Learn, see the [contributor guide](https://learn.microsoft.com/contribute/).

When your PR is ready for review, add a comment with the text #sign-off to the Conversation tab.
-->
