### PR TITLE
Fix code example not appearing under the bullet point

### DIFF
--- a/docs/msbuild/msbuild-best-practices.md
+++ b/docs/msbuild/msbuild-best-practices.md
@@ -17,11 +17,11 @@ We recommend the following best practices for writing MSBuild scripts:
 
 - Default property values are best handled by using the `Condition` attribute, and not by declaring a property whose default value can be overridden on the command line. For example, use
 
-```xml
-<MyProperty Condition="'$(MyProperty)' == ''">
-   MyDefaultValue
-</MyProperty>
-```
+  ```xml
+  <MyProperty Condition="'$(MyProperty)' == ''">
+     MyDefaultValue
+  </MyProperty>
+  ```
 
 - In general, avoid the use of wildcards when you select items. Instead, specify files explicitly. This is because in most project types, MSBuild expands wildcards at various times, such as when adding or removing items, which can lead to unexpected behavior. An exception to this is in .NET Core SDK-style projects, which do process wildcards correctly.
 


### PR DESCRIPTION

Indented the snippet to align to the bullet point.