### PR TITLE
Remove References section from JavaScript tools/options documentation

### DIFF
--- a/docs/ide/reference/options-text-editor-javascript-intellisense.md
+++ b/docs/ide/reference/options-text-editor-javascript-intellisense.md
@@ -20,7 +20,7 @@ ms.workload:
 
  [!INCLUDE [Visual Studio](~/includes/applies-to-version/vs-windows-only.md)]
 
-Use the **IntelliSense** page of the **Options** dialog box to modify settings that affect the behavior of IntelliSense for JavaScript. You can access the **IntelliSense** page by choosing **Tools** > **Options** on the  menu bar, and then expanding **Text Editor** > **JavaScript/TypeScript** > **IntelliSense.**
+Use the **IntelliSense** page of the **Options** dialog box to modify settings that affect the behavior of IntelliSense for JavaScript. You can access the **IntelliSense** page by choosing **Tools** > **Options** on the  menu bar, and then expanding **Text Editor** > **JavaScript/TypeScript** > **IntelliSense** > **General**.
 
 [!INCLUDE[note_settings_general](../../data-tools/includes/note_settings_general_md.md)]
 
@@ -35,44 +35,6 @@ You can use these options to change the behavior of IntelliSense statement compl
 **Only use Tab or Enter to commit**
 
 When you select this check box, the JavaScript code editor appends statements with items selected in the completion list only after you choose the **Tab** or **Enter** key. When you deselect this check box, other characters – such as a period, comma, colon, open parenthesis, and open brace ({) – can also append statements with the selected items.
-
-## References
-
-You can use these options to specify the types of IntelliSense .js files that are in scope for different JavaScript project types. The IntelliSense references are typically used to provide IntelliSense support for global objects. You can also use this page to set the loading order for scripts that must be loaded at run time, and to add IntelliSense extension files.
-
-### UIElement list
-
-**Reference groups**
-
-This option specifies the reference group type. Three reference groups are supported:
-
-You can use pre-defined reference groups to specify that particular IntelliSense .js files are in scope for different JavaScript projects. Four reference groups are available:
-
-- Implicit (Windows *version*), for [!INCLUDE[win8_appname_long](../../debugger/includes/win8_appname_long_md.md)] apps using JavaScript. Files included in this group are in scope for every .js file opened in the Code Editor for [!INCLUDE[win8_appname_long](../../debugger/includes/win8_appname_long_md.md)] apps using JavaScript.
-
-- Implicit (Web), for HTML5 projects. Files included in this group are in scope for every .js file opened in the Code Editor for these project types.
-
-- Dedicated worker reference groups, for HTML5 web workers. Files specified in this group are in scope for .js files that have an explicit reference to a dedicated worker reference group.
-
-- Generic, for other JavaScript project types.
-
-**Included files**
-
-This option specifies the order in which files are loaded into the context of the language service. You can configure the order by using the **Remove**, **Move Up**, and **Move Down** buttons. For IntelliSense to work correctly, a file that is dependent on another must be loaded after the other file.
-
-> [!CAUTION]
-> If an object is defined unconditionally in two or more implicit references, the last reference in this list will be used to define the object.
-
-**Add a reference to the group**
-
-This option provides a way to add additional IntelliSense .js files by browsing to the appropriate files.
-
-**Download remote references (e.g. http://) for files in the miscellaneous files project**
-
-When this check box is selected, and if you have a JavaScript file opened outside the context of a project, Visual Studio downloads remote JavaScript files referenced in the file for the purpose of providing IntelliSense information. If this option is selected, files are downloaded when you include them as a reference in your JavaScript file.
-
-> [!NOTE]
-> For web projects, remote files referenced in your project are downloaded by default.
 
 ## See also
 

--- a/docs/ide/reference/options-text-editor-javascript-intellisense.md
+++ b/docs/ide/reference/options-text-editor-javascript-intellisense.md
@@ -2,7 +2,7 @@
 title: Options, Text Editor, JavaScript, IntelliSense
 description: Learn how to use the IntelliSense page of the Options dialog box to modify settings that affect the behavior of IntelliSense for JavaScript.
 ms.custom: SEO-VS-2020
-ms.date: 10/29/2018
+ms.date: 01/16/2023
 ms.technology: vs-javascript
 ms.topic: reference
 f1_keywords:


### PR DESCRIPTION

<!--
Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for Microsoft Learn, see the [contributor guide](https://learn.microsoft.com/contribute/).

When your PR is ready for review, add a comment with the text #sign-off to the Conversation tab.
-->

Removing the "References" section from the JS/TS tools/options documentation since it doesn't exist anymore.