### PR TITLE
Make it clear that you cannot filter the list of tests that get displayed

### DIFF
--- a/docs/test/vstest-console-options.md
+++ b/docs/test/vstest-console-options.md
@@ -41,7 +41,7 @@ The following table lists all the options for *VSTest.Console.exe* and short des
 |**/TestCaseFilter:[*expression*]**|Run tests that match the given expression.<br /><Expression\> is of the format <property\>=<value\>[\|<Expression\>].<br />Example: `/TestCaseFilter:"Priority=1"`<br />Example: `/TestCaseFilter:"TestCategory=Nightly|FullyQualifiedName=Namespace.ClassName.MethodName"`<br />The **/TestCaseFilter** command-line option cannot be used with the **/Tests** command-line option. <br />For information about creating and using expressions, see [TestCase filter](https://github.com/Microsoft/vstest-docs/blob/master/docs/filter.md).|
 |**/?**|Displays usage information.|
 |**/Logger:[*uri/friendlyname*]**|Specify a logger for test results. Specify the parameter multiple times to enable multiple loggers.<br />Example: To log results into a Visual Studio Test Results File (TRX), use<br />**/Logger:trx**<br />**[;LogFileName=\<Defaults to unique file name>]**|
-|**/ListTests:[*file name*]**|Lists discovered tests from the given test container.|
+|**/ListTests:[*file name*]**|Lists discovered tests from the given test container.<br />Note: The `/TestCaseFilters` option has no effect when listing tests; it only controls which tests get run.|
 |**/ListDiscoverers**|Lists installed test discoverers.|
 |**/ListExecutors**|Lists installed test executors.|
 |**/ListLoggers**|Lists installed test loggers.|


### PR DESCRIPTION
- In my pipeline I was trying to output a clean list of all the tests that would get run, before actually running them.
- When I do run tests, I use a filter, so I was also trying to use the same filter when listing tests.
- I spent over an hour trying to understand why the filter I was specifying was not working.
- In the end it ended up being because a specified filter has no effect when listing tests; only when running tests.

I've updated the documentation to make this clear.  It would be nice if VSTest was also updated at some point in the future to actually support filtering when listing.