### PR TITLE
Add example for filtering an item list based on 'String.Contains'

### DIFF
--- a/docs/msbuild/msbuild-items.md
+++ b/docs/msbuild/msbuild-items.md
@@ -157,6 +157,12 @@ For more information about wildcard characters, see [How to: Select the files to
 </Target>
 ```
 
+The following code filters an item list like `abcdef;abc;def;xyz` by creating a string using the `new` property function, and then using the String.Contains method to apply a substring test as a filter. This code only works in a target, since it uses a metadata expresion that only works in a target.
+
+```xml
+<Filtered Include="@(Unfiltered)" Condition="$([System.String]::new('%(Unfiltered.Identity)').Contains('abc'))"></Filtered>
+```
+
 For more operations on items, see [MSBuild item functions](item-functions.md) and [Transforms](../msbuild/msbuild-transforms.md).
 
 ## Item definitions


### PR DESCRIPTION

<!--
Thanks for contributing to the Visual Studio documentation.

Note: Internal Microsoft employees and vendors should use the private repo, https://github.com/MicrosoftDocs/visualstudio-docs-pr. You must be a member of the MicrosoftDocs GitHub organization. To join, see https://review.learn.microsoft.com/help/get-started/setup-github?branch=main#3-join-microsoftdocs-and-other-organizations.

Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for Microsoft Learn, see the [contributor guide](https://learn.microsoft.com/contribute/).

When your PR is ready for review, add a comment with the text #sign-off to the Conversation tab.
-->
