### PR TITLE
Fix MSB8088 message in blockquotes

### DIFF
--- a/docs/msbuild/errors/msb8088.md
+++ b/docs/msbuild/errors/msb8088.md
@@ -15,6 +15,7 @@ ms.subservice: msbuild
 # MSBuild MSB8088 diagnostic code
 
 > MSB8088: Dynamic debugging and whole program optimization are incompatible. Disabling whole program optimization.
+
 When you turn on [C++ Dynamic Debugging (Preview)](/visualstudio/debugger/cpp-dynamic-debugging), the build automatically turns off whole program optimization (compiler switch [`/GL`](/cpp/build/reference/gl-whole-program-optimization)). These two options are incompatible.
 
 To resolve this issue, turn off whole program optimization in the project properties by setting **Configuration Properties** > **Advanced** > **Whole Program Optimization** to **Off**. For more information, see [General Property Page (Project)](/cpp/build/reference/general-property-page-project).


### PR DESCRIPTION
Fix issue where the first paragraph is lumped into the diagnostics message in blockquotes. This PR also adds the missing newline at the end of the file.