### PR TITLE
Correct ADMX count of categories

### DIFF
--- a/docs/install/administrative-templates.md
+++ b/docs/install/administrative-templates.md
@@ -28,7 +28,7 @@ The Visual Studio group policy settings contained in the ADMX file are machine-w
  
  ## Visual Studio policy categories
  
- There are four main categories of Visual Studio policies that are included in the Visual Studio Administrative Templates (ADMX):
+ There are five main categories of Visual Studio policies that are included in the Visual Studio Administrative Templates (ADMX):
  
   - **Feedback** - controls behavior of the send-a-smile feature.
   - [**Install and Update**](./configure-policies-for-enterprise-deployments.md) - controls product acquisition behavior.


### PR DESCRIPTION
The bullet list of the categories consists of 5 items, however in the preceding text it said there are 4 categories. Fix the count in the text.



<!--
Thanks for contributing to the Visual Studio documentation.

Note: Internal Microsoft employees and vendors should use the private repo, https://github.com/MicrosoftDocs/visualstudio-docs-pr. You must be a member of the MicrosoftDocs GitHub organization. To join, see https://review.learn.microsoft.com/help/get-started/setup-github?branch=main#3-join-microsoftdocs-and-other-organizations.

Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for Microsoft Learn, see the [contributor guide](https://learn.microsoft.com/contribute/).

When your PR is ready for review, add a comment with the text #sign-off to the Conversation tab.
-->
