### PR TITLE
Update disable-dpi-awareness.md

### DIFF
--- a/docs/designers/disable-dpi-awareness.md
+++ b/docs/designers/disable-dpi-awareness.md
@@ -36,7 +36,7 @@ When you open a form in the **Windows Forms Designer** on an HDPI monitor, Visua
 If you aren't working in the designer and don't need to adjust the layout of your form, you can ignore the information bar and continue working in the code editor or in other types of designers. (You can also [disable notifications](#disable-notifications) so that the information bar doesn't continue to appear.) Only the **Windows Forms Designer** is affected.
 
 > [!TIP]
-> If you've closed the information bar but you still want restart Visual Studio with 100% scaling, you can. [Use the DevEnv.exe tool](#use-the-devenvexe-tool) to do so.
+> If you've closed the information bar but you still want to restart Visual Studio with 100% scaling, you can. [Use the DevEnv.exe tool](#use-the-devenvexe-tool) to do so.
 
 ## Resolve HDPI display problems
 


### PR DESCRIPTION
Missing word. BEFORE: If you've closed the information bar but you still want restart Visual Studio with 100% scaling, you can. Use the DevEnv.exe tool to do so. AFTER: If you've closed the information bar but you still want to restart Visual Studio with 100% scaling, you can. Use the DevEnv.exe tool to do so.



<!--
Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for Microsoft Learn, see the [contributor guide](https://learn.microsoft.com/contribute/).

When your PR is ready for review, add a comment with the text #sign-off to the Conversation tab.
-->
