### PR TITLE
Update code sample on configure-unit-tests-by-using-a-dot-runsettings-file.md

### DIFF
--- a/docs/test/configure-unit-tests-by-using-a-dot-runsettings-file.md
+++ b/docs/test/configure-unit-tests-by-using-a-dot-runsettings-file.md
@@ -260,13 +260,12 @@ The XML configuration should be placed directly into `<RunSettings>` node:
 Test run parameters provide a way to define variables and values that are available to the tests at run time. Access the parameters using the MSTest <xref:Microsoft.VisualStudio.TestTools.UnitTesting.TestContext.Properties%2A?displayProperty=nameWithType> property (or the NUnit [TestContext](https://docs.nunit.org/articles/nunit/writing-tests/TestContext.html)):
 
 ```csharp
-private string _appUrl;
 public TestContext TestContext { get; set; }
 
 [TestMethod] // [Test] for NUnit
 public void HomePageTest()
 {
-    string _appUrl = TestContext.Properties["webAppUrl"];
+    string appUrl = TestContext.Properties["webAppUrl"];
 }
 ```
 


### PR DESCRIPTION
Updated the C# code sample in section TestRunParameters: it's either a field or a variable, not both at the same time.