### PR TITLE
Fix project name in adding-a-tool-window.md

### DIFF
--- a/docs/extensibility/adding-a-tool-window.md
+++ b/docs/extensibility/adding-a-tool-window.md
@@ -31,7 +31,7 @@ The Visual Studio SDK is included as an optional feature in Visual Studio setup.
 
 ## Create a tool window
 
-1. Create a project named **FirstToolWin** using the VSIX template, and add a custom tool window item template named **FirstToolWindow**.
+1. Create a project named **FirstToolWindow** using the VSIX template, and add a custom tool window item template named **FirstToolWindow**.
 
     > [!NOTE]
     > For more information about creating an extension with a tool window, see [Create an extension with a tool window](../extensibility/creating-an-extension-with-a-tool-window.md).


### PR DESCRIPTION
<!--
Thanks for contributing to the Visual Studio documentation.

Note: Internal Microsoft employees and vendors should use the private repo, https://github.com/MicrosoftDocs/visualstudio-docs-pr. You must be a member of the MicrosoftDocs GitHub organization. To join, see https://review.learn.microsoft.com/help/get-started/setup-github?branch=main#3-join-microsoftdocs-and-other-organizations.

Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for Microsoft Learn, see the [contributor guide](https://learn.microsoft.com/contribute/).

When your PR is ready for review, add a comment with the text #sign-off to the Conversation tab.
-->

I think this is a typo, the first step says to call the project "FirstToolWin" but then throughout the project is referenced as FirstToolWindow. For example the second step under the "Add a toolbar to the tool window" section says find the node with name "guidFirstToolWindowPackageCmdSet" but that should be "guidFirstToolWindPackageCmdSet" if the project were called FirstToolWin, right?

Caused confusion for me as a first time VS extension developer so just wanted to clarify and fix this. Lmk if I am missing something.