### PR TITLE
Adding version specifier to paragraph on filters

### DIFF
--- a/docs/test/using-code-coverage-to-determine-how-much-code-is-being-tested.md
+++ b/docs/test/using-code-coverage-to-determine-how-much-code-is-being-tested.md
@@ -73,6 +73,7 @@ You can also have the results displayed for lines by choosing **Add/Remove Colum
 > [!TIP]
 > A line of code can contain more than one code block. If this is the case, and the test run exercises all the code blocks in the line, it is counted as one line. If some but not all code blocks in the line are exercised, it is counted as a partial line.
 
+::: moniker range=">=vs-2022"
 ## Filter code coverage results
 
 The **Code Coverage Results** window usually shows the result for the entire solution. The results can be filtered to show the results for only the files that have been updated in the current branch. 
@@ -86,6 +87,7 @@ From the search box in the **Code Coverage Results** window, there are several w
 - To **Show 100% fully covered**, enter "Covered (%Lines)":"100" in the search box.
 - To **Show (>0% && < 100%) partially covered**, enter "Partially Covered (%Lines)":"<##" replacing the ## with the percentage covered.
 - To **Show 0% covered**, enter "Not Covered (%Lines)":"0" in the search box.
+::: moniker-end
 
 ## Manage code coverage results
 


### PR DESCRIPTION
Didn't realize the same page was used for different versions. Need to remove the filters from VS2019



<!--
Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for Microsoft Learn, see the [contributor guide](https://learn.microsoft.com/contribute/).

When your PR is ready for review, add a comment with the text #sign-off to the Conversation tab.
-->
