### PR TITLE
Fix typo in how-to-exclude-files-from-the-build.md

### DIFF
--- a/docs/msbuild/how-to-exclude-files-from-the-build.md
+++ b/docs/msbuild/how-to-exclude-files-from-the-build.md
@@ -31,7 +31,7 @@ In a project file you can use wildcards to include all the files in one director
 <JPGFile Include="Images\**\*.jpg"/>
 ```
 
- If you have used wildcards to include all the files in one directory or a nested set of directories as inputs for a build, there might be one or more files in the directory or one directory in the a nested set of directories that you do not want to include. To exclude an item from the item list, use the `Exclude` attribute.
+ If you have used wildcards to include all the files in one directory or a nested set of directories as inputs for a build, there might be one or more files in the directory or one directory in the nested set of directories that you do not want to include. To exclude an item from the item list, use the `Exclude` attribute.
 
 #### To include all *.cs* or *.vb* files except *Form2*
 


### PR DESCRIPTION
The sentence:

> ...in the **a** nested...

Should read:

> ...in the nested...



<!--
Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for Microsoft Learn, see the [contributor guide](https://learn.microsoft.com/contribute/).

When your PR is ready for review, add a comment with the text #sign-off to the Conversation tab.
-->
