### PR TITLE
Remove mistaken duplicated lines.

### DIFF
--- a/docs/ide/visual-studio-whole-line-completions.md
+++ b/docs/ide/visual-studio-whole-line-completions.md
@@ -78,10 +78,6 @@ Click on the Feedback icon on the top right of Visual Studio to file a feedback 
 
 ![Screenshot of submitting feedback for IntelliCode.](media/intellicode/intellicode-visual-studio-whole-line-completions-feedback-small.png)
 
-The second setting, `Wait for pauses in typing before showing line completions`, when enabled, makes whole line completions only show up if the user has paused typing. The user may prefer this choice if they find the whole line completions distracting in the default mode.
-
-The third setting, `Show completions on new lines` can be turned on or off depending on whether the user wants to see whole line completions when they have entered a new line such as by pressing `Return` or `Enter`. 
-
 ## Next steps
 
 [See Privacy](intellicode-privacy.md#intellicode-whole-line-completions)


### PR DESCRIPTION
The lines removed from the «Provide feedback» section are duplicated [almost] verbatim from the «Control whole-line autocompletions» section, immediately above it. Almost... the minor difference between these otherwise duplicated lines is that those that have been removed use "completion" whereas the rest of the document (and the lines in the correct section) use "autocompletion".



<!--
Thanks for contributing to the Visual Studio documentation.

Note: Internal Microsoft employees and vendors should use the private repo, https://github.com/MicrosoftDocs/visualstudio-docs-pr. You must be a member of the MicrosoftDocs GitHub organization. To join, see https://review.learn.microsoft.com/help/get-started/setup-github?branch=main#3-join-microsoftdocs-and-other-organizations.

Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for Microsoft Learn, see the [contributor guide](https://learn.microsoft.com/contribute/).

When your PR is ready for review, add a comment with the text #sign-off to the Conversation tab.
-->
