### PR TITLE
Fix description of get_modifierValues

### DIFF
--- a/docs/debugger/debug-interface-access/idiasymbol-get-modifiervalues.md
+++ b/docs/debugger/debug-interface-access/idiasymbol-get-modifiervalues.md
@@ -14,7 +14,7 @@ ms.subservice: debug-diagnostics
 ---
 # IDiaSymbol::get_modifierValues
 
-Retrieves the total invocation count in PGO training.
+Retrieves an array of [`modifiers`](../../debugger/debug-interface-access/cv-modifier-e.md) affecting the symbol.
 
 ## Syntax
 


### PR DESCRIPTION
Old description was copy-pasted from get_PGOEntryCount

