### PR TITLE
Link to non-deprecated package

### DIFF
--- a/docs/extensibility/roslyn-version-support.md
+++ b/docs/extensibility/roslyn-version-support.md
@@ -12,7 +12,7 @@ ms.subservice: extensibility-integration
 ---
 # .NET compiler platform package version reference
 
-The following table shows which [.NET compiler platform (Roslyn) package](https://www.nuget.org/packages/Microsoft.Net.Compilers/) versions are supported for different versions of Visual Studio.
+The following table shows which [.NET compiler platform (Roslyn) package](https://www.nuget.org/packages/Microsoft.Net.Compilers.Toolset/) versions are supported for different versions of Visual Studio.
 
 As an example, to ensure that your custom analyzer works on all versions of Visual Studio 2017, it should target version 2.0 of Microsoft.Net.Compilers.
 


### PR DESCRIPTION
https://www.nuget.org/packages/Microsoft.Net.Compilers.Toolset is deprecated. I've updated the link to the non-deprecated version instead.