### PR TITLE
The Exec task calls /bin/sh on Linux

### DIFF
--- a/docs/msbuild/exec-task.md
+++ b/docs/msbuild/exec-task.md
@@ -51,7 +51,7 @@ The following table describes the parameters for the `Exec` task.
 
 This task is useful when a specific MSBuild task for the job that you want to perform is not available. However, the `Exec` task, unlike a more specific task, cannot do additional processing or conditional operations based on the result of the tool or command that it runs.
 
-The `Exec` task calls *cmd.exe* instead of directly invoking a process.
+Instead of directly invoking a process, the `Exec` task calls *cmd.exe* or */bin/sh* depending on the OS.
 
 The parameters `IgnoreExitCode` and `IgnoreStandardErrorWarningFormat` affect the conditions under which the task returns `false`, indicating an error. With the default settings (`false` for both), the `Exec` task indicates a failure (returns `false`) either if the executable has a non-zero exit code, or if a diagnostic message is found in the executable's standard error stream. If you only want `Exec` to indicate failure if the executable returns a non-zero exit code, then set `IgnoreStandardErrorWarningFormat` to `true`.
 

--- a/docs/msbuild/exec-task.md
+++ b/docs/msbuild/exec-task.md
@@ -51,7 +51,7 @@ The following table describes the parameters for the `Exec` task.
 
 This task is useful when a specific MSBuild task for the job that you want to perform is not available. However, the `Exec` task, unlike a more specific task, cannot do additional processing or conditional operations based on the result of the tool or command that it runs.
 
-Instead of directly invoking a process, the `Exec` task calls *cmd.exe* or */bin/sh* depending on the OS.
+Instead of directly invoking a process, the `Exec` task calls *cmd.exe* or */bin/sh*, depending on the operating system.
 
 The parameters `IgnoreExitCode` and `IgnoreStandardErrorWarningFormat` affect the conditions under which the task returns `false`, indicating an error. With the default settings (`false` for both), the `Exec` task indicates a failure (returns `false`) either if the executable has a non-zero exit code, or if a diagnostic message is found in the executable's standard error stream. If you only want `Exec` to indicate failure if the executable returns a non-zero exit code, then set `IgnoreStandardErrorWarningFormat` to `true`.
 

--- a/docs/msbuild/exec-task.md
+++ b/docs/msbuild/exec-task.md
@@ -51,7 +51,7 @@ The following table describes the parameters for the `Exec` task.
 
 This task is useful when a specific MSBuild task for the job that you want to perform is not available. However, the `Exec` task, unlike a more specific task, cannot do additional processing or conditional operations based on the result of the tool or command that it runs.
 
-Instead of directly invoking a process, the `Exec` task calls *cmd.exe* or */bin/sh*, depending on the operating system.
+Instead of directly invoking a process, the `Exec` task calls *cmd.exe*  on Windows, or *sh* otherwise.
 
 The parameters `IgnoreExitCode` and `IgnoreStandardErrorWarningFormat` affect the conditions under which the task returns `false`, indicating an error. With the default settings (`false` for both), the `Exec` task indicates a failure (returns `false`) either if the executable has a non-zero exit code, or if a diagnostic message is found in the executable's standard error stream. If you only want `Exec` to indicate failure if the executable returns a non-zero exit code, then set `IgnoreStandardErrorWarningFormat` to `true`.
 


### PR DESCRIPTION
I was wondering how the Exec task works on Linux so I read [the source code](https://github.com/dotnet/msbuild/blob/main/src/Tasks/Exec.cs) and found it calls `/bin/sh` (rather than, say `bash`) with the specified command.

Therefore I think it's worth noting that the Exec task calls /bin/sh on Linux on the documentation.


<!--

Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for Microsoft Learn, see the [contributor guide](https://learn.microsoft.com/contribute/).

When your PR is ready for review, add a comment with the text #sign-off to the Conversation tab.
-->
