### PR TITLE
MSBuild: specify TaskHostFactory is short-lived

### DIFF
--- a/docs/msbuild/how-to-configure-targets-and-tasks.md
+++ b/docs/msbuild/how-to-configure-targets-and-tasks.md
@@ -96,6 +96,8 @@ Before it runs a task, MSBuild checks to see whether it is designated to run in 
 </UsingTask>
 ```
 
+When `TaskHostFactory` is specified explicitly, the process that runs the task is short-lived. This allows the operating system to clean up all resources related to the task immediately after it executes. For this reason, specify `TaskHostFactory` when referencing tasks built in the same build process as their use, to avoid file-in-use errors when updating the task assembly after a build.
+
 ## Phantom task parameters
 
 Like any other task parameters, `MSBuildRuntime` and `MSBuildArchitecture` can be set from build properties.


### PR DESCRIPTION
In some offline discussion, @jaredpar pointed out that the TaskHostFactory docs didn't specify that the TaskHost node wouldn't live on past the build. It has since 16.6 (https://github.com/dotnet/msbuild/pull/5144), so document that.



<!--
Thanks for contributing to the Visual Studio documentation.

Note: Internal Microsoft employees and vendors should use the private repo, https://github.com/MicrosoftDocs/visualstudio-docs-pr. You must be a member of the MicrosoftDocs GitHub organization. To join, see https://review.learn.microsoft.com/help/get-started/setup-github?branch=main#3-join-microsoftdocs-and-other-organizations.

Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for Microsoft Learn, see the [contributor guide](https://learn.microsoft.com/contribute/).

When your PR is ready for review, add a comment with the text #sign-off to the Conversation tab.
-->
