### PR TITLE
Remove extra comma in MSBuild AspNetCompiler task

### DIFF
--- a/docs/msbuild/aspnetcompiler-task.md
+++ b/docs/msbuild/aspnetcompiler-task.md
@@ -23,11 +23,11 @@ The `AspNetCompiler` task wraps *aspnet_compiler.exe*, a utility to precompile A
 
 ## Task parameters
 
-The following table describes the parameters of the `AspNetCompiler` task.
+The following table describes the parameters of the `AspNetCompiler` task:
 
 |Parameter|Description|
 |---------------|-----------------|
-|`AllowPartiallyTrustedCallers`|Optional `Boolean` parameter.<br /><br /> If this parameter is `true`,, the strong-name assembly will allow partially trusted callers.|
+|`AllowPartiallyTrustedCallers`|Optional `Boolean` parameter.<br /><br /> If this parameter is `true`, the strong-name assembly will allow partially trusted callers.|
 |`Clean`|Optional `Boolean` parameter<br /><br /> If this parameter is `true`, the precompiled application will be built clean. Any previously compiled components will be recompiled. The default value is `false`. This parameter corresponds to the **-c** switch on *aspnet_compiler.exe*.|
 |`Debug`|Optional `Boolean` parameter.<br /><br /> If this parameter is `true`, debug information (.PDB file) is emitted during compilation. The default value is `false`. This parameter corresponds to the **-d** switch on *aspnet_compiler.exe*.|
 |`DelaySign`|Optional `Boolean` parameter.<br /><br /> If this parameter is `true`, the assembly is not fully signed when created.|
@@ -46,7 +46,7 @@ The following table describes the parameters of the `AspNetCompiler` task.
 
 ## Example
 
-The following code example uses the `AspNetCompiler` task to precompile an ASP.NET application.
+The following code example uses the `AspNetCompiler` task to precompile an ASP.NET application:
 
 ```xml
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">


### PR DESCRIPTION
Remove the extra comma found and change period characters to colons (as those are referring to content below).