### PR TITLE
Update build-tools-container.md to default to 64-bit builds

### DIFF
--- a/docs/install/build-tools-container.md
+++ b/docs/install/build-tools-container.md
@@ -81,7 +81,7 @@ Save the following example Dockerfile to a new file on your disk. If the file is
 
    # Define the entry point for the docker container.
    # This entry point starts the developer command prompt and launches the PowerShell shell.
-   ENTRYPOINT ["C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\BuildTools\\Common7\\Tools\\VsDevCmd.bat", "&&", "powershell.exe", "-NoLogo", "-ExecutionPolicy", "Bypass"]
+   ENTRYPOINT ["C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\BuildTools\\VC\\Auxiliary\\Build\\vcvars64.bat", "&&", "powershell.exe", "-NoLogo", "-ExecutionPolicy", "Bypass"]
    ```
 
    > [!TIP]


### PR DESCRIPTION
As a novice when it comes to building on Windows, it took a significant amount of research to find out why I was getting missing symbols when compiling basic extension modules for Python.

https://learn.microsoft.com/en-us/cpp/build/how-to-enable-a-64-bit-visual-cpp-toolset-on-the-command-line#remarks

> When you install a C++ workload in the Visual Studio installer, it always installs 32-bit, x86-hosted, native and cross compiler tools to build x86 and x64 code.

I couldn't find out the proper flag for 64-bit so I used the dedicated batch file.