### PR TITLE
Add keyboard shortcuts to the completions documentation

### DIFF
--- a/docs/ide/visual-studio-github-copilot-extension.md
+++ b/docs/ide/visual-studio-github-copilot-extension.md
@@ -75,7 +75,7 @@ As you type code or comments in the editor, GitHub Copilot provides context-awar
   
    If the command palette doesn't appear, you might have reached the default limit for its display. To change this, go to **Tools** > **Options** > **IntelliCode** > **Advanced**, and adjust the value for **Minimum commits to suppress hint text**.
 
-1. Add following code to see whole line completions from GitHub Copilot.
+1. Add following code to see completions from GitHub Copilot.
 
    ```csharp
        int a = 5;
@@ -84,6 +84,11 @@ As you type code or comments in the editor, GitHub Copilot provides context-awar
    ```
   
     :::image type="content" source="media/vs-2022/visual-studio-github-copilot-extension/github-copilot-whole-line-completions.gif" alt-text="Animated screenshot that shows using the GitHub Copilot completions in Visual Studio.":::
+
+   **Tips**
+
+   - Manually trigger a completion using `Alt+,`
+   - Cycle through available completions using `Alt+.` (next) and `Alt+,` (previous)
 
 ## Content exclusions
 

--- a/docs/ide/visual-studio-github-copilot-extension.md
+++ b/docs/ide/visual-studio-github-copilot-extension.md
@@ -88,7 +88,7 @@ As you type code or comments in the editor, GitHub Copilot provides context-awar
    **Tips**
 
    - Manually trigger a completion using <kbd>Alt</kbd>+<kbd>,</kbd>
-   - Cycle through available completions using `Alt+.` (next) and `Alt+,` (previous)
+   - Cycle through available completions using <kbd>Alt</kbd>+<kbd>.</kbd> (next) and <kbd>Alt</kbd>+<kbd>,</kbd> (previous)
 
 ## Content exclusions
 

--- a/docs/ide/visual-studio-github-copilot-extension.md
+++ b/docs/ide/visual-studio-github-copilot-extension.md
@@ -87,7 +87,7 @@ As you type code or comments in the editor, GitHub Copilot provides context-awar
 
    **Tips**
 
-   - Manually trigger a completion using `Alt+,`
+   - Manually trigger a completion using <kbd>Alt</kbd>+<kbd>,</kbd>
    - Cycle through available completions using `Alt+.` (next) and `Alt+,` (previous)
 
 ## Content exclusions


### PR DESCRIPTION

<!--
Thanks for contributing to the Visual Studio documentation.

Note: Internal Microsoft employees and vendors should use the private repo, https://github.com/MicrosoftDocs/visualstudio-docs-pr. You must be a member of the MicrosoftDocs GitHub organization. To join, see https://review.learn.microsoft.com/help/get-started/setup-github?branch=main#3-join-microsoftdocs-and-other-organizations.

Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for Microsoft Learn, see the [contributor guide](https://learn.microsoft.com/contribute/).

When your PR is ready for review, add a comment with the text #sign-off to the Conversation tab.
-->
