### PR TITLE
Adding clarity where Bitmaps section is

### DIFF
--- a/docs/extensibility/adding-icons-to-menu-commands.md
+++ b/docs/extensibility/adding-icons-to-menu-commands.md
@@ -48,7 +48,7 @@ Commands can appear on both menus and toolbars. On toolbars, it is common for a 
     </GuidSymbol>
     ```
 
-6. Create a `<Bitmap>` in the `<Bitmaps>` section of the *.vsct* file to represent the bitmap containing the icons.
+6. Create a `<Bitmap>` in the `<Bitmaps>` section within `<Commands>` section of the *.vsct* file to represent the bitmap containing the icons.
 
     - Set the `guid` value to the name of the `<GuidSymbol>` element you created in the previous step.
 


### PR DESCRIPTION
Adding clarity where the Bitmaps section is

The Bitmaps section is within the Commands section and it could be clearer to note that.