### PR TITLE
Add note about 'winget install' not updating VS

### DIFF
--- a/docs/install/use-command-line-parameters-to-install-visual-studio.md
+++ b/docs/install/use-command-line-parameters-to-install-visual-studio.md
@@ -272,7 +272,7 @@ Of course, you can also just include components directly during the initial inst
   winget install --id Microsoft.VisualStudio.2022.Community --override "--quiet --add Microsoft.Visualstudio.Workload.Azure"
   ```
 
-If you already have Visual Studio installed on your machine, then it's not possible to use winget's `--override` switch alongside winget's `upgrade` command. This means that you can't use Visual Studio's `--config` or `--add` parameters to modify an existing installation and add components to it.  
+If you already have Visual Studio installed on your machine, then it's not possible to use winget's `--override` switch alongside winget's `install` or `upgrade` commands. This means that you can't use Visual Studio's `--config` or `--add` parameters to modify an existing installation and add components to it.  
 
 Remember that Visual Studio installations and updates require administrator privileges, so winget will prompt you to elevate your privileges if necessary to complete the command. Also, it's not currently possible to use winget to install multiple editions (that is, different SKUs) or multiple instances of the same SKU at the same time on a client machine. 
 


### PR DESCRIPTION
The winget section gives several examples of the 'winget install' command but then gives a caveat on the 'winget upgrade' command. From testing, the 'winget install' command is has the same limitation of not "modify an existing installation and add components to it"



<!--
Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for Microsoft Learn, see the [contributor guide](https://learn.microsoft.com/contribute/).

When your PR is ready for review, add a comment with the text #sign-off to the Conversation tab.
-->
