### PR TITLE
Clarify ProjectReference Targets metadata

### DIFF
--- a/docs/msbuild/common-msbuild-project-items.md
+++ b/docs/msbuild/common-msbuild-project-items.md
@@ -81,7 +81,7 @@ Represents a reference to another project. `ProjectReference` items are transfor
 |SetPlatform|Optional string. Sets the global property `Platform` for the referenced project, for example `Platform=AnyCPU`.|
 |SetTargetFramework|Optional string. Sets the global property `TargetFramework` for the referenced project, for example `TargetFramework=netstandard2.0`.|
 |SkipGetTargetFrameworkProperties|Optional boolean. If `true`, builds the referenced project without negotiating the most compatible `TargetFramework` value. Defaults to `false`.|
-|Targets|Optional `string[]`. Semicolon separated list of targets in the referenced projects that should be built. Default is the value of `$(ProjectReferenceBuildTargets)`, which defaults to empty, indicating the default targets.|
+|Targets|Optional `string[]`. Semicolon separated list of targets in the referenced projects that should be built. Default is the value of `$(ProjectReferenceBuildTargets)`, which defaults to empty, indicating the default targets. When building in Visual Studio (as opposed to `MSBuild.exe` or `dotnet build`), specifying this does not prevent Visual Studio from building the default targets of the referenced project.|
 
 > [!NOTE]
 > There is a difference between how project references work between .NET Framework and .NET Core (including .NET 5 and later). In .NET Framework projects, project references aren't transitive. That is, if Project1 references Project2, and Project2 references Project3, you can't code against Project3 from Project1. However, in .NET Core (including .NET 5 and later), project references *are* transitive. You can code against Project3 in Project1.


### PR DESCRIPTION
This metadata influences the way MSBuild's ResolveProjectReferences calls the referenced project, but another system can build referenced projects in other ways--and VS does.



<!--
Thanks for contributing to the Visual Studio documentation.

Note: Internal Microsoft employees and vendors should use the private repo, https://github.com/MicrosoftDocs/visualstudio-docs-pr. You must be a member of the MicrosoftDocs GitHub organization. To join, see https://review.learn.microsoft.com/help/get-started/setup-github?branch=main#3-join-microsoftdocs-and-other-organizations.

Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for Microsoft Learn, see the [contributor guide](https://learn.microsoft.com/contribute/).

When your PR is ready for review, add a comment with the text #sign-off to the Conversation tab.
-->
