### PR TITLE
Add note that the Just-In-Time component is required

### DIFF
--- a/docs/debugger/debug-using-the-just-in-time-debugger.md
+++ b/docs/debugger/debug-using-the-just-in-time-debugger.md
@@ -26,6 +26,7 @@ Just-In-Time debugging works for Windows desktop apps. It does not work for Univ
 
 ## <a name="BKMK_Enabling"></a> Enable or disable Just-In-Time debugging in Visual Studio
 
+
 >[!NOTE]
 >To enable or disable Just-In-Time debugging, you must be running Visual Studio as an administrator. Enabling or disabling Just-In-Time debugging sets a registry key, and administrator privileges may be required to change that key. To open Visual Studio as an administrator, right-click the Visual Studio app and choose **Run as administrator**.
 
@@ -36,6 +37,10 @@ You can configure Just-In-Time debugging from the Visual Studio **Tools** > **Op
 1. On the **Tools** or **Debug** menu, select **Options** > **Debugging** > **Just-In-Time**.
 
    ![Enable or disable JIT debugging](../debugger/media/dbg-jit-enable-or-disable.png "Enable or disable JIT debugging")
+
+
+>[!NOTE]
+>If the Just-In-Time menu option is not shown ensure the Just-In-Time debugger is installed using the Visual Studio Installer.
 
 1. In the **Enable Just-In-Time debugging for these types of code** box, select the types of code you want Just-In-Time debugging to debug: **Managed**, **Native**, and/or **Script**.
 

--- a/docs/debugger/debug-using-the-just-in-time-debugger.md
+++ b/docs/debugger/debug-using-the-just-in-time-debugger.md
@@ -40,7 +40,7 @@ You can configure Just-In-Time debugging from the Visual Studio **Tools** > **Op
 
 
 >[!NOTE]
->If the Just-In-Time menu option is not shown ensure the Just-In-Time debugger is installed using the Visual Studio Installer.
+>If the Just-In-Time menu option is not shown, make sure the Just-In-Time debugger is installed using the Visual Studio Installer.
 
 1. In the **Enable Just-In-Time debugging for these types of code** box, select the types of code you want Just-In-Time debugging to debug: **Managed**, **Native**, and/or **Script**.
 


### PR DESCRIPTION
The Just-In-Time debugger is only installed if you install certain feature packages for Visual Studio (E.G. C# development or C++ Desktop development). If it is not installed the Just-In-Time section is missing from Options > Debug. It would be helpful to note that if this doesnt exist the user should ensure the component is installed. (Or potentially update VS to explain that there are no options because it is not installed).

I was trying to debug an IIS website crash, and so had only installed the ASP.NET development module. Without clicking on another feature package in the installer and seeing that there is a Just-In-Time debugger option that is added it is not obvious that this is a component that needs to be installed.
