### PR TITLE
Update how-to-change-the-build-output-directory.md

### DIFF
--- a/docs/ide/how-to-change-the-build-output-directory.md
+++ b/docs/ide/how-to-change-the-build-output-directory.md
@@ -171,7 +171,6 @@ By default, [!INCLUDE[vsprvs](../code-quality/includes/vsprvs_md.md)] builds eac
 
    See [Specify custom build events](specifying-custom-build-events-in-visual-studio.md).
 
-   The obj folder is not created when you build from the MSBuild command line.
 
 ## See also
 


### PR DESCRIPTION
Removed incorrect statement about obj folder creation when using MSBuild from command line.



<!--
Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for Microsoft Learn, see the [contributor guide](https://learn.microsoft.com/contribute/).

When your PR is ready for review, add a comment with the text #sign-off to the Conversation tab.
-->
