### PR TITLE
Fix incorrect enum value name in extended documentation.

### DIFF
--- a/docs/debugger/debug-interface-access/cv-modifier-e.md
+++ b/docs/debugger/debug-interface-access/cv-modifier-e.md
@@ -57,7 +57,7 @@ typedef enum CV_modifier_e
 | ------------ | ---------------------------- |
 | `CV_MOD_INVALID` | Invalid modifier (unused) |
 | `CV_MOD_CONST` | C++ `const` |
-| `CV_MOD_CONST` | C++ `volatile` |
+| `CV_MOD_VOLATILE` | C++ `volatile` |
 | `CV_MOD_HLSL_UNIFORM` | HLSL uniform |
 | `CV_MOD_HLSL_LINE` | HLSL line |
 | `CV_MOD_HLSL_TRIANGLE` | HLSL triangle |


### PR DESCRIPTION
Seems that the line was copy-pasted from the one above and the word was missed
