### PR TITLE
Reverted the changes in f4bf1f5

### DIFF
--- a/docs/python/configure-web-apps-for-iis-windows.md
+++ b/docs/python/configure-web-apps-for-iis-windows.md
@@ -25,38 +25,11 @@ When you use Internet Information Services (IIS) as a web server on a Windows co
 
 ## Set web.config to point to the Python interpreter
 
-The `web.config` file for your Python application instructs the IIS web server (version 7 or later) running on Windows about how it should handle Python requests through HttpPlatform, ASP.NET Core Module, or FastCGI. Visual Studio versions 2015 and earlier make these modifications automatically. For Visual Studio 2017 and later, you must modify the `web.config` file manually.
+The `web.config` file for your Python application instructs the IIS web server (version 7 or later) running on Windows about how it should handle Python requests through HttpPlatformHandler (recommended) or FastCGI. Visual Studio versions 2015 and earlier make these modifications automatically. For Visual Studio 2017 and later, you must modify the `web.config` file manually.
 
 If your project does not already contain a `web.config` file, you can add one by right-clicking the project directory, selecting **Add > New Item** and searching for `web.config` or creating a blank `web.config` XML file.
 
-### Configure the ASP.Net Core Module handler
-
-The ASP.NET Core Module facilitates the direct transfer of socket connections to an independent Python process. This approach offers the flexibility to utilize any preferred web server, although it requires a startup script responsible for initiating a local web server, typically leveraging a Python web framework like Flask or Django. Within the `web.config` file, you define this script within the `<aspNetCore>` element. Here, the `processPath` attribute designates the Python interpreter associated with the site extension, while the `arguments` attribute specifies your chosen startup script, such as `runserver.py`, alongside any desired arguments.
-
-```xml
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <system.webServer>
-    <handlers>
-      <add name="PythonHandler" path="*" verb="*" modules="AspNetCoreModule" resourceType="Unspecified"/>
-    </handlers>
-    <aspNetCore processPath="c:\python36-32\python.exe"
-                  arguments="c:\home\site\wwwroot\runserver.py"
-                  stdoutLogEnabled="true"
-                  stdoutLogFile="c:\home\LogFiles\python.log"
-                  startupTimeLimit="60"
-                  processesPerApplication="16">
-      <environmentVariables>
-        <environmentVariable name="SERVER_PORT" value=".." />
-      </environmentVariables>
-    </httpPlatform>
-  </system.webServer>
-</configuration>
-```
-
-For more details about ASP.NET `web.config` files, please reference [ASP.NET IIS `web.config` file](https://learn.microsoft.com/aspnet/core/host-and-deploy/iis/web-config).
-
-### Configure the HttpPlatform handler
+### Configure the HttpPlatformHandler
 
 The HttpPlatform module passes socket connections directly to a standalone Python process. This pass-through allows you to run any web server you like, but it requires a startup script that runs a local web server. This approach is commonly done by using a Python web framework, such as Flask or Django. You specify the script in the `<httpPlatform>` element of the `web.config` file. The `processPath` attribute points to the site extension's Python interpreter. The `arguments` attribute points to your startup script that runs a local web server, in this case `runserver.py`, and any arguments you want to provide:
 
@@ -88,7 +61,7 @@ In this example, the `HTTP_PLATFORM_PORT` environment variable contains the port
 FastCGI is an interface that works at the request level. IIS receives incoming connections and forwards each request to a WSGI app running in one or more persistent Python processes.
 
 > [!NOTE]
-> We recommend using **HttpPlatform** or **ASP.NET Core Module** to configure your apps, as the [WFastCGI](https://pypi.org/project/wfastcgi/) project is no longer maintained. 
+> We recommend using **HttpPlatformHandler** to configure your apps, as the [WFastCGI](https://pypi.org/project/wfastcgi/) project is no longer maintained. 
 
 To use FastCGI, first install and configure the wfastcgi package as described in [pypi.org/project/wfastcgi/](https://pypi.io/project/wfastcgi).
 


### PR DESCRIPTION

<!--
Thanks for contributing to the Visual Studio documentation.

Note: Internal Microsoft employees and vendors should use the private repo, https://github.com/MicrosoftDocs/visualstudio-docs-pr. You must be a member of the MicrosoftDocs GitHub organization. To join, see https://review.learn.microsoft.com/help/get-started/setup-github?branch=main#3-join-microsoftdocs-and-other-organizations.

Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for Microsoft Learn, see the [contributor guide](https://learn.microsoft.com/contribute/).

When your PR is ready for review, add a comment with the text #sign-off to the Conversation tab.
-->

1. Since wfastcgi is no longer actively maintained by Microsoft, HttpPlatformHandler should remain the recommended approach in this article.
2. It is more common to call this IIS out-of-band module "HttpPlatformHandler", instead of "HttpPlatform". You can find that formal name from IIS documentation like https://www.iis.net/downloads/microsoft/httpplatformhandler.
3. ASP.NET Core module is irrelevant. People often were confused due to an ambiguous announcement made by ASP.NET Core team. I wrote about that in https://docs.lextudio.com/blog/the-rough-history-of-iis-httpplatformhandler/#the-mist-of-aspnet-core.
4. HttpPlatformHandler alone can handle Python web apps very well, so there is no need to use an ASP.NET Core specific module (which is also bigger to load into memory due to ASP.NET Core in-process mode).

Thus, in this pull request I reverted all changes made in the earlier commit, revised HttpPlatformHandler name in references.