### PR TITLE
Add SOH and UOH to psuedovariables

### DIFF
--- a/docs/debugger/pseudovariables.md
+++ b/docs/debugger/pseudovariables.md
@@ -50,8 +50,8 @@ Pseudovariables are terms used to display certain information in a variable wind
 |`$exception`|Displays information on the last exception. If no exception has occurred, evaluating `$exception` displays an error message.<br /><br /> When the Exception Assistant is disabled, `$exception` is automatically added to the **Locals** window when an exception occurs.|
 |`$user`|Displays a structure with account information for the account running the application. For security reasons, the password information is not displayed.|
 |`$returnvalue`|Displays the return value of a .NET method.|
-|`$threadSmallObjectHeapBytes`|Displays the total number of bytes allocated in the small object heap by the current thread|
-|`$threadUserOldHeapBytes`|Displays the total number of bytes allocated in the user old heap by the current thread.|
+|`$threadSmallObjectHeapBytes`|Displays the total number of bytes allocated in the small object heap by the current thread. (.NET 6+)|
+|`$threadUserOldHeapBytes`|Displays the total number of bytes allocated in the user old heap by the current thread. `User Old Heap = Large Object Heap + Pinned Object Heap` (.NET 6+)|
 
  In Visual Basic, you can use the pseudovariables shown in the following table:
 

--- a/docs/debugger/pseudovariables.md
+++ b/docs/debugger/pseudovariables.md
@@ -50,6 +50,8 @@ Pseudovariables are terms used to display certain information in a variable wind
 |`$exception`|Displays information on the last exception. If no exception has occurred, evaluating `$exception` displays an error message.<br /><br /> When the Exception Assistant is disabled, `$exception` is automatically added to the **Locals** window when an exception occurs.|
 |`$user`|Displays a structure with account information for the account running the application. For security reasons, the password information is not displayed.|
 |`$returnvalue`|Displays the return value of a .NET method.|
+|`$threadSmallObjectHeapBytes`|Displays the total number of bytes allocated in the small object heap by the current thread|
+|`$threadUserOldHeapBytes`|Displays the total number of bytes allocated in the user old heap by the current thread.|
 
  In Visual Basic, you can use the pseudovariables shown in the following table:
 


### PR DESCRIPTION
This PR documents the new psuedovariables added to VS 2022.

Reference: https://www.poppastring.com/blog/the-user-old-heap-uoh

<!--
Thanks for contributing to the Visual Studio documentation.

Note: Internal Microsoft employees and vendors should use the private repo, https://github.com/MicrosoftDocs/visualstudio-docs-pr. You must be a member of the MicrosoftDocs GitHub organization. To join, see https://review.learn.microsoft.com/help/get-started/setup-github?branch=main#3-join-microsoftdocs-and-other-organizations.

Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for Microsoft Learn, see the [contributor guide](https://learn.microsoft.com/contribute/).

When your PR is ready for review, add a comment with the text #sign-off to the Conversation tab.
-->
