### PR TITLE
Adding default note for IncludeTestAssembly in code coverage documentation

### DIFF
--- a/docs/test/customizing-code-coverage-analysis.md
+++ b/docs/test/customizing-code-coverage-analysis.md
@@ -163,7 +163,7 @@ In this example, setting `<IncludeTestAssembly>` to `False` will exclude test as
 ```
 
 > [!NOTE]
-> The default value of `IncludeTestAssembly` in [VSTest](https:/visualstudio/test/vstest-console-options) is `true`, while it is `false` in [Microsoft.Testing.Platform](/dotnet/core/testing/microsoft-testing-platform-extensions-code-coverage). This means that test projects are included by default. For more information, see [Code Coverage configuration](https://github.com/microsoft/codecoverage/blob/main/docs/configuration.md).
+> The default value of `IncludeTestAssembly` in [VSTest](/visualstudio/test/vstest-console-options) is `true`, while it is `false` in [Microsoft.Testing.Platform](/dotnet/core/testing/microsoft-testing-platform-extensions-code-coverage). This means that test projects are included by default. For more information, see [Code Coverage configuration](https://github.com/microsoft/codecoverage/blob/main/docs/configuration.md).
 
 ### Regular expressions
 

--- a/docs/test/customizing-code-coverage-analysis.md
+++ b/docs/test/customizing-code-coverage-analysis.md
@@ -162,6 +162,9 @@ In this example, setting `<IncludeTestAssembly>` to `False` will exclude test as
 </RunSettings>
 ```
 
+> [!NOTE]
+> The default value of `IncludeTestAssembly` in [VSTest](https://learn.microsoft.com/en-us/visualstudio/test/vstest-console-options?view=vs-2022) is `true`, while it is `false` in [Microsoft.Testing.Platform](https://learn.microsoft.com/en-us/dotnet/core/testing/microsoft-testing-platform-extensions-code-coverage). This means that test projects are included by default. For more information, see [Code Coverage configuration](https://github.com/microsoft/codecoverage/blob/main/docs/configuration.md).
+
 ### Regular expressions
 
 Include and exclude nodes use regular expressions, which aren't the same as wildcards. All matches are case-insensitive. Some examples are:

--- a/docs/test/customizing-code-coverage-analysis.md
+++ b/docs/test/customizing-code-coverage-analysis.md
@@ -163,7 +163,7 @@ In this example, setting `<IncludeTestAssembly>` to `False` will exclude test as
 ```
 
 > [!NOTE]
-> The default value of `IncludeTestAssembly` in [VSTest](https://learn.microsoft.com/en-us/visualstudio/test/vstest-console-options?view=vs-2022) is `true`, while it is `false` in [Microsoft.Testing.Platform](https://learn.microsoft.com/en-us/dotnet/core/testing/microsoft-testing-platform-extensions-code-coverage). This means that test projects are included by default. For more information, see [Code Coverage configuration](https://github.com/microsoft/codecoverage/blob/main/docs/configuration.md).
+> The default value of `IncludeTestAssembly` in [VSTest](https:/visualstudio/test/vstest-console-options) is `true`, while it is `false` in [Microsoft.Testing.Platform](/dotnet/core/testing/microsoft-testing-platform-extensions-code-coverage). This means that test projects are included by default. For more information, see [Code Coverage configuration](https://github.com/microsoft/codecoverage/blob/main/docs/configuration.md).
 
 ### Regular expressions
 


### PR DESCRIPTION
Adding default note for IncludeTestAssembly in code coverage documentation