### PR TITLE
Correct VS 17.4.33403.182 display version number

### DIFF
--- a/docs/install/visual-studio-build-numbers-and-release-dates.md
+++ b/docs/install/visual-studio-build-numbers-and-release-dates.md
@@ -26,7 +26,7 @@ The following table lists the build numbers and release dates for Visual Studio 
 
 | **Version**| **Channel** | **Release date** | **Build version** |
 | ---------------------- | ----------- | ---------------- | ----------------- |
-| 17.4.4  | Release | February 14, 2023 | 17.4.33403.182 |
+| 17.4.5  | Release | February 14, 2023 | 17.4.33403.182 |
 | 17.2.13 | Release | February 14, 2023 | 17.2.33402.178 |
 | 17.0.19 | Release | February 14, 2023 | 17.0.33402.176 |
 | 17.5.0  | Preview 6 | February 7, 2023 | 17.5.33402.96 |


### PR DESCRIPTION
This change corrects the display version number for 17.4.33403.182 to 17.4.5.

VSWhere identifies build version 17.4.33403.182 with the 17.4.5 display version. The entry on February 14, 2023 incorrectly identifies it as 17.4.4, which introduced an incorrect duplicate entry for 17.4.4.

Addresses #8969.



<!--
Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for Microsoft Learn, see the [contributor guide](https://learn.microsoft.com/contribute/).

When your PR is ready for review, add a comment with the text #sign-off to the Conversation tab.
-->
