### PR TITLE
Specify exact project in -targets query

### DIFF
--- a/docs/msbuild/msbuild-targets.md
+++ b/docs/msbuild/msbuild-targets.md
@@ -116,13 +116,13 @@ Reference: 4.0
 Some build targets depend on the SDK you're referencing, if any. To get all targets available for a project file, use the `-targets` or `-ts` command-line option. See [MSBuild command line reference](msbuild-command-line-reference.md). The build system contains a large number of targets that are for internal use by the build, which are usually indicated with an underscore (_) at the beginning of the target name. To get a list of the public targets only, try piping the output to something that filters out the underscores. For example, in bash when working with `dotnet build`, you can do the following:
 
 ```cli
-dotnet build -ts | grep -v '_'
+dotnet build -targets path/to/project.csproj | grep -v '_'
 ```
 
 In PowerShell, you can filter with:
 
 ```powershell
- dotnet build -ts | select-string -pattern '_' -NotMatch
+ dotnet build -targets path\to\project.csproj | select-string -pattern '_' -NotMatch
 ```
 
 If you're not using .NET, use `MSBuild.exe -ts` in place of `dotnet build -ts`, followed by the same piping and filtering operations.


### PR DESCRIPTION
If a `.sln` file is in the current working directory, `-ts` will return an error. Instead guide users to specifying a specific project to query about its targets.

<!--
Thanks for contributing to the Visual Studio documentation.

Note: Internal Microsoft employees and vendors should use the private repo, https://github.com/MicrosoftDocs/visualstudio-docs-pr. You must be a member of the MicrosoftDocs GitHub organization. To join, see https://review.learn.microsoft.com/help/get-started/setup-github?branch=main#3-join-microsoftdocs-and-other-organizations.

Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for Microsoft Learn, see the [contributor guide](https://learn.microsoft.com/contribute/).

When your PR is ready for review, add a comment with the text #sign-off to the Conversation tab.
-->
