### PR TITLE
Add CV_MOD_UNALIGNED to examples

### DIFF
--- a/docs/debugger/debug-interface-access/cv-modifier-e.md
+++ b/docs/debugger/debug-interface-access/cv-modifier-e.md
@@ -58,6 +58,7 @@ typedef enum CV_modifier_e
 | `CV_MOD_INVALID` | Invalid modifier (unused) |
 | `CV_MOD_CONST` | C++ `const` |
 | `CV_MOD_VOLATILE` | C++ `volatile` |
+| `CV_MOD_UNALIGNED` | C++ `__unaligned` |
 | `CV_MOD_HLSL_UNIFORM` | HLSL uniform |
 | `CV_MOD_HLSL_LINE` | HLSL line |
 | `CV_MOD_HLSL_TRIANGLE` | HLSL triangle |


### PR DESCRIPTION
Double checked this with a quick compilation.

Given this struct compiled with `/Od`:
```C

typedef struct FieldsWithModifiers_s
{
    volatile long volatileField;
    const long constField;
    char padding1;
    _UNALIGNED long unalignedField;
    char padding2;
} FieldsWithModifiers;
```

We get that the _type_ of "unalignedField" is unaligned. That is:
"unalignedField" is a `SymTagData` symbol, its `get_type` returns a `SymTagBaseType`, and when performing `get_unalignedType` we get `true`. Calling `get_unalignedType` on "unalignedField" of tag `SymTagData` actually returns `false`. Not sure how intuitive it is, but should probably be mentioned in the docs.