### PR TITLE
Description in wrong column for get[Item|Property|TargetResult]

### DIFF
--- a/docs/msbuild/msbuild-command-line-reference.md
+++ b/docs/msbuild/msbuild-command-line-reference.md
@@ -39,9 +39,9 @@ MSBuild.exe [Switches] [ProjectFile]
 |Switch|Short form|Description|
 |------------|----------------|-----------------|
 |-detailedSummary[:`True` or `False`]|-ds[:`True` or `False`]|If `True`, show detailed information at the end of the build log about the configurations that were built and how they were scheduled to nodes.|
-|-getItem:`itemName`,...|Write out the value of the item or items after evaluation, without executing the build, or if either the `-targets` option or the `-getTargetResult` option is used, write out the values after the build.|
-|-getProperty:`propertyName`,...|Write out the value of the property or properties after evaluation, without executing the build, or if either the `-targets` option or the `-getTargetResult` option is used, write out the values after the build.|
-|-getTargetResult:`targetName`,...|Write out the output values of the specified targets.|
+|-getItem:`itemName`,...||Write out the value of the item or items after evaluation, without executing the build, or if either the `-targets` option or the `-getTargetResult` option is used, write out the values after the build.|
+|-getProperty:`propertyName`,...||Write out the value of the property or properties after evaluation, without executing the build, or if either the `-targets` option or the `-getTargetResult` option is used, write out the values after the build.|
+|-getTargetResult:`targetName`,...||Write out the output values of the specified targets.|
 |-graphBuild[:`True` or `False`]|-graph[:`True` or `False`]|Causes MSBuild to construct and build a project graph. Constructing a graph involves identifying project references to form dependencies. Building that graph involves attempting to build project references prior to the projects that reference them, differing from traditional MSBuild scheduling. Requires MSBuild 16 or later.|
 |-help|/? or -h|Display usage information. The following command is an example:<br /><br /> `msbuild.exe -?`|
 |-ignoreProjectExtensions: `extensions`|-ignore: `extensions`|Ignore the specified extensions when determining which project file to build. Use a semicolon or a comma to separate multiple extensions, as the following example shows:<br /><br /> `-ignoreprojectextensions:.vcproj,.sln`|


### PR DESCRIPTION
Update msbuild-command-line-reference.md to change -getItem, -getProperty, -getTargetResult to move description to the correct column.



<!--
Thanks for contributing to the Visual Studio documentation.

Note: Internal Microsoft employees and vendors should use the private repo, https://github.com/MicrosoftDocs/visualstudio-docs-pr. You must be a member of the MicrosoftDocs GitHub organization. To join, see https://review.learn.microsoft.com/help/get-started/setup-github?branch=main#3-join-microsoftdocs-and-other-organizations.

Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for Microsoft Learn, see the [contributor guide](https://learn.microsoft.com/contribute/).

When your PR is ready for review, add a comment with the text #sign-off to the Conversation tab.
-->
