### PR TITLE
Update tutorial-multicontainer.md

### DIFF
--- a/docs/containers/tutorial-multicontainer.md
+++ b/docs/containers/tutorial-multicontainer.md
@@ -218,8 +218,6 @@ Add a project to the same solution and call it *MyWebAPI*. Select **API** as the
    The *docker-compose.yml* appears as follows:
 
    ```yaml
-   version: '3.4'
-
     services:
       webfrontend:
         image: ${DOCKER_REGISTRY-}webfrontend
@@ -242,8 +240,6 @@ Add a project to the same solution and call it *MyWebAPI*. Select **API** as the
     Visual Studio makes some changes to your Docker Compose YML file. Now both services are included.
 
     ```yaml
-    version: '3.4'
-
     services:
       webfrontend:
         image: ${DOCKER_REGISTRY-}webfrontend
@@ -344,8 +340,6 @@ Congratulations, you're running a Docker Compose application with a custom Docke
    The *docker-compose.yml* appears as follows:
 
    ```yaml
-   version: '3.4'
-
     services:
       webfrontend:
         image: ${DOCKER_REGISTRY-}webfrontend
@@ -368,8 +362,6 @@ Congratulations, you're running a Docker Compose application with a custom Docke
     Visual Studio makes some changes to your `docker-compose` YML file. Now both services are included.
 
     ```yaml
-    version: '3.4'
-
     services:
       webfrontend:
         image: ${DOCKER_REGISTRY-}webfrontend


### PR DESCRIPTION
Removed the top-level `version` element from the Docker compose files, since [It's officially obsolete](https://docs.docker.com/compose/compose-file/04-version-and-name/#version-top-level-element-optional) and results in `docker-compose.yml: 'version' is obsolete"` and similar warnings in the output

PS. Also, it seems that the `Add Docker Compose support` section is duplicated in this file and some embedded images lead to 404. I'm assuming the page is in the middle of being edited, so I refrained from fixing that. Somebody may want to look into that.