### PR TITLE
Fix the markdown rendering issue in the "Report a problem with the Visual Studio product or installer" documentation.

### DIFF
--- a/docs/ide/how-to-report-a-problem-with-visual-studio.md
+++ b/docs/ide/how-to-report-a-problem-with-visual-studio.md
@@ -45,7 +45,7 @@ Here are the steps to report a problem.
     ![Take a screenshot](../ide/media/feedback-screenshot.png)
     *Only Microsoft engineers can see the screenshot*
 
-1. <a name="trace"/>Record your actions to reproduce the issue.
+1. Record your actions to reproduce the issue.
 
    One of the best ways to help the Visual Studio engineering team solve the problem is to provide a trace and heap dump files for them to look through. You can do that by recording the steps that resulted in the bug. A screenshot will be captured every time the mouse is clicked, but keyboard entry will not record screenshots.
    1. Click **Start recording**. Wait a moment for the permissions prompt.


### PR DESCRIPTION
Fix the markdown rendering issue in the ["Report a problem with the Visual Studio product or installer"](https://learn.microsoft.com/visualstudio/ide/how-to-report-a-problem-with-visual-studio?view=vs-2022) documentation. As you can see in the screenshot below, every line below the `Record your actions to reproduce the issue` section is clickable. Clicking on the link does nothing. I think this rendering issue is confusing for customers. Additionally, internal product teams can't add a direct link to any section below the `Record your actions to reproduce the issue` topic while responding to a Visual Studio feedback ticket.

![image](https://github.com/MicrosoftDocs/visualstudio-docs/assets/52756182/4783956b-b970-4352-8db0-efee20123b59)

<!--
Thanks for contributing to the Visual Studio documentation.

Note: Internal Microsoft employees and vendors should use the private repo, https://github.com/MicrosoftDocs/visualstudio-docs-pr. You must be a member of the MicrosoftDocs GitHub organization. To join, see https://review.learn.microsoft.com/help/get-started/setup-github?branch=main#3-join-microsoftdocs-and-other-organizations.

Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for Microsoft Learn, see the [contributor guide](https://learn.microsoft.com/contribute/).

When your PR is ready for review, add a comment with the text #sign-off to the Conversation tab.
-->
