### PR TITLE
Added missing </AL> in item-metadata-in-target-batching.md

### DIFF
--- a/docs/msbuild/item-metadata-in-target-batching.md
+++ b/docs/msbuild/item-metadata-in-target-batching.md
@@ -57,6 +57,7 @@ The following example contains an item list named `Res` that is divided into two
         <AL Resources="@(Res)"
             TargetType="library"
             OutputAssembly="%(Culture)\MyApp.resources.dll">
+        </AL>
 
     </Target>
 


### PR DESCRIPTION
- Added missing </AL> inside the Target, without it the document will not be xml well-formed and cause the project to unload.