### PR TITLE
Fix typo in how-to-create-a-data-driven-unit-test.md

### DIFF
--- a/docs/test/how-to-create-a-data-driven-unit-test.md
+++ b/docs/test/how-to-create-a-data-driven-unit-test.md
@@ -111,7 +111,7 @@ public void AddIntegers_FromDynamicDataTest(int x, int y, int expected)
 }
 ```
 
-It is also possible to override the default generated display name, using the `DynamicDataDisplayName` property of the `DynamicData` attribute. The display name method signature must be `publc static string` and accept two parameters, the first of type `MethodInfo` and the second of type `object[]`.
+It is also possible to override the default generated display name, using the `DynamicDataDisplayName` property of the `DynamicData` attribute. The display name method signature must be `public static string` and accept two parameters, the first of type `MethodInfo` and the second of type `object[]`.
 
 ```csharp
 public static string GetCustomDynamicDataDisplayName(MethodInfo methodInfo, object[] data)


### PR DESCRIPTION
Amended a small typo in the page, missing `i` in `publc`
<!--
Thanks for contributing to the Visual Studio documentation.

Note: Internal Microsoft employees and vendors should use the private repo, https://github.com/MicrosoftDocs/visualstudio-docs-pr. You must be a member of the MicrosoftDocs GitHub organization. To join, see https://review.learn.microsoft.com/help/get-started/setup-github?branch=main#3-join-microsoftdocs-and-other-organizations.

Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for Microsoft Learn, see the [contributor guide](https://learn.microsoft.com/contribute/).

When your PR is ready for review, add a comment with the text #sign-off to the Conversation tab.
-->
