### PR TITLE
Add missing options to CompileAs MSBuild Property

### DIFF
--- a/docs/msbuild/cl-task.md
+++ b/docs/msbuild/cl-task.md
@@ -166,7 +166,13 @@ Wraps the Microsoft C++ compiler tool, *cl.exe*. The compiler produces executabl
 
   - **CompileAsCpp** - **/TP**
 
-    For more information, see [/Tc, /Tp, /TC, /TP (Specify source file type)](/cpp/build/reference/tc-tp-tc-tp-specify-source-file-type).
+  - **CompileAsCppModule** - **/interface**
+
+  - **CompileAsCppModuleInternalPartition** - **/internalPartition**
+
+  - **CompileAsHeaderUnit** - **/exportHeader**
+
+    For more information, see [/Tc, /Tp, /TC, /TP (Specify source file type)](/cpp/build/reference/tc-tp-tc-tp-specify-source-file-type), [/interface (Treat the input file as a module interface unit)](cpp/build/reference/interface), [/internalPartition (Treat the input file as an internal partition unit)](/cpp/build/reference/internal-partition) and [/exportHeader (Create header units)](/cpp/build/reference/module-exportheader).
 
 - **CompileAsManaged**
 

--- a/docs/msbuild/cl-task.md
+++ b/docs/msbuild/cl-task.md
@@ -172,7 +172,7 @@ Wraps the Microsoft C++ compiler tool, *cl.exe*. The compiler produces executabl
 
   - **CompileAsHeaderUnit** - **/exportHeader**
 
-    For more information, see [/Tc, /Tp, /TC, /TP (Specify source file type)](/cpp/build/reference/tc-tp-tc-tp-specify-source-file-type), [/interface (Treat the input file as a module interface unit)](cpp/build/reference/interface), [/internalPartition (Treat the input file as an internal partition unit)](/cpp/build/reference/internal-partition) and [/exportHeader (Create header units)](/cpp/build/reference/module-exportheader).
+    For more information, see [/Tc, /Tp, /TC, /TP (Specify source file type)](/cpp/build/reference/tc-tp-tc-tp-specify-source-file-type), [/interface (Treat the input file as a module interface unit)](/cpp/build/reference/interface), [/internalPartition (Treat the input file as an internal partition unit)](/cpp/build/reference/internal-partition) and [/exportHeader (Create header units)](/cpp/build/reference/module-exportheader).
 
 - **CompileAsManaged**
 


### PR DESCRIPTION
Visual Studio 2020 exposes some C++20 module and header-unit related options for C++ files via the "Compile As" option in the Advanced tab, that are missing from the MSBuild documentation.



<!--
Thanks for contributing to the Visual Studio documentation.

Note: Internal Microsoft employees and vendors should use the private repo, https://github.com/MicrosoftDocs/visualstudio-docs-pr. You must be a member of the MicrosoftDocs GitHub organization. To join, see https://review.learn.microsoft.com/help/get-started/setup-github?branch=main#3-join-microsoftdocs-and-other-organizations.

Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for Microsoft Learn, see the [contributor guide](https://learn.microsoft.com/contribute/).

When your PR is ready for review, add a comment with the text #sign-off to the Conversation tab.
-->
