### PR TITLE
Fix grammar in usingtask-element-msbuild.md

### DIFF
--- a/docs/msbuild/usingtask-element-msbuild.md
+++ b/docs/msbuild/usingtask-element-msbuild.md
@@ -86,7 +86,7 @@ The assembly containing the custom task is loaded when the `Task` is first used.
            AssemblyFile="c:\myTasks\myTask.dll" />
 ```
 
-Because there is no `Runtime` or `TaskHost` specified, the task will be executed the MSBuild process, in the runtime and architecture that happen to be running for a given build.
+Because there is no `Runtime` or `TaskHost` specified, the task will be executed in the MSBuild process, in the runtime and architecture that happen to be running for a given build.
 
 ## Example 2
 


### PR DESCRIPTION
## Summary

I was looking over this document and I reread this sentence several times, trying to understand what the intent was.

> Because there is no `Runtime` or `TaskHost` specified, the task will be executed the MSBuild process, in the runtime and architecture that happen to be running for a given build.

I believe it meant that "the task will be executed in the current MSBuild process", but I just added `in` since I wasn't exactly sure. Feel free to modify the PR if there is a better phrasing for clarity.