### PR TITLE
Update ca2211-non-constant-fields-should-not-be-visible_1.cs

### DIFF
--- a/docs/code-quality/codesnippet/CSharp/ca2211-non-constant-fields-should-not-be-visible_1.cs
+++ b/docs/code-quality/codesnippet/CSharp/ca2211-non-constant-fields-should-not-be-visible_1.cs
@@ -6,7 +6,7 @@ namespace UsageLibrary
    {
       // Violates rule: AvoidNonConstantStatic;
       // the field is public and not a literal.
-      static public DateTime publicField = DateTime.Now;
+      public static DateTime publicField = DateTime.Now;
 
       // Satisfies rule: AvoidNonConstantStatic.
       public static readonly DateTime literalField = DateTime.Now;


### PR DESCRIPTION
Sorting elements as public static instead of static public.
