### PR TITLE
Update incremental builds docs

### DIFF
--- a/docs/msbuild/incremental-builds.md
+++ b/docs/msbuild/incremental-builds.md
@@ -22,7 +22,7 @@ Incremental builds are builds that are optimized so that targets that have outpu
 
 If all output items are up-to-date, MSBuild skips the target. This *incremental build* of the target can significantly improve the build speed. If only some files are up-to-date, MSBuild executes the target but skips the up-to-date items, and thereby brings all items up-to-date. This process is known as a *partial incremental build*.
 
-1-to-1 mappings can only be produced by transforming the `Inputs` items. For more information, see [Transforms](../msbuild/msbuild-transforms.md).
+1-to-1 mappings can only be produced by making the `Outputs` attribute a transformation of the `Inputs` attribute. For more information, see [Transforms](../msbuild/msbuild-transforms.md).
 
  Consider the following target.
 

--- a/docs/msbuild/incremental-builds.md
+++ b/docs/msbuild/incremental-builds.md
@@ -22,7 +22,7 @@ Incremental builds are builds that are optimized so that targets that have outpu
 
 If all output items are up-to-date, MSBuild skips the target. This *incremental build* of the target can significantly improve the build speed. If only some files are up-to-date, MSBuild executes the target but skips the up-to-date items, and thereby brings all items up-to-date. This process is known as a *partial incremental build*.
 
-1-to-1 mappings are typically produced by item transformations. For more information, see [Transforms](../msbuild/msbuild-transforms.md).
+1-to-1 mappings can only be produced by transforming the `Inputs` items. For more information, see [Transforms](../msbuild/msbuild-transforms.md).
 
  Consider the following target.
 


### PR DESCRIPTION
Makes the docs clearer about incremental builds requiring `Outputs` to be a transformation of `Inputs`.

Related to https://github.com/dotnet/msbuild/issues/7021
<!--
Thanks for contributing to the Visual Studio documentation.

Note: Internal Microsoft employees and vendors should use the private repo, https://github.com/MicrosoftDocs/visualstudio-docs-pr. You must be a member of the MicrosoftDocs GitHub organization. To join, see https://review.learn.microsoft.com/help/get-started/setup-github?branch=main#3-join-microsoftdocs-and-other-organizations.

Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for Microsoft Learn, see the [contributor guide](https://learn.microsoft.com/contribute/).

When your PR is ready for review, add a comment with the text #sign-off to the Conversation tab.
-->
