### PR TITLE
Update example usage for IDiaSymbol::get_value

### DIFF
--- a/docs/debugger/debug-interface-access/idiasymbol-get-value.md
+++ b/docs/debugger/debug-interface-access/idiasymbol-get-value.md
@@ -44,7 +44,7 @@ The supplied VARIANT must be initialized before it is passed to this method. For
 void ProcessValue(IDiaSymbol *pSymbol)
 {
     VARIANT value;
-    value.vt = VT_EMPTY;    // Initialize variant for use.
+    VariantInit(&value);    // Initialize variant for use.
     if (pSymbol->get_value(&value) == S_OK)
     {
         // Do something with value.
@@ -65,3 +65,4 @@ void ProcessValue2(IDiaSymbol *pSymbol)
 
 ## See also
 - [IDiaSymbol](../../debugger/debug-interface-access/idiasymbol.md)
+- [Variant Manipulation Functions](/previous-versions/windows/desktop/automat/variant-manipulation-functions)


### PR DESCRIPTION
I believe that using `VariantInit` from oleauto.h is more future-proof rather than manually initializing the VARIANT's fields in case the internal implementation of VARIANT/VARIANTARG changes.

Regarding the "see also" added at the end: I see that it refers to "previous versions" topic and there is a warning banner when entering the page. Not sure if it is better this way or if we should refer readers to [VariantInit function (oleauto.h)](https://learn.microsoft.com/en-us/windows/win32/api/oleauto/nf-oleauto-variantinit) directly. On the other hand, that page refers readers to [Variant Manipulation Functions](https://learn.microsoft.com/en-us/previous-versions/windows/desktop/automat/variant-manipulation-functions)
