### PR TITLE
Fix XAML samples in Advanced Remote UI page

### DIFF
--- a/docs/extensibility/visualstudio.extensibility/inside-the-sdk/advanced-remote-ui.md
+++ b/docs/extensibility/visualstudio.extensibility/inside-the-sdk/advanced-remote-ui.md
@@ -69,8 +69,8 @@ To start, update `MyToolWindowContent.xaml` to show a list view and a button":
                     </Grid>
                 </DataTemplate>
             </ListView.ItemTemplate>
-        </ListView>        
-        <Button Content=**Add color** Command="{Binding AddColorCommand}" Grid.Row="1" />
+        </ListView>
+        <Button Content="Add color" Command="{Binding AddColorCommand}" Grid.Row="1" />
     </Grid>
 </DataTemplate>
 ```
@@ -168,7 +168,7 @@ This solution still has imperfect synchronization since, when the user clicks th
 A better solution is to use the `RunningCommandsCount` property of *async commands*:
 
 ```xml
-<Button Content=**Add color** Command="{Binding AddColorCommand}" IsEnabled="{Binding AddColorCommand.RunningCommandsCount.IsZero}" Grid.Row="1" />
+<Button Content="Add color" Command="{Binding AddColorCommand}" IsEnabled="{Binding AddColorCommand.RunningCommandsCount.IsZero}" Grid.Row="1" />
 ```
 
 `RunningCommandsCount` is a counter of how many concurrent async executions of the command are currently underway. This counter is incremented on the UI thread as soon as the button is clicked, which allows to synchronously disable the button by binding `IsEnabled` to `RunningCommandsCount.IsZero`.


### PR DESCRIPTION

While working through [Tutorial: Advanced remote UI](https://learn.microsoft.com/en-us/visualstudio/extensibility/visualstudio.extensibility/inside-the-sdk/advanced-remote-ui?view=vs-2022) in the VisualStudio.Extensibility docs, I noticed that some of the XAML fragments required changing after they were copied and pasted into a local test project -- the samples contain invalid XAML.

In this case, Button Content elements were missing quotes.

I suspect there may have been a find/replace pass as some point in the past, as the markdown uses the text `**Add color**` to render in bold, however the sample screenshots show the label text as "Add color". I've removed the `*` characters from the XAML fragments.

With this change, the sample XAML code can now be more easily copied and pasted into local projects for anyone following along with the tutorial.

<!--
Thanks for contributing to the Visual Studio documentation.

Note: Internal Microsoft employees and vendors should use the private repo, https://github.com/MicrosoftDocs/visualstudio-docs-pr. You must be a member of the MicrosoftDocs GitHub organization. To join, see https://review.learn.microsoft.com/help/get-started/setup-github?branch=main#3-join-microsoftdocs-and-other-organizations.

Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for Microsoft Learn, see the [contributor guide](https://learn.microsoft.com/contribute/).

When your PR is ready for review, add a comment with the text #sign-off to the Conversation tab.
-->
