### PR TITLE
Fix malformed anchor in headers

### DIFF
--- a/docs/ide/optimize-visual-studio-startup-time.md
+++ b/docs/ide/optimize-visual-studio-startup-time.md
@@ -26,7 +26,7 @@ If Visual Studio detects slow startup, a pop-up message appears, alerting you to
 
 The dialog box lists the extensions and tools windows that are affecting startup performance. You can change extension and tool window settings to improve startup performance.
 
-## <a name="extensions" />To change extension settings to improve startup, solution load, and typing performance
+## <a name="extensions"></a> To change extension settings to improve startup, solution load, and typing performance
 
 1. Open the **Performance Manager** dialog box by choosing **Help** > **Visual Studio Performance Manager** from the menu bar.
 
@@ -38,7 +38,7 @@ The dialog box lists the extensions and tools windows that are affecting startup
 
 You can always re-enable the extension for future sessions by using the **Extension Manager** or the **Visual Studio Performance Manager** dialog box.
 
-## <a name="tool-windows" />To change tool window settings to improve startup time
+## <a name="tool-windows"></a> To change tool window settings to improve startup time
 
 1. Open the **Performance Manager** dialog box by choosing **Help** > **Visual Studio Performance Manager** from the menu bar.
 

--- a/docs/ide/walkthrough-creating-a-multiple-computer-build-environment.md
+++ b/docs/ide/walkthrough-creating-a-multiple-computer-build-environment.md
@@ -280,7 +280,7 @@ If *vcvarsall.bat* runs successfully—that is, no error message is displayed—
 
    - %windir%\Microsoft.NET\Framework64\v4.0.30319
 
-## <a name="install-msbuild-to-gac" /> Install MSBuild assemblies to the Global Assembly Cache (GAC) on the build computer
+## <a name="install-msbuild-to-gac"></a> Install MSBuild assemblies to the Global Assembly Cache (GAC) on the build computer
 
 MSBuild requires some additional assemblies to be installed to the GAC on the build computer.
 

--- a/docs/modeling/analyze-and-model-your-architecture.md
+++ b/docs/modeling/analyze-and-model-your-architecture.md
@@ -72,7 +72,7 @@ Use domain-specific language to:
 Learn more:
 - [Modeling SDK for Visual Studio - Domain-Specific Languages](../modeling/modeling-sdk-for-visual-studio-domain-specific-languages.md)
 
-## <a name="VersionSupport" />Edition support for architecture and modeling tools
+## <a name="VersionSupport"></a> Edition support for architecture and modeling tools
 
 Visual Studio is available in several editions. Not all of these provide support for the architecture and modeling tools. The following table shows the availability of each tool.
 


### PR DESCRIPTION
Fix problem where a malformed anchor causes a whole chunk of text to be rendered as a link.

For example:
![image](https://github.com/user-attachments/assets/3fa801ac-963c-4d7e-9297-7c9e03b8ec7f)
