### PR TITLE
Fix typo for Static Class Usage 'calculator'

### DIFF
--- a/docs/get-started/csharp/tutorial-console.md
+++ b/docs/get-started/csharp/tutorial-console.md
@@ -667,7 +667,7 @@ Let's get started.
                 { 
                    try
                    {
-                      result = calculator.DoOperation(cleanNum1, cleanNum2, op);
+                      result = Calculator.DoOperation(cleanNum1, cleanNum2, op);
                       if (double.IsNaN(result))
                       {
                          Console.WriteLine("This operation will result in a mathematical error.\n");
@@ -932,7 +932,7 @@ class Program
             { 
                 try
                 {
-                    result = calculator.DoOperation(cleanNum1, cleanNum2, op);
+                    result = Calculator.DoOperation(cleanNum1, cleanNum2, op);
                     if (double.IsNaN(result))
                     {
                         Console.WriteLine("This operation will result in a mathematical error.\n");


### PR DESCRIPTION
Changed 'calculator' to uppercase because its a Static Method that uses the "Calculator" Class.



<!--
Thanks for contributing to the Visual Studio documentation.

Note: Internal Microsoft employees and vendors should use the private repo, https://github.com/MicrosoftDocs/visualstudio-docs-pr. You must be a member of the MicrosoftDocs GitHub organization. To join, see https://review.learn.microsoft.com/help/get-started/setup-github?branch=main#3-join-microsoftdocs-and-other-organizations.

Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for Microsoft Learn, see the [contributor guide](https://learn.microsoft.com/contribute/).

When your PR is ready for review, add a comment with the text #sign-off to the Conversation tab.
-->
