### PR TITLE
Use ToDouble() instead of ToInt32() for double type variable

### DIFF
--- a/docs/get-started/csharp/tutorial-console.md
+++ b/docs/get-started/csharp/tutorial-console.md
@@ -395,7 +395,7 @@ Let's change the code to handle this error. In *Program.cs*, replace the code fo
                 while (num2 == 0)
                 {
                     Console.WriteLine("Enter a non-zero divisor: ");
-                    num2 = Convert.ToInt32(Console.ReadLine());
+                    num2 = Convert.ToDouble(Console.ReadLine());
                 }
                 Console.WriteLine($"Your result: {num1} / {num2} = " + (num1 / num2));
                 break;


### PR DESCRIPTION
The variable `num2` is of type double, but the code was using `ToInt32()` to convert it. This can lead to potential loss of precision or rounding errors. The method should be updated to use `ToDouble()` to properly handle the double type.



<!--
Thanks for contributing to the Visual Studio documentation.

Note: Internal Microsoft employees and vendors should use the private repo, https://github.com/MicrosoftDocs/visualstudio-docs-pr. You must be a member of the MicrosoftDocs GitHub organization. To join, see https://review.learn.microsoft.com/help/get-started/setup-github?branch=main#3-join-microsoftdocs-and-other-organizations.

Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for Microsoft Learn, see the [contributor guide](https://learn.microsoft.com/contribute/).

When your PR is ready for review, add a comment with the text #sign-off to the Conversation tab.
-->
