### PR TITLE
Typo "Excute" → "Execute"

### DIFF
--- a/docs/extensibility/changing-the-text-of-a-menu-command.md
+++ b/docs/extensibility/changing-the-text-of-a-menu-command.md
@@ -63,7 +63,7 @@ The following steps show how to change the text label of a menu command by using
         commandService = commandService ?? throw new ArgumentNullException(nameof(commandService));
         
         var menuCommandID = new CommandID(CommandSet, CommandId);
-        var menuItem = new OleMenuCommand(this.Excute, menuCommandID);
+        var menuItem = new OleMenuCommand(this.Execute, menuCommandID);
         menuItem.BeforeQueryStatus += new EventHandler(OnBeforeQueryStatus);
         commandService.AddCommand(menuItem);
     }


### PR DESCRIPTION
Typo in the sample code (`this.Excute` → `this.Execute`)
[https://learn.microsoft.com/en-us/visualstudio/extensibility/changing-the-text-of-a-menu-command](https://learn.microsoft.com/en-us/visualstudio/extensibility/changing-the-text-of-a-menu-command)

<!--
Thanks for contributing to the Visual Studio documentation.

Note: Internal Microsoft employees and vendors should use the private repo, https://github.com/MicrosoftDocs/visualstudio-docs-pr. You must be a member of the MicrosoftDocs GitHub organization. To join, see https://review.learn.microsoft.com/help/get-started/setup-github?branch=main#3-join-microsoftdocs-and-other-organizations.

Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for Microsoft Learn, see the [contributor guide](https://learn.microsoft.com/contribute/).

When your PR is ready for review, add a comment with the text #sign-off to the Conversation tab.
-->
