### PR TITLE
Dev/jadelaga/vsix sign tool

### DIFF
--- a/docs/extensibility/dotnet-sign-CLI-reference-vsix.md
+++ b/docs/extensibility/dotnet-sign-CLI-reference-vsix.md
@@ -1,0 +1,172 @@
+---
+title: dotnet sign CLI Reference for VSIX Packages
+description: The dotnet sign command can sign VSIX packages using certificates from PFX, Windows Certificate Manager (WCM), or Cryptographic Service Providers (CSP)
+ms.topic: how-to
+helpviewer_keywords:
+- signature
+- signing
+- sign
+- pfx
+- sha256
+- authenticode
+- vsix
+- packages
+author: jadelaga
+ms.author: maiak
+manager: mijacobs
+ms.subservice: extensibility-integration
+ms.date: 04/11/2024
+---
+
+# Dotnet Sign CLI Reference for VSIX Packages
+
+## Name
+
+`sign` - Dotnet tool used for signing files and containers using certificates from PFX, Windows Certificate Manager (WCM), Cryptographic Service Providers (CSP) or Azure Key Vault.
+
+## Synopsis
+
+```dotnetcli
+sign code certificate-store [<PATH(s)>]
+    [-o|--output <PATH>]
+    [-b|--base-directory <wORKINGDIRECTORY>]
+    [-f|--force]
+    [-m|--max-concurrency <MAXCONCURRENCY>]
+    [-fl|--filelist <FILELISTPATH>]
+    [-s|--sha1 <SHA>]
+    [-d|--description <DESCRIPTION>]
+    [-u|--descriptionUrl <URL>]
+    [-cf|--certificate-file <PATH>]
+    [-p|--password <PASSWORD>]
+    [-csp|--crypto-service-provider <CSPNAME>]
+    [-k|---key-container <HASHALGORITHM>]
+    [-fd|--file-digest <DIGEST>]
+    [-t|--timestamp-url <URL>]
+    [-tr|--timestamp-rfc3161 <URL>]
+    [-td|--timestamp-digest <DIGEST>]
+
+sign code certificate-store -h|--help
+```
+
+## Description
+
+`sign` is a Dotnet tool that recursively signs files and containers with a certificate and private. The certificate and private key can be obtained from either a file (PFX, P7B, CER) or from a certificate installed in a certificate store by providing a SHA-1 fingerprint. USB keys can be accessed using a [Cryptographic Service Provider](https://learn.microsoft.com/en-us/windows/win32/seccrypto/cryptographic-service-providers) implemented by the manufacturer and accessed from the certificate store.
+
+## Installation
+Install Sign globally using `dotnet tool install sign --version <version> --global`, where `<version>` is the latest available version under [Sign (nuget.org)](https://www.nuget.org/packages/sign)
+
+## Arguments
+
+- **`VSIX-paths(s)`**
+
+  Specifies the file path to the VSIX package to be signed.
+
+## Options
+
+- **`-o|--output <PATH>`**
+
+  The output file. If omitted, input is overwritten. Must be a directory if multiple files are specified.
+
+- **`-b|--base-directory <PATH>`**
+
+  Base directory for files to override the working directory.
+
+- **`--f|--force`**
+
+  Overwrites a signature if it exists.
+
+- **`-m|--max-concurrency <MAXCONCURRENCY>`**
+
+  Maximum concurrency (default is 4)
+
+- **`-fl | --filelist <PATH>`**
+
+  Path to file containing paths of files to sign within an archive. Supports glob patterns and will recursively enter and sign matching files for nested containers.
+
+- **`-s|--sha1 <SHA>`**
+
+   SHA-1 thumbprint used to identify a certificate within a certificate store.
+
+- **`-d|--description <DESCRIPTION>`**
+
+   Description of the signing certificate.
+
+- **`-u|--certificate-store-location <STORENAME>`**
+
+   Description Url of the signing certificate.
+
+- **`-cf|--certificate-file <PATH>`**
+
+   PFX, P7B, or CER file containing a certificate and potentially a private key.
+
+- **`-p|--certificate-fingerprint <FINGERPRINT>`**
+
+   Optional password for certificate file.
+
+- **`-csp|--certificate-password <PASSWORD>`**
+
+   Cryptographic Service Provider containing the private key.
+
+- **`-k|--hash-algorithm <HASHALGORITHM>]`**
+
+   Private key container name.
+
+- **`-fd | --file-digest <DIGEST>`**
+
+   The digest algorithm to hash the file with.
+   
+- **`-t|--timestamp-url <URL>`**
+
+   RFC 3161 timestamp server URL. [default: http://timestamp.acs.microsoft.com/]
+
+- **`-tr | --timestamp-rfc3161 <URL>`**
+
+   Specifies the RFC 3161 timestamp server's URL.
+
+- **`-td|--timestamp-digest <DIGEST>`**
+
+  Used with the -tr switch to request a digest algorithm used by the RFC 3161 timestamp server.
+
+- **`-?|-h|--help`**
+
+  Prints out a description of how to use the command.
+
+## Examples
+
+- Sign *contoso.vsix* with a certificate imported to either user or machine certificate store:
+
+  ```dotnetcli
+  sign contoso.vsix -s 24D58920B2D24D00A7DF07FB9523B36E -d "Constoso VSIX Signature" -u "http://www.contoso.com"
+  ```
+
+- Sign *contoso.vsix* with certificate *cert.pfx* (not password protected):
+
+  ```dotnetcli
+  sign contoso.vsix -s 24D58920B2D24D00A7DF07FB9523B36E -cf cert.pfx -d "Constoso VSIX Signature" -u "http://www.contoso.com"
+  ```
+
+- Sign *contoso.vsix* with certificate *cert.pfx* (password protected):
+
+  ```dotnetcli
+  sign contoso.vsix -s 24D58920B2D24D00A7DF07FB9523B36E -cf cert.pfx -p <password> -d "Constoso VSIX Signature" -u "http://www.contoso.com"
+  ```
+
+- Sign multiple VSIX packages - *contoso.vsix* and *all .vsix files in the directory specified* with certificate *cert.pfx* (not password protected):
+
+  ```dotnetcli
+  sign *.vsix -s 24D58920B2D24D00A7DF07FB9523B36E -cf cert.pfx -d "Constoso VSIX Signature" -u "http://www.contoso.com"
+  ```
+
+- Sign *contoso.vsix* with a certificate stored in a secure USB drive
+
+  ```dotnetcli
+  sign contoso.vsix -s 24D58920B2D24D00A7DF07FB9523B36E -csp "Microsoft Software Key Storage Provider" -k "NuGetSigning 0B2D249223B36D00A7DF07FB95E24D58" -d "Constoso VSIX Signature" -u "http://www.contoso.com"
+  ```
+  > [!NOTE]
+  > When the `-k` option isn't provided, the tool checks all containers in the provided CSP for a matching SHA-1 Thumbprint certificate.
+
+- Sign *contoso.vsix* with a certificate stored in a secure USB drive specifying algorithm digest, timestamp server, and a custom output path for the signed VSIX
+
+  ```dotnetcli
+  sign contoso.vsix -s 24D58920B2D24D00A7DF07FB9523B36E -csp "Microsoft Software Key Storage Provider" -k "NuGetSigning 0B2D249223B36D00A7DF07FB95E24D58" -d "Constoso VSIX Signature" -u "http://www.contoso.com" -t sha256 -fd sha256 -o "ContosoSigned.vsix"
+  ```

--- a/docs/extensibility/signing-vsix-packages.md
+++ b/docs/extensibility/signing-vsix-packages.md
@@ -1,7 +1,7 @@
 ---
 title: Signing VSIX Packages
 description: Learn about signing extension assemblies. The VSIX installer displays a message that a VSIX is signed and information about the signature itself.
-ms.date: 11/04/2016
+ms.date: 4/10/2024
 ms.topic: how-to
 helpviewer_keywords:
 - signature
@@ -9,7 +9,7 @@ helpviewer_keywords:
 - authenticode
 - vsix
 - packages
-author: maiak
+author: jadelaga
 ms.author: maiak
 manager: mijacobs
 ms.subservice: extensibility-integration
@@ -18,27 +18,57 @@ ms.subservice: extensibility-integration
 
 Extension assemblies do not need to be signed before they can run in Visual Studio, but it is a good practice to do so.
 
- If you want to secure your extension and make sure it hasn't been tampered with, you can add a digital signature to a VSIX package. When a VSIX is signed, the VSIX installer will display a message indicating that it is signed, plus more information about the signature itself. If the contents of the VSIX have been modified, and the VSIX has not been signed again, the VSIX installer will show that the signature is not valid. The installation is not stopped, but the user is warned.
+Adding a digital signature to a VSIX package secures your extension and prevents tampering. During install, the VSIX installer will display the signature and a link to the certificate. If the contents of the VSIX are modified without signing again the VSIX installer will mark the signature as invalid. Invalid signatures do not block installing extensions, but the user is warned.
 
 > [!IMPORTANT]
 > Beginning with Visual Studio 2015, VSIX packages signed using anything other than SHA256 encryption will be identified as having an invalid signature. VSIX installation is not blocked but the user will be warned.
 
-## Signing a VSIX with VSIXSignTool
- There is a SHA256 encryption signing tool available from [VisualStudioExtensibility](https://www.nuget.org/profiles/VisualStudioExtensibility) on nuget.org at [VsixSignTool](https://www.nuget.org/packages/Microsoft.VSSDK.Vsixsigntool).
+## Signing a VSIX with Dotnet Sign
+VSIXSignTool has been integrated into [Dotnet/Sign (github.com)](https://github.com/dotnet/sign) and is now accessible as a dotnet tool. This tool is published to NuGet package as [Sign (nuget.org)](https://www.nuget.org/packages/sign) and can be used for local or cloud signing using Azure Key Vault.
 
-#### To use the VSIXSignTool
+Sign supports certificates and private keys stored in any combination of these locations:
+- `PFX`, `P7B`, or `CER` files
+- Imported into Windows Certificate Manager
+- Stored in a USB device with access via a Cryptographic Service Provider (CSP)
 
-1. Add your VSIX to a project.
+#### Installing Dotnet Sign
+1. Open a [Developer PowerShell](https://learn.microsoft.com/en-us/visualstudio/ide/reference/command-prompt-powershell?view=vs-2022) instance.
 
-2. Right click on the project node in Solution Explorer, selecting **Add &#124; Manage NuGet Packages**.  For more information on NuGet and adding NuGet packages see the [NuGet documentation](/NuGet) and [Package Manager UI](/NuGet/Tools/Package-Manager-UI) topics.
+1. Verify nuget.org is added and enabled as a NuGet source.
+    - Check your sources using `dotnet nuget list source` 
+    - Add NuGet.org as a source using `dotnet nuget add source -n NuGet.org https://api.nuget.org/v3/index.json`
 
-3. Search for VSIXSignTool from VisualStudioExtensibility and install the NuGet package.
+1. Install Sign by running `dotnet tool install sign --version <version> --global`, where `<version>` is the latest available version under [Sign (nuget.org)](https://www.nuget.org/packages/sign)
+    - `--global` is optional but will allow using sign outside of the PowerShell instance.
 
-4. You can now run the VSIXSignTool from the project's local packages location. Consult the tool's command line help for your signing scenario (VSIXSignTool.exe /?).
 
-   For example to sign with a password protected certificate file:
+#### Using Dotnet Sign
+Once installed, Sign can be accessed in a Developer Powershell instance using `sign code <command> <options>`. For a breakdown of the options see 
 
-   VSIXSignTool.exe sign /f \<certfile> /p \<password> \<VSIXfile>
+- Signing using a PFX file with certificate and private key:
+```shell
+sign code certificate-store -s f5ec6169345347a7cd2f83af662970d5d0bfc914  -cf "D:\Certs\f5ec6169345347a7cd2f83af662970d5d0bfc914.pfx" -d "VSIX Signature" -u "http://timestamp.acs.microsoft.com/" "C:\Users\Contoso\Downloads\FingerSnapper2022.vsix"
+```
+##### Note: PFX files contain both certificate and private key used for signing and do not comply with C/A Browser Forum requiements for non-EV and EV signing. It is recommended to only use private keys stored in an HSM device.
+
+- Signing using Microsoft Certificate Manager:
+```shell
+code certificate-store -s f5ec6169345347a7cd2f83af662970d5d0bfc914 -csp "Microsoft Software Key Storage Provider" -d "VSIX Signature" -u "http://timestamp.acs.microsoft.com/" "C:\Users\Contoso\Downloads\FingerSnapper2022.vsix"
+```
+
+- Signing using a private key in a USB drive:
+```shell
+code certificate-store -s f5ec6169345347a7cd2f83af662970d5d0bfc914 -csp "eToken Base Cryptographic Provider" -d "VSIX Signature" -u "http://timestamp.acs.microsoft.com/" "C:\Users\Contoso\Downloads\FingerSnapper2022.vsix"
+```
+
+- Signing using a USB drive using a specific key container:
+```shell
+code certificate-store -s f5ec6169345347a7cd2f83af662970d5d0bfc914 -csp "eToken Base Cryptographic Provider" -k "NuGet Signing.629c9149345347cd2f83af6f5ec70d5d0a7bf616" -d "VSIX Signature" -u "http://timestamp.acs.microsoft.com/" "C:\Users\Contoso\Downloads\FingerSnapper2022.vsix"
+```
+
+#### Signing using PFX files
+
 
 ## Related content
 - [Shipping Visual Studio Extensions](../extensibility/shipping-visual-studio-extensions.md)
+- [Dotnet Sign CLI Reference for VSIX Packages](../extensibility/dotnet-sign-CLI-reference-vsix.md)


### PR DESCRIPTION
Updates the documentation for signing VSIX packages using `dotnet sign` and adds a CLI reference page. Another page is being added next to the sign code under [Dotnet/Sign](https://github.com/dotnet/sign)

<!--
Thanks for contributing to the Visual Studio documentation.

Note: Internal Microsoft employees and vendors should use the private repo, https://github.com/MicrosoftDocs/visualstudio-docs-pr. You must be a member of the MicrosoftDocs GitHub organization. To join, see https://review.learn.microsoft.com/help/get-started/setup-github?branch=main#3-join-microsoftdocs-and-other-organizations.

Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for Microsoft Learn, see the [contributor guide](https://learn.microsoft.com/contribute/).

When your PR is ready for review, add a comment with the text #sign-off to the Conversation tab.
-->
