### PR TITLE
Fix URL

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -14105,7 +14105,7 @@
     },
     {
       "source_path": "scripting-docs/javascript/reference/winrterror-object-javascript.md",
-      "redirect_url": "https://docs.microsoft.com/microsoft-edge/progressive-web-apps/windows-features",
+      "redirect_url": "https://learn.microsoft.com/microsoft-edge/progressive-web-apps/windows-features",
       "redirect_document_id": false
     },
     {
@@ -17185,3052 +17185,3052 @@
     },
     {
       "source_path": "scripting-docs/winscript/reference/includes/vista-first-md.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/includes/vista-first",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/includes/vista-first",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/includes/win7-md.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/includes/win7",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/includes/win7",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/active-script-authoring-interfaces.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/active-script-authoring-interfaces",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/active-script-authoring-interfaces",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/active-script-constants-enumerations-and-error-codes.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/active-script-constants-enumerations-and-error-codes",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/active-script-constants-enumerations-and-error-codes",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/active-script-debugger-constants-enumerations-and-structures.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/active-script-debugger-constants-enumerations-and-structures",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/active-script-debugger-constants-enumerations-and-structures",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/active-script-debugger-interfaces.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/active-script-debugger-interfaces",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/active-script-debugger-interfaces",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/active-script-interfaces.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/active-script-interfaces",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/active-script-interfaces",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/active-script-profiler-constants-enumerations-and-structures.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/active-script-profiler-constants-enumerations-and-structures",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/active-script-profiler-constants-enumerations-and-structures",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/active-script-profiler-interfaces.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/active-script-profiler-interfaces",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/active-script-profiler-interfaces",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/appbreakflags-enumeration.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/appbreakflags-enumeration",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/appbreakflags-enumeration",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/application-node-event-filter-enumeration.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/application-node-event-filter-enumeration",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/application-node-event-filter-enumeration",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/breakpoint-state-enumeration.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/breakpoint-state-enumeration",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/breakpoint-state-enumeration",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/breakreason-enumeration.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/breakreason-enumeration",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/breakreason-enumeration",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/breakresumeaction-enumeration.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/breakresumeaction-enumeration",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/breakresumeaction-enumeration",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/dbgprop-attrib-flags.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/dbgprop-attrib-flags",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/dbgprop-attrib-flags",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/dbgprop-info-flags.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/dbgprop-info-flags",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/dbgprop-info-flags",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/debugpropertyinfo-structure.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/debugpropertyinfo-structure",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/debugpropertyinfo-structure",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/debug-property-interfaces.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/debug-property-interfaces",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/debug-property-interfaces",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/debugstackframedescriptor-structure.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/debugstackframedescriptor-structure",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/debugstackframedescriptor-structure",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/debug-text-constants.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/debug-text-constants",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/debug-text-constants",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/dispatch-extension-interfaces.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/dispatch-extension-interfaces",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/dispatch-extension-interfaces",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/documentnametype-enumeration.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/documentnametype-enumeration",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/documentnametype-enumeration",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/errorresumeaction-enumeration.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/errorresumeaction-enumeration",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/errorresumeaction-enumeration",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ex-dbgprop-info-flags.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ex-dbgprop-info-flags",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ex-dbgprop-info-flags",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/extendeddebugpropertyinfo-structure.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/extendeddebugpropertyinfo-structure",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/extendeddebugpropertyinfo-structure",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescript.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescript",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescript",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescript-addnameditem.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescript-addnameditem",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescript-addnameditem",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescript-addtypelib.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescript-addtypelib",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescript-addtypelib",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptauthor-addnameditem.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptauthor-addnameditem",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptauthor-addnameditem",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptauthor-addscriptlet.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptauthor-addscriptlet",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptauthor-addscriptlet",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptauthor-addtypelib.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptauthor-addtypelib",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptauthor-addtypelib",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptauthor-getchars.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptauthor-getchars",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptauthor-getchars",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptauthor-geteventhandler.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptauthor-geteventhandler",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptauthor-geteventhandler",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptauthor-getinfofromcontext.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptauthor-getinfofromcontext",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptauthor-getinfofromcontext",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptauthor-getlanguageflags.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptauthor-getlanguageflags",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptauthor-getlanguageflags",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptauthor-getroot.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptauthor-getroot",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptauthor-getroot",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptauthor-getscriptlettextattributes.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptauthor-getscriptlettextattributes",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptauthor-getscriptlettextattributes",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptauthor-getscripttextattributes.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptauthor-getscripttextattributes",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptauthor-getscripttextattributes",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptauthor-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptauthor-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptauthor-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptauthor-iscommitchar.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptauthor-iscommitchar",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptauthor-iscommitchar",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptauthor-parsescripttext.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptauthor-parsescripttext",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptauthor-parsescripttext",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptauthorprocedure-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptauthorprocedure-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptauthorprocedure-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptauthorprocedure-parseproceduretext.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptauthorprocedure-parseproceduretext",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptauthorprocedure-parseproceduretext",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptauthor-removenameditem.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptauthor-removenameditem",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptauthor-removenameditem",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptauthor-removetypelib.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptauthor-removetypelib",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptauthor-removetypelib",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescript-clone.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescript-clone",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescript-clone",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescript-close.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescript-close",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescript-close",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptdebug-enumcodecontextsofposition.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptdebug-enumcodecontextsofposition",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptdebug-enumcodecontextsofposition",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptdebug-getscriptlettextattributes.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptdebug-getscriptlettextattributes",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptdebug-getscriptlettextattributes",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptdebug-getscripttextattributes.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptdebug-getscripttextattributes",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptdebug-getscripttextattributes",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptdebug-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptdebug-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptdebug-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescripterror.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescripterror",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescripterror",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescripterrordebug110-getexceptionthrownkind.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescripterrordebug110-getexceptionthrownkind",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescripterrordebug110-getexceptionthrownkind",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescripterrordebug110-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescripterrordebug110-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescripterrordebug110-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescripterrordebug-getdocumentcontext.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescripterrordebug-getdocumentcontext",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescripterrordebug-getdocumentcontext",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescripterrordebug-getstackframe.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescripterrordebug-getstackframe",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescripterrordebug-getstackframe",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescripterrordebug-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescripterrordebug-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescripterrordebug-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescripterror-getexceptioninfo.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescripterror-getexceptioninfo",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescripterror-getexceptioninfo",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescripterror-getsourcelinetext.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescripterror-getsourcelinetext",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescripterror-getsourcelinetext",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescripterror-getsourceposition.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescripterror-getsourceposition",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescripterror-getsourceposition",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptgarbagecollector-collectgarbage.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptgarbagecollector-collectgarbage",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptgarbagecollector-collectgarbage",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptgarbagecollector-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptgarbagecollector-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptgarbagecollector-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescript-getcurrentscriptthreadid.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescript-getcurrentscriptthreadid",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescript-getcurrentscriptthreadid",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescript-getscriptdispatch.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescript-getscriptdispatch",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescript-getscriptdispatch",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescript-getscriptsite.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescript-getscriptsite",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescript-getscriptsite",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescript-getscriptstate.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescript-getscriptstate",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescript-getscriptstate",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescript-getscriptthreadid.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescript-getscriptthreadid",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescript-getscriptthreadid",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescript-getscriptthreadstate.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescript-getscriptthreadstate",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescript-getscriptthreadstate",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescript-interruptscriptthread.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescript-interruptscriptthread",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescript-interruptscriptthread",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptparse.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptparse",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptparse",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptparse32.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptparse32",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptparse32",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptparse32-addscriptlet.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptparse32-addscriptlet",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptparse32-addscriptlet",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptparse32-initnew.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptparse32-initnew",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptparse32-initnew",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptparse32-parsescripttext.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptparse32-parsescripttext",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptparse32-parsescripttext",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptparse-addscriptlet.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptparse-addscriptlet",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptparse-addscriptlet",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptparse-initnew.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptparse-initnew",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptparse-initnew",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptparse-parsescripttext.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptparse-parsescripttext",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptparse-parsescripttext",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptparseprocedure.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptparseprocedure",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptparseprocedure",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptparseprocedure32.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptparseprocedure32",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptparseprocedure32",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptparseprocedure32-parseproceduretext.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptparseprocedure32-parseproceduretext",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptparseprocedure32-parseproceduretext",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptparseprocedureold-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptparseprocedureold-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptparseprocedureold-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptparseprocedureold-parseproceduretext.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptparseprocedureold-parseproceduretext",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptparseprocedureold-parseproceduretext",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptparseprocedure-parseproceduretext.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptparseprocedure-parseproceduretext",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptparseprocedure-parseproceduretext",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptprofilercallback2-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptprofilercallback2-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptprofilercallback2-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptprofilercallback2-onfunctionenterbyname.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptprofilercallback2-onfunctionenterbyname",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptprofilercallback2-onfunctionenterbyname",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptprofilercallback2-onfunctionexitbyname.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptprofilercallback2-onfunctionexitbyname",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptprofilercallback2-onfunctionexitbyname",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptprofilercallback3-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptprofilercallback3-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptprofilercallback3-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptprofilercallback3-setwebworkerid-method.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptprofilercallback3-setwebworkerid-method",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptprofilercallback3-setwebworkerid-method",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptprofilercallback-functioncompiled.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptprofilercallback-functioncompiled",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptprofilercallback-functioncompiled",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptprofilercallback-initialize.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptprofilercallback-initialize",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptprofilercallback-initialize",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptprofilercallback-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptprofilercallback-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptprofilercallback-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptprofilercallback-onfunctionenter.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptprofilercallback-onfunctionenter",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptprofilercallback-onfunctionenter",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptprofilercallback-onfunctionexit.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptprofilercallback-onfunctionexit",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptprofilercallback-onfunctionexit",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptprofilercallback-scriptcompiled.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptprofilercallback-scriptcompiled",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptprofilercallback-scriptcompiled",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptprofilercallback-shutdown.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptprofilercallback-shutdown",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptprofilercallback-shutdown",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptprofilercontrol2-completeprofilerstart.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptprofilercontrol2-completeprofilerstart",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptprofilercontrol2-completeprofilerstart",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptprofilercontrol2-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptprofilercontrol2-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptprofilercontrol2-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptprofilercontrol2-prepareprofilerstop.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptprofilercontrol2-prepareprofilerstop",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptprofilercontrol2-prepareprofilerstop",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptprofilercontrol3-enumheap-method.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptprofilercontrol3-enumheap-method",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptprofilercontrol3-enumheap-method",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptprofilercontrol3-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptprofilercontrol3-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptprofilercontrol3-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptprofilercontrol5-enumheap2-method.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptprofilercontrol5-enumheap2-method",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptprofilercontrol5-enumheap2-method",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptprofilercontrol5-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptprofilercontrol5-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptprofilercontrol5-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptprofilercontrol-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptprofilercontrol-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptprofilercontrol-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptprofilercontrol-setprofilereventmask.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptprofilercontrol-setprofilereventmask",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptprofilercontrol-setprofilereventmask",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptprofilercontrol-startprofiling.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptprofilercontrol-startprofiling",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptprofilercontrol-startprofiling",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptprofilercontrol-stopprofiling.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptprofilercontrol-stopprofiling",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptprofilercontrol-stopprofiling",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptprofilerheapenum-freeobjectandoptionalinfo-method.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptprofilerheapenum-freeobjectandoptionalinfo-method",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptprofilerheapenum-freeobjectandoptionalinfo-method",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptprofilerheapenum-getnameidmap.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptprofilerheapenum-getnameidmap",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptprofilerheapenum-getnameidmap",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptprofilerheapenum-getoptionalinfo-method.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptprofilerheapenum-getoptionalinfo-method",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptprofilerheapenum-getoptionalinfo-method",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptprofilerheapenum-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptprofilerheapenum-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptprofilerheapenum-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptprofilerheapenum-next-method.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptprofilerheapenum-next-method",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptprofilerheapenum-next-method",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptproperty.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptproperty",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptproperty",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptproperty-getproperty.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptproperty-getproperty",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptproperty-getproperty",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptproperty-setproperty.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptproperty-setproperty",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptproperty-setproperty",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescript-setscriptsite.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescript-setscriptsite",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescript-setscriptsite",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescript-setscriptstate.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescript-setscriptstate",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescript-setscriptstate",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptsite.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptsite",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptsite",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptsitedebug32-getapplication.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptsitedebug32-getapplication",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptsitedebug32-getapplication",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptsitedebug32-getdocumentcontextfromposition.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptsitedebug32-getdocumentcontextfromposition",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptsitedebug32-getdocumentcontextfromposition",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptsitedebug32-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptsitedebug32-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptsitedebug32-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptsitedebugex-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptsitedebugex-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptsitedebugex-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptsitedebugex-oncannotjitscripterrordebug.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptsitedebugex-oncannotjitscripterrordebug",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptsitedebugex-oncannotjitscripterrordebug",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptsitedebug-getapplication.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptsitedebug-getapplication",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptsitedebug-getapplication",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptsitedebug-getdocumentcontextfromposition.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptsitedebug-getdocumentcontextfromposition",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptsitedebug-getdocumentcontextfromposition",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptsitedebug-getrootapplicationnode.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptsitedebug-getrootapplicationnode",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptsitedebug-getrootapplicationnode",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptsitedebug-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptsitedebug-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptsitedebug-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptsitedebug-onscripterrordebug.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptsitedebug-onscripterrordebug",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptsitedebug-onscripterrordebug",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptsite-getdocversionstring.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptsite-getdocversionstring",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptsite-getdocversionstring",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptsite-getiteminfo.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptsite-getiteminfo",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptsite-getiteminfo",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptsite-getlcid.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptsite-getlcid",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptsite-getlcid",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptsiteinterruptpoll-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptsiteinterruptpoll-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptsiteinterruptpoll-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptsiteinterruptpoll-querycontinue.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptsiteinterruptpoll-querycontinue",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptsiteinterruptpoll-querycontinue",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptsite-onenterscript.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptsite-onenterscript",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptsite-onenterscript",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptsite-onleavescript.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptsite-onleavescript",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptsite-onleavescript",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptsite-onscripterror.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptsite-onscripterror",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptsite-onscripterror",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptsite-onscriptterminate.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptsite-onscriptterminate",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptsite-onscriptterminate",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptsite-onstatechange.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptsite-onstatechange",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptsite-onstatechange",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptsitetraceinfo-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptsitetraceinfo-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptsitetraceinfo-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptsitetraceinfo-sendscripttraceinfo-method.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptsitetraceinfo-sendscripttraceinfo-method",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptsitetraceinfo-sendscripttraceinfo-method",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptsiteuicontrol-getuibehavior-method.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptsiteuicontrol-getuibehavior-method",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptsiteuicontrol-getuibehavior-method",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptsiteuicontrol-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptsiteuicontrol-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptsiteuicontrol-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptsitewindow.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptsitewindow",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptsitewindow",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptsitewindow-enablemodeless.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptsitewindow-enablemodeless",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptsitewindow-enablemodeless",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptsitewindow-getwindow.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptsitewindow-getwindow",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptsitewindow-getwindow",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptstats-getstat.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptstats-getstat",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptstats-getstat",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptstats-getstatex.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptstats-getstatex",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptstats-getstatex",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptstats-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptstats-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptstats-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptstats-resetstats.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptstats-resetstats",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptstats-resetstats",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptstringcompare-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptstringcompare-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptstringcompare-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptstringcompare-strcomp.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptstringcompare-strcomp",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptstringcompare-strcomp",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescripttraceinfo-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescripttraceinfo-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescripttraceinfo-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescripttraceinfo-startscripttracing-method.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescripttraceinfo-startscripttracing-method",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescripttraceinfo-startscripttracing-method",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescripttraceinfo-stopscripttracing-method.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescripttraceinfo-stopscripttracing-method",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescripttraceinfo-stopscripttracing-method",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptwinrterrordebug-getcapabilitysid.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptwinrterrordebug-getcapabilitysid",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptwinrterrordebug-getcapabilitysid",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptwinrterrordebug-getrestrictederrorreference.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptwinrterrordebug-getrestrictederrorreference",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptwinrterrordebug-getrestrictederrorreference",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptwinrterrordebug-getrestrictederrorstring.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptwinrterrordebug-getrestrictederrorstring",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptwinrterrordebug-getrestrictederrorstring",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iactivescriptwinrterrordebug-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptwinrterrordebug-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iactivescriptwinrterrordebug-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iapplicationdebugger-createinstanceatdebugger.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iapplicationdebugger-createinstanceatdebugger",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iapplicationdebugger-createinstanceatdebugger",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iapplicationdebugger-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iapplicationdebugger-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iapplicationdebugger-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iapplicationdebugger-onclose.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iapplicationdebugger-onclose",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iapplicationdebugger-onclose",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iapplicationdebugger-ondebuggerevent.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iapplicationdebugger-ondebuggerevent",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iapplicationdebugger-ondebuggerevent",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iapplicationdebugger-ondebugoutput.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iapplicationdebugger-ondebugoutput",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iapplicationdebugger-ondebugoutput",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iapplicationdebugger-onhandlebreakpoint.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iapplicationdebugger-onhandlebreakpoint",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iapplicationdebugger-onhandlebreakpoint",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iapplicationdebugger-queryalive.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iapplicationdebugger-queryalive",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iapplicationdebugger-queryalive",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iapplicationdebuggerui-bringdocumentcontexttotop.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iapplicationdebuggerui-bringdocumentcontexttotop",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iapplicationdebuggerui-bringdocumentcontexttotop",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iapplicationdebuggerui-bringdocumenttotop.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iapplicationdebuggerui-bringdocumenttotop",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iapplicationdebuggerui-bringdocumenttotop",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iapplicationdebuggerui-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iapplicationdebuggerui-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iapplicationdebuggerui-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ibindeventhandler-bindhandler.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ibindeventhandler-bindhandler",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ibindeventhandler-bindhandler",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ibindeventhandler-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ibindeventhandler-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ibindeventhandler-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/icanhandleexception-canhandleexception.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/icanhandleexception-canhandleexception",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/icanhandleexception-canhandleexception",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/icanhandleexception-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/icanhandleexception-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/icanhandleexception-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugapplication110-asynchronouscallinmainthread.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplication110-asynchronouscallinmainthread",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplication110-asynchronouscallinmainthread",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugapplication110-callablewaitforhandles.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplication110-callablewaitforhandles",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplication110-callablewaitforhandles",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugapplication110-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplication110-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplication110-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugapplication110-synchronouscallinmainthread.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplication110-synchronouscallinmainthread",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplication110-synchronouscallinmainthread",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugapplication-addglobalexpressioncontextprovider.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplication-addglobalexpressioncontextprovider",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplication-addglobalexpressioncontextprovider",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugapplication-addstackframesniffer.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplication-addstackframesniffer",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplication-addstackframesniffer",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugapplication-close.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplication-close",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplication-close",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugapplication-createapplicationnode.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplication-createapplicationnode",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplication-createapplicationnode",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugapplication-createasyncdebugoperation.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplication-createasyncdebugoperation",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplication-createasyncdebugoperation",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugapplication-debugoutput.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplication-debugoutput",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplication-debugoutput",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugapplication-fcanjitdebug.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplication-fcanjitdebug",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplication-fcanjitdebug",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugapplication-firedebuggerevent.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplication-firedebuggerevent",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplication-firedebuggerevent",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugapplication-fisautojitdebugenabled.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplication-fisautojitdebugenabled",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplication-fisautojitdebugenabled",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugapplication-getbreakflags.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplication-getbreakflags",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplication-getbreakflags",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugapplication-getcurrentthread.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplication-getcurrentthread",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplication-getcurrentthread",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugapplication-handlebreakpoint.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplication-handlebreakpoint",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplication-handlebreakpoint",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugapplication-handleruntimeerror.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplication-handleruntimeerror",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplication-handleruntimeerror",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugapplication-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplication-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplication-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugapplicationnode100-getexcludeddocuments.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplicationnode100-getexcludeddocuments",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplicationnode100-getexcludeddocuments",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugapplicationnode100-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplicationnode100-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplicationnode100-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugapplicationnode100-queryischildnode.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplicationnode100-queryischildnode",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplicationnode100-queryischildnode",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugapplicationnode100-setfilterforeventsink.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplicationnode100-setfilterforeventsink",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplicationnode100-setfilterforeventsink",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugapplicationnode-attach.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplicationnode-attach",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplicationnode-attach",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugapplicationnode-close.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplicationnode-close",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplicationnode-close",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugapplicationnode-detach.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplicationnode-detach",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplicationnode-detach",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugapplicationnode-enumchildren.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplicationnode-enumchildren",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplicationnode-enumchildren",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugapplicationnodeevents-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplicationnodeevents-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplicationnodeevents-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugapplicationnodeevents-onaddchild.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplicationnodeevents-onaddchild",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplicationnodeevents-onaddchild",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugapplicationnodeevents-onattach.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplicationnodeevents-onattach",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplicationnodeevents-onattach",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugapplicationnodeevents-ondetach.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplicationnodeevents-ondetach",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplicationnodeevents-ondetach",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugapplicationnodeevents-onremovechild.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplicationnodeevents-onremovechild",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplicationnodeevents-onremovechild",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugapplicationnode-getparent.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplicationnode-getparent",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplicationnode-getparent",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugapplicationnode-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplicationnode-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplicationnode-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugapplicationnode-setdocumentprovider.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplicationnode-setdocumentprovider",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplicationnode-setdocumentprovider",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugapplication-querycurrentthreadisdebuggerthread.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplication-querycurrentthreadisdebuggerthread",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplication-querycurrentthreadisdebuggerthread",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugapplication-removeglobalexpressioncontextprovider.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplication-removeglobalexpressioncontextprovider",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplication-removeglobalexpressioncontextprovider",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugapplication-removestackframesniffer.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplication-removestackframesniffer",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplication-removestackframesniffer",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugapplication-setname.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplication-setname",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplication-setname",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugapplication-startdebugsession.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplication-startdebugsession",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplication-startdebugsession",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugapplication-stepoutcomplete.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplication-stepoutcomplete",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplication-stepoutcomplete",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugapplication-synchronouscallindebuggerthread.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplication-synchronouscallindebuggerthread",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplication-synchronouscallindebuggerthread",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugapplicationthread110-asynchronouscallintothread.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplicationthread110-asynchronouscallintothread",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplicationthread110-asynchronouscallintothread",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugapplicationthread110-getactivethreadrequestcount.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplicationthread110-getactivethreadrequestcount",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplicationthread110-getactivethreadrequestcount",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugapplicationthread110-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplicationthread110-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplicationthread110-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugapplicationthread110-issuspendedforbreakpoint.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplicationthread110-issuspendedforbreakpoint",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplicationthread110-issuspendedforbreakpoint",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugapplicationthread110-isthreadcallable.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplicationthread110-isthreadcallable",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplicationthread110-isthreadcallable",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugapplicationthreadevents110-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplicationthreadevents110-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplicationthreadevents110-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugapplicationthreadevents110-onbeginthreadrequest.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplicationthreadevents110-onbeginthreadrequest",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplicationthreadevents110-onbeginthreadrequest",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugapplicationthreadevents110-onresumefrombreakpoint.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplicationthreadevents110-onresumefrombreakpoint",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplicationthreadevents110-onresumefrombreakpoint",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugapplicationthreadevents110-onsuspendforbreakpoint.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplicationthreadevents110-onsuspendforbreakpoint",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplicationthreadevents110-onsuspendforbreakpoint",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugapplicationthreadevents110-onthreadrequestcomplete.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplicationthreadevents110-onthreadrequestcomplete",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplicationthreadevents110-onthreadrequestcomplete",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugapplicationthread-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplicationthread-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplicationthread-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugapplicationthread-queryiscurrentthread.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplicationthread-queryiscurrentthread",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplicationthread-queryiscurrentthread",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugapplicationthread-queryisdebuggerthread.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplicationthread-queryisdebuggerthread",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplicationthread-queryisdebuggerthread",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugapplicationthread-setdescription.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplicationthread-setdescription",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplicationthread-setdescription",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugapplicationthread-setstatestring.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplicationthread-setstatestring",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplicationthread-setstatestring",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugapplicationthread-synchronouscallintothread.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplicationthread-synchronouscallintothread",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugapplicationthread-synchronouscallintothread",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugasyncoperation-abort.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugasyncoperation-abort",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugasyncoperation-abort",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugasyncoperationcallback-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugasyncoperationcallback-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugasyncoperationcallback-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugasyncoperationcallback-oncomplete.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugasyncoperationcallback-oncomplete",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugasyncoperationcallback-oncomplete",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugasyncoperation-getresult.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugasyncoperation-getresult",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugasyncoperation-getresult",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugasyncoperation-getsyncdebugoperation.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugasyncoperation-getsyncdebugoperation",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugasyncoperation-getsyncdebugoperation",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugasyncoperation-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugasyncoperation-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugasyncoperation-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugasyncoperation-queryiscomplete.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugasyncoperation-queryiscomplete",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugasyncoperation-queryiscomplete",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugasyncoperation-start.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugasyncoperation-start",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugasyncoperation-start",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugcodecontext-getdocumentcontext.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugcodecontext-getdocumentcontext",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugcodecontext-getdocumentcontext",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugcodecontext-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugcodecontext-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugcodecontext-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugcodecontext-setbreakpoint.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugcodecontext-setbreakpoint",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugcodecontext-setbreakpoint",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugcookie-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugcookie-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugcookie-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugcookie-setdebugcookie.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugcookie-setdebugcookie",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugcookie-setdebugcookie",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugdocumentcontext-enumcodecontexts.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumentcontext-enumcodecontexts",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumentcontext-enumcodecontexts",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugdocumentcontext-getdocument.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumentcontext-getdocument",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumentcontext-getdocument",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugdocumentcontext-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumentcontext-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumentcontext-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugdocumenthelper-adddbcstext.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenthelper-adddbcstext",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenthelper-adddbcstext",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugdocumenthelper-adddeferredtext.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenthelper-adddeferredtext",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenthelper-adddeferredtext",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugdocumenthelper-addunicodetext.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenthelper-addunicodetext",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenthelper-addunicodetext",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugdocumenthelper-attach.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenthelper-attach",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenthelper-attach",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugdocumenthelper-bringdocumentcontexttotop.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenthelper-bringdocumentcontexttotop",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenthelper-bringdocumentcontexttotop",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugdocumenthelper-bringdocumenttotop.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenthelper-bringdocumenttotop",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenthelper-bringdocumenttotop",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugdocumenthelper-createdebugdocumentcontext.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenthelper-createdebugdocumentcontext",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenthelper-createdebugdocumentcontext",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugdocumenthelper-definescriptblock.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenthelper-definescriptblock",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenthelper-definescriptblock",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugdocumenthelper-detach.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenthelper-detach",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenthelper-detach",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugdocumenthelper-getdebugapplicationnode.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenthelper-getdebugapplicationnode",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenthelper-getdebugapplicationnode",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugdocumenthelper-getscriptblockinfo.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenthelper-getscriptblockinfo",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenthelper-getscriptblockinfo",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugdocumenthelper-init.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenthelper-init",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenthelper-init",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugdocumenthelper-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenthelper-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenthelper-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugdocumenthelper-setdebugdocumenthost.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenthelper-setdebugdocumenthost",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenthelper-setdebugdocumenthost",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugdocumenthelper-setdefaulttextattr.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenthelper-setdefaulttextattr",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenthelper-setdefaulttextattr",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugdocumenthelper-setdocumentattr.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenthelper-setdocumentattr",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenthelper-setdocumentattr",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugdocumenthelper-setlongname.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenthelper-setlongname",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenthelper-setlongname",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugdocumenthelper-setshortname.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenthelper-setshortname",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenthelper-setshortname",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugdocumenthelper-settextattributes.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenthelper-settextattributes",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenthelper-settextattributes",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugdocumenthost-getdeferredtext.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenthost-getdeferredtext",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenthost-getdeferredtext",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugdocumenthost-getfilename.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenthost-getfilename",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenthost-getfilename",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugdocumenthost-getpathname.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenthost-getpathname",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenthost-getpathname",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugdocumenthost-getscripttextattributes.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenthost-getscripttextattributes",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenthost-getscripttextattributes",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugdocumenthost-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenthost-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenthost-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugdocumenthost-notifychanged.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenthost-notifychanged",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenthost-notifychanged",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugdocumenthost-oncreatedocumentcontext.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenthost-oncreatedocumentcontext",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenthost-oncreatedocumentcontext",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugdocumentinfo-getdocumentclassid.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumentinfo-getdocumentclassid",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumentinfo-getdocumentclassid",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugdocumentinfo-getname.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumentinfo-getname",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumentinfo-getname",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugdocumentinfo-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumentinfo-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumentinfo-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugdocument-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocument-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocument-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugdocumentprovider-getdocument.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumentprovider-getdocument",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumentprovider-getdocument",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugdocumentprovider-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumentprovider-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumentprovider-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugdocumenttextauthor-inserttext.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenttextauthor-inserttext",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenttextauthor-inserttext",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugdocumenttextauthor-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenttextauthor-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenttextauthor-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugdocumenttextauthor-removetext.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenttextauthor-removetext",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenttextauthor-removetext",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugdocumenttextauthor-replacetext.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenttextauthor-replacetext",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenttextauthor-replacetext",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugdocumenttextevents-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenttextevents-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenttextevents-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugdocumenttextevents-ondestroy.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenttextevents-ondestroy",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenttextevents-ondestroy",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugdocumenttextevents-oninserttext.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenttextevents-oninserttext",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenttextevents-oninserttext",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugdocumenttextevents-onremovetext.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenttextevents-onremovetext",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenttextevents-onremovetext",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugdocumenttextevents-onreplacetext.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenttextevents-onreplacetext",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenttextevents-onreplacetext",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugdocumenttextevents-onupdatedocumentattributes.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenttextevents-onupdatedocumentattributes",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenttextevents-onupdatedocumentattributes",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugdocumenttextevents-onupdatetextattributes.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenttextevents-onupdatetextattributes",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenttextevents-onupdatetextattributes",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugdocumenttextexternalauthor-getfilename.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenttextexternalauthor-getfilename",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenttextexternalauthor-getfilename",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugdocumenttextexternalauthor-getpathname.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenttextexternalauthor-getpathname",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenttextexternalauthor-getpathname",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugdocumenttextexternalauthor-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenttextexternalauthor-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenttextexternalauthor-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugdocumenttextexternalauthor-notifychanged.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenttextexternalauthor-notifychanged",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenttextexternalauthor-notifychanged",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugdocumenttext-getcontextofposition.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenttext-getcontextofposition",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenttext-getcontextofposition",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugdocumenttext-getdocumentattributes.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenttext-getdocumentattributes",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenttext-getdocumentattributes",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugdocumenttext-getlineofposition.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenttext-getlineofposition",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenttext-getlineofposition",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugdocumenttext-getpositionofcontext.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenttext-getpositionofcontext",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenttext-getpositionofcontext",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugdocumenttext-getpositionofline.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenttext-getpositionofline",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenttext-getpositionofline",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugdocumenttext-getsize.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenttext-getsize",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenttext-getsize",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugdocumenttext-gettext.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenttext-gettext",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenttext-gettext",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugdocumenttext-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenttext-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugdocumenttext-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugexpression-abort.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugexpression-abort",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugexpression-abort",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugexpressioncallback-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugexpressioncallback-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugexpressioncallback-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugexpressioncallback-oncomplete.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugexpressioncallback-oncomplete",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugexpressioncallback-oncomplete",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugexpressioncontext-getlanguageinfo.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugexpressioncontext-getlanguageinfo",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugexpressioncontext-getlanguageinfo",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugexpressioncontext-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugexpressioncontext-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugexpressioncontext-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugexpressioncontext-parselanguagetext.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugexpressioncontext-parselanguagetext",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugexpressioncontext-parselanguagetext",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugexpression-getresultasdebugproperty.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugexpression-getresultasdebugproperty",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugexpression-getresultasdebugproperty",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugexpression-getresultasstring.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugexpression-getresultasstring",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugexpression-getresultasstring",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugexpression-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugexpression-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugexpression-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugexpression-queryiscomplete.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugexpression-queryiscomplete",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugexpression-queryiscomplete",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugexpression-start.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugexpression-start",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugexpression-start",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugextendedproperty-enumextendedmembers.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugextendedproperty-enumextendedmembers",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugextendedproperty-enumextendedmembers",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugextendedproperty-getextendedpropertyinfo.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugextendedproperty-getextendedpropertyinfo",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugextendedproperty-getextendedpropertyinfo",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugextendedproperty-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugextendedproperty-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugextendedproperty-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugformatter-getstringforvariant.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugformatter-getstringforvariant",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugformatter-getstringforvariant",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugformatter-getstringforvartype.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugformatter-getstringforvartype",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugformatter-getstringforvartype",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugformatter-getvariantforstring.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugformatter-getvariantforstring",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugformatter-getvariantforstring",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugformatter-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugformatter-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugformatter-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebughelper-createpropertybrowser.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebughelper-createpropertybrowser",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebughelper-createpropertybrowser",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebughelper-createpropertybrowserex.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebughelper-createpropertybrowserex",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebughelper-createpropertybrowserex",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebughelper-createsimpleconnectionpoint.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebughelper-createsimpleconnectionpoint",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebughelper-createsimpleconnectionpoint",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebughelper-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebughelper-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebughelper-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugproperty-enummembers.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugproperty-enummembers",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugproperty-enummembers",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugpropertyenumtype-all-getname.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugpropertyenumtype-all-getname",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugpropertyenumtype-all-getname",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugpropertyenumtype-all-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugpropertyenumtype-all-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugpropertyenumtype-all-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugproperty-getextendedinfo.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugproperty-getextendedinfo",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugproperty-getextendedinfo",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugproperty-getparent.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugproperty-getparent",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugproperty-getparent",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugproperty-getpropertyinfo.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugproperty-getpropertyinfo",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugproperty-getpropertyinfo",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugproperty-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugproperty-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugproperty-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugproperty-setvalueasstring.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugproperty-setvalueasstring",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugproperty-setvalueasstring",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugsessionproviderex-canjitdebug.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugsessionproviderex-canjitdebug",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugsessionproviderex-canjitdebug",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugsessionproviderex-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugsessionproviderex-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugsessionproviderex-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugsessionproviderex-startdebugsession.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugsessionproviderex-startdebugsession",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugsessionproviderex-startdebugsession",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugsessionprovider-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugsessionprovider-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugsessionprovider-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugsessionprovider-startdebugsession.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugsessionprovider-startdebugsession",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugsessionprovider-startdebugsession",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugstackframe-getcodecontext.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugstackframe-getcodecontext",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugstackframe-getcodecontext",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugstackframe-getdebugproperty.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugstackframe-getdebugproperty",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugstackframe-getdebugproperty",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugstackframe-getdescriptionstring.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugstackframe-getdescriptionstring",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugstackframe-getdescriptionstring",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugstackframe-getlanguagestring.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugstackframe-getlanguagestring",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugstackframe-getlanguagestring",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugstackframe-getthread.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugstackframe-getthread",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugstackframe-getthread",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugstackframe-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugstackframe-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugstackframe-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugstackframesniffer-enumstackframes.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugstackframesniffer-enumstackframes",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugstackframesniffer-enumstackframes",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugstackframesnifferex-enumstackframesex.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugstackframesnifferex-enumstackframesex",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugstackframesnifferex-enumstackframesex",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugstackframesnifferex-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugstackframesnifferex-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugstackframesnifferex-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugstackframesniffer-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugstackframesniffer-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugstackframesniffer-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugsyncoperation-execute.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugsyncoperation-execute",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugsyncoperation-execute",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugsyncoperation-gettargetthread.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugsyncoperation-gettargetthread",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugsyncoperation-gettargetthread",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugsyncoperation-inprogressabort.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugsyncoperation-inprogressabort",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugsyncoperation-inprogressabort",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugsyncoperation-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugsyncoperation-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugsyncoperation-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugthreadcall-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugthreadcall-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugthreadcall-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idebugthreadcall-threadcallhandler.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugthreadcall-threadcallhandler",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idebugthreadcall-threadcallhandler",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idispatchex-deletememberbydispid.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idispatchex-deletememberbydispid",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idispatchex-deletememberbydispid",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idispatchex-deletememberbyname.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idispatchex-deletememberbyname",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idispatchex-deletememberbyname",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idispatchex-getdispid.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idispatchex-getdispid",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idispatchex-getdispid",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idispatchex-getmembername.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idispatchex-getmembername",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idispatchex-getmembername",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idispatchex-getmemberproperties.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idispatchex-getmemberproperties",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idispatchex-getmemberproperties",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idispatchex-getnamespaceparent.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idispatchex-getnamespaceparent",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idispatchex-getnamespaceparent",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idispatchex-getnextdispid.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idispatchex-getnextdispid",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idispatchex-getnextdispid",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idispatchex-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idispatchex-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idispatchex-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idispatchex-invokeex.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idispatchex-invokeex",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idispatchex-invokeex",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idispatchex-methods.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idispatchex-methods",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idispatchex-methods",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idisperror-getdescription.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idisperror-getdescription",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idisperror-getdescription",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idisperror-gethelpinfo.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idisperror-gethelpinfo",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idisperror-gethelpinfo",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idisperror-gethresult.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idisperror-gethresult",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idisperror-gethresult",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idisperror-getnext.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idisperror-getnext",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idisperror-getnext",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idisperror-getsource.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idisperror-getsource",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idisperror-getsource",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idisperror-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idisperror-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idisperror-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/idisperror-queryerrorinfo.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idisperror-queryerrorinfo",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/idisperror-queryerrorinfo",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ienumdebugapplicationnodes-clone.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumdebugapplicationnodes-clone",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumdebugapplicationnodes-clone",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ienumdebugapplicationnodes-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumdebugapplicationnodes-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumdebugapplicationnodes-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ienumdebugapplicationnodes-next.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumdebugapplicationnodes-next",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumdebugapplicationnodes-next",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ienumdebugapplicationnodes-reset.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumdebugapplicationnodes-reset",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumdebugapplicationnodes-reset",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ienumdebugapplicationnodes-skip.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumdebugapplicationnodes-skip",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumdebugapplicationnodes-skip",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ienumdebugcodecontexts-clone.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumdebugcodecontexts-clone",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumdebugcodecontexts-clone",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ienumdebugcodecontexts-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumdebugcodecontexts-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumdebugcodecontexts-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ienumdebugcodecontexts-next.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumdebugcodecontexts-next",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumdebugcodecontexts-next",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ienumdebugcodecontexts-reset.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumdebugcodecontexts-reset",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumdebugcodecontexts-reset",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ienumdebugcodecontexts-skip.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumdebugcodecontexts-skip",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumdebugcodecontexts-skip",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ienumdebugexpressioncontexts-clone.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumdebugexpressioncontexts-clone",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumdebugexpressioncontexts-clone",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ienumdebugexpressioncontexts-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumdebugexpressioncontexts-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumdebugexpressioncontexts-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ienumdebugexpressioncontexts-next.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumdebugexpressioncontexts-next",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumdebugexpressioncontexts-next",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ienumdebugexpressioncontexts-reset.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumdebugexpressioncontexts-reset",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumdebugexpressioncontexts-reset",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ienumdebugexpressioncontexts-skip.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumdebugexpressioncontexts-skip",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumdebugexpressioncontexts-skip",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ienumdebugextendedpropertyinfo-clone.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumdebugextendedpropertyinfo-clone",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumdebugextendedpropertyinfo-clone",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ienumdebugextendedpropertyinfo-getcount.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumdebugextendedpropertyinfo-getcount",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumdebugextendedpropertyinfo-getcount",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ienumdebugextendedpropertyinfo-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumdebugextendedpropertyinfo-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumdebugextendedpropertyinfo-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ienumdebugextendedpropertyinfo-next.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumdebugextendedpropertyinfo-next",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumdebugextendedpropertyinfo-next",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ienumdebugextendedpropertyinfo-reset.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumdebugextendedpropertyinfo-reset",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumdebugextendedpropertyinfo-reset",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ienumdebugextendedpropertyinfo-skip.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumdebugextendedpropertyinfo-skip",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumdebugextendedpropertyinfo-skip",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ienumdebugpropertyinfo-clone.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumdebugpropertyinfo-clone",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumdebugpropertyinfo-clone",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ienumdebugpropertyinfo-getcount.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumdebugpropertyinfo-getcount",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumdebugpropertyinfo-getcount",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ienumdebugpropertyinfo-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumdebugpropertyinfo-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumdebugpropertyinfo-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ienumdebugpropertyinfo-next.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumdebugpropertyinfo-next",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumdebugpropertyinfo-next",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ienumdebugpropertyinfo-reset.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumdebugpropertyinfo-reset",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumdebugpropertyinfo-reset",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ienumdebugpropertyinfo-skip.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumdebugpropertyinfo-skip",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumdebugpropertyinfo-skip",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ienumdebugstackframes-clone.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumdebugstackframes-clone",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumdebugstackframes-clone",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ienumdebugstackframes-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumdebugstackframes-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumdebugstackframes-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ienumdebugstackframes-next.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumdebugstackframes-next",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumdebugstackframes-next",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ienumdebugstackframes-reset.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumdebugstackframes-reset",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumdebugstackframes-reset",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ienumdebugstackframes-skip.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumdebugstackframes-skip",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumdebugstackframes-skip",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ienumjsstackframes-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumjsstackframes-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumjsstackframes-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ienumjsstackframes-next-method.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumjsstackframes-next-method",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumjsstackframes-next-method",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ienumjsstackframes-reset-method.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumjsstackframes-reset-method",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumjsstackframes-reset-method",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ienumremotedebugapplications-clone.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumremotedebugapplications-clone",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumremotedebugapplications-clone",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ienumremotedebugapplications-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumremotedebugapplications-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumremotedebugapplications-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ienumremotedebugapplications-next.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumremotedebugapplications-next",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumremotedebugapplications-next",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ienumremotedebugapplications-reset.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumremotedebugapplications-reset",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumremotedebugapplications-reset",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ienumremotedebugapplications-skip.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumremotedebugapplications-skip",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumremotedebugapplications-skip",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ienumremotedebugapplicationthreads-clone.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumremotedebugapplicationthreads-clone",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumremotedebugapplicationthreads-clone",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ienumremotedebugapplicationthreads-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumremotedebugapplicationthreads-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumremotedebugapplicationthreads-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ienumremotedebugapplicationthreads-next.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumremotedebugapplicationthreads-next",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumremotedebugapplicationthreads-next",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ienumremotedebugapplicationthreads-reset.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumremotedebugapplicationthreads-reset",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumremotedebugapplicationthreads-reset",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ienumremotedebugapplicationthreads-skip.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumremotedebugapplicationthreads-skip",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ienumremotedebugapplicationthreads-skip",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ijsdebugbreakpoint-delete-method.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugbreakpoint-delete-method",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugbreakpoint-delete-method",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ijsdebugbreakpoint-disable-method.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugbreakpoint-disable-method",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugbreakpoint-disable-method",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ijsdebugbreakpoint-enable-method.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugbreakpoint-enable-method",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugbreakpoint-enable-method",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ijsdebugbreakpoint-getdocumentposition-method.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugbreakpoint-getdocumentposition-method",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugbreakpoint-getdocumentposition-method",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ijsdebugbreakpoint-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugbreakpoint-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugbreakpoint-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ijsdebugbreakpoint-isenabled-method.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugbreakpoint-isenabled-method",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugbreakpoint-isenabled-method",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ijsdebugdatatarget-allocatevirtualmemory-method.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugdatatarget-allocatevirtualmemory-method",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugdatatarget-allocatevirtualmemory-method",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ijsdebugdatatarget-createstackframeenumerator-method.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugdatatarget-createstackframeenumerator-method",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugdatatarget-createstackframeenumerator-method",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ijsdebugdatatarget-freevirtualmemory-method.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugdatatarget-freevirtualmemory-method",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugdatatarget-freevirtualmemory-method",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ijsdebugdatatarget-getthreadcontext-method.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugdatatarget-getthreadcontext-method",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugdatatarget-getthreadcontext-method",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ijsdebugdatatarget-gettlsvalue-method.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugdatatarget-gettlsvalue-method",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugdatatarget-gettlsvalue-method",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ijsdebugdatatarget-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugdatatarget-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugdatatarget-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ijsdebugdatatarget-readbstr-method.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugdatatarget-readbstr-method",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugdatatarget-readbstr-method",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ijsdebugdatatarget-readmemory-method.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugdatatarget-readmemory-method",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugdatatarget-readmemory-method",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ijsdebugdatatarget-readnullterminatedstring-method.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugdatatarget-readnullterminatedstring-method",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugdatatarget-readnullterminatedstring-method",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ijsdebugdatatarget-writememory-method.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugdatatarget-writememory-method",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugdatatarget-writememory-method",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ijsdebugframe-evaluate-method.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugframe-evaluate-method",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugframe-evaluate-method",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ijsdebugframe-getdebugproperty-method.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugframe-getdebugproperty-method",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugframe-getdebugproperty-method",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ijsdebugframe-getdocumentpositionwithid-method.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugframe-getdocumentpositionwithid-method",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugframe-getdocumentpositionwithid-method",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ijsdebugframe-getdocumentpositionwithname-method.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugframe-getdocumentpositionwithname-method",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugframe-getdocumentpositionwithname-method",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ijsdebugframe-getname-method.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugframe-getname-method",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugframe-getname-method",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ijsdebugframe-getreturnaddress-method.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugframe-getreturnaddress-method",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugframe-getreturnaddress-method",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ijsdebugframe-getstackrange-method.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugframe-getstackrange-method",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugframe-getstackrange-method",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ijsdebugframe-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugframe-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugframe-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ijsdebug-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebug-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebug-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ijsdebug-openvirtualprocess-method.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebug-openvirtualprocess-method",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebug-openvirtualprocess-method",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ijsdebugprocess-createbreakpoint-method.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugprocess-createbreakpoint-method",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugprocess-createbreakpoint-method",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ijsdebugprocess-createstackwalker-method.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugprocess-createstackwalker-method",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugprocess-createstackwalker-method",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ijsdebugprocess-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugprocess-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugprocess-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ijsdebugprocess-performasyncbreak-method.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugprocess-performasyncbreak-method",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugprocess-performasyncbreak-method",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ijsdebugproperty-getmembers-method.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugproperty-getmembers-method",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugproperty-getmembers-method",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ijsdebugproperty-getpropertyinfo-method.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugproperty-getpropertyinfo-method",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugproperty-getpropertyinfo-method",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ijsdebugproperty-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugproperty-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugproperty-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ijsdebugstackwalker-getnext-method.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugstackwalker-getnext-method",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugstackwalker-getnext-method",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ijsdebugstackwalker-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugstackwalker-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsdebugstackwalker-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ijsenumdebugproperty-getcount-method.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsenebugproperty-getcount-method",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsenebugproperty-getcount-method",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ijsenumdebugproperty-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsenebugproperty-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsenebugproperty-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ijsenumdebugproperty-next-method.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsenebugproperty-next-method",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ijsenebugproperty-next-method",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/imachinedebugmanager-addapplication.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/imachinedebugmanager-addapplication",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/imachinedebugmanager-addapplication",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/imachinedebugmanagercookie-addapplication.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/imachinedebugmanagercookie-addapplication",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/imachinedebugmanagercookie-addapplication",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/imachinedebugmanagercookie-enumapplications.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/imachinedebugmanagercookie-enumapplications",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/imachinedebugmanagercookie-enumapplications",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/imachinedebugmanagercookie-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/imachinedebugmanagercookie-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/imachinedebugmanagercookie-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/imachinedebugmanagercookie-removeapplication.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/imachinedebugmanagercookie-removeapplication",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/imachinedebugmanagercookie-removeapplication",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/imachinedebugmanager-enumapplications.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/imachinedebugmanager-enumapplications",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/imachinedebugmanager-enumapplications",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/imachinedebugmanagerevents-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/imachinedebugmanagerevents-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/imachinedebugmanagerevents-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/imachinedebugmanagerevents-onaddapplication.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/imachinedebugmanagerevents-onaddapplication",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/imachinedebugmanagerevents-onaddapplication",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/imachinedebugmanagerevents-onremoveapplication.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/imachinedebugmanagerevents-onremoveapplication",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/imachinedebugmanagerevents-onremoveapplication",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/imachinedebugmanager-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/imachinedebugmanager-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/imachinedebugmanager-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/imachinedebugmanager-removeapplication.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/imachinedebugmanager-removeapplication",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/imachinedebugmanager-removeapplication",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iobjectidentity-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iobjectidentity-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iobjectidentity-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iobjectidentity-isequalobject.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iobjectidentity-isequalobject",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iobjectidentity-isequalobject",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iperpropertybrowsing2-getdisplaystring.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iperpropertybrowsing2-getdisplaystring",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iperpropertybrowsing2-getdisplaystring",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iperpropertybrowsing2-getpredefinedstrings.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iperpropertybrowsing2-getpredefinedstrings",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iperpropertybrowsing2-getpredefinedstrings",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iperpropertybrowsing2-interface-1.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iperpropertybrowsing2-interface-1",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iperpropertybrowsing2-interface-1",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iperpropertybrowsing2-mappropertytopage.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iperpropertybrowsing2-mappropertytopage",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iperpropertybrowsing2-mappropertytopage",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iperpropertybrowsing2-setpredefinedvalue.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iperpropertybrowsing2-setpredefinedvalue",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iperpropertybrowsing2-setpredefinedvalue",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iprocessdebugmanager-addapplication.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iprocessdebugmanager-addapplication",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iprocessdebugmanager-addapplication",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iprocessdebugmanager-createapplication.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iprocessdebugmanager-createapplication",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iprocessdebugmanager-createapplication",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iprocessdebugmanager-createdebugdocumenthelper.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iprocessdebugmanager-createdebugdocumenthelper",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iprocessdebugmanager-createdebugdocumenthelper",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iprocessdebugmanager-getdefaultapplication.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iprocessdebugmanager-getdefaultapplication",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iprocessdebugmanager-getdefaultapplication",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iprocessdebugmanager-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iprocessdebugmanager-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iprocessdebugmanager-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iprocessdebugmanager-removeapplication.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iprocessdebugmanager-removeapplication",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iprocessdebugmanager-removeapplication",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iprovideexpressioncontexts-enumexpressioncontexts.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iprovideexpressioncontexts-enumexpressioncontexts",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iprovideexpressioncontexts-enumexpressioncontexts",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iprovideexpressioncontexts-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iprovideexpressioncontexts-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iprovideexpressioncontexts-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iremotedebugapplication110-getcurrentdebuggeroptions.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplication110-getcurrentdebuggeroptions",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplication110-getcurrentdebuggeroptions",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iremotedebugapplication110-getmainthread.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplication110-getmainthread",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplication110-getmainthread",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iremotedebugapplication110-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplication110-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplication110-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iremotedebugapplication110-setdebuggeroptions.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplication110-setdebuggeroptions",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplication110-setdebuggeroptions",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iremotedebugapplication-causebreak.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplication-causebreak",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplication-causebreak",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iremotedebugapplication-connectdebugger.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplication-connectdebugger",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplication-connectdebugger",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iremotedebugapplication-createinstanceatapplication.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplication-createinstanceatapplication",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplication-createinstanceatapplication",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iremotedebugapplication-disconnectdebugger.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplication-disconnectdebugger",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplication-disconnectdebugger",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iremotedebugapplication-enumglobalexpressioncontexts.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplication-enumglobalexpressioncontexts",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplication-enumglobalexpressioncontexts",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iremotedebugapplication-enumthreads.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplication-enumthreads",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplication-enumthreads",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iremotedebugapplicationevents-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplicationevents-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplicationevents-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iremotedebugapplicationevents-onbreakflagchange.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplicationevents-onbreakflagchange",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplicationevents-onbreakflagchange",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iremotedebugapplicationevents-onclose.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplicationevents-onclose",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplicationevents-onclose",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iremotedebugapplicationevents-onconnectdebugger.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplicationevents-onconnectdebugger",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplicationevents-onconnectdebugger",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iremotedebugapplicationevents-oncreatethread.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplicationevents-oncreatethread",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplicationevents-oncreatethread",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iremotedebugapplicationevents-ondebugoutput.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplicationevents-ondebugoutput",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplicationevents-ondebugoutput",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iremotedebugapplicationevents-ondestroythread.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplicationevents-ondestroythread",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplicationevents-ondestroythread",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iremotedebugapplicationevents-ondisconnectdebugger.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplicationevents-ondisconnectdebugger",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplicationevents-ondisconnectdebugger",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iremotedebugapplicationevents-onenterbreakpoint.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplicationevents-onenterbreakpoint",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplicationevents-onenterbreakpoint",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iremotedebugapplicationevents-onleavebreakpoint.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplicationevents-onleavebreakpoint",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplicationevents-onleavebreakpoint",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iremotedebugapplicationevents-onsetname.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplicationevents-onsetname",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplicationevents-onsetname",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iremotedebugapplicationex-forcestepmode.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplicationex-forcestepmode",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplicationex-forcestepmode",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iremotedebugapplicationex-gethostpid.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplicationex-gethostpid",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplicationex-gethostpid",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iremotedebugapplicationex-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplicationex-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplicationex-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iremotedebugapplicationex-revokebreak.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplicationex-revokebreak",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplicationex-revokebreak",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iremotedebugapplicationex-setlocale.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplicationex-setlocale",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplicationex-setlocale",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iremotedebugapplication-getdebugger.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplication-getdebugger",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplication-getdebugger",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iremotedebugapplication-getname.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplication-getname",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplication-getname",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iremotedebugapplication-getrootnode.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplication-getrootnode",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplication-getrootnode",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iremotedebugapplication-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplication-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplication-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iremotedebugapplication-queryalive.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplication-queryalive",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplication-queryalive",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iremotedebugapplication-resumefrombreakpoint.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplication-resumefrombreakpoint",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplication-resumefrombreakpoint",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iremotedebugapplicationthread-enumstackframes.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplicationthread-enumstackframes",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplicationthread-enumstackframes",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iremotedebugapplicationthreadex-enumglobalcontexts.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplicationthreadex-enumglobalcontexts",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplicationthreadex-enumglobalcontexts",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iremotedebugapplicationthreadex-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplicationthreadex-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplicationthreadex-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iremotedebugapplicationthread-getapplication.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplicationthread-getapplication",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplicationthread-getapplication",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iremotedebugapplicationthread-getdescription.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplicationthread-getdescription",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplicationthread-getdescription",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iremotedebugapplicationthread-getstate.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplicationthread-getstate",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplicationthread-getstate",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iremotedebugapplicationthread-getsuspendcount.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplicationthread-getsuspendcount",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplicationthread-getsuspendcount",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iremotedebugapplicationthread-getsystemthreadid.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplicationthread-getsystemthreadid",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplicationthread-getsystemthreadid",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iremotedebugapplicationthread-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplicationthread-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplicationthread-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iremotedebugapplicationthread-resume.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplicationthread-resume",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplicationthread-resume",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iremotedebugapplicationthread-setnextstatement.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplicationthread-setnextstatement",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplicationthread-setnextstatement",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iremotedebugapplicationthread-suspend.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplicationthread-suspend",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iremotedebugapplicationthread-suspend",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iscriptentry-getbody.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iscriptentry-getbody",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iscriptentry-getbody",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iscriptentry-getitemname.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iscriptentry-getitemname",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iscriptentry-getitemname",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iscriptentry-getname.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iscriptentry-getname",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iscriptentry-getname",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iscriptentry-getrange.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iscriptentry-getrange",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iscriptentry-getrange",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iscriptentry-getsignature.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iscriptentry-getsignature",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iscriptentry-getsignature",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iscriptentry-gettext.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iscriptentry-gettext",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iscriptentry-gettext",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iscriptentry-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iscriptentry-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iscriptentry-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iscriptentry-setbody.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iscriptentry-setbody",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iscriptentry-setbody",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iscriptentry-setitemname.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iscriptentry-setitemname",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iscriptentry-setitemname",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iscriptentry-setname.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iscriptentry-setname",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iscriptentry-setname",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iscriptentry-setsignature.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iscriptentry-setsignature",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iscriptentry-setsignature",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iscriptentry-settext.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iscriptentry-settext",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iscriptentry-settext",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iscriptnode-alive.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iscriptnode-alive",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iscriptnode-alive",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iscriptnode-createchildentry.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iscriptnode-createchildentry",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iscriptnode-createchildentry",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iscriptnode-createchildhandler.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iscriptnode-createchildhandler",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iscriptnode-createchildhandler",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iscriptnode-delete.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iscriptnode-delete",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iscriptnode-delete",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iscriptnode-getchild.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iscriptnode-getchild",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iscriptnode-getchild",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iscriptnode-getcookie.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iscriptnode-getcookie",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iscriptnode-getcookie",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iscriptnode-getindexinparent.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iscriptnode-getindexinparent",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iscriptnode-getindexinparent",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iscriptnode-getlanguage.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iscriptnode-getlanguage",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iscriptnode-getlanguage",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iscriptnode-getnumberofchildren.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iscriptnode-getnumberofchildren",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iscriptnode-getnumberofchildren",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iscriptnode-getparent.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iscriptnode-getparent",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iscriptnode-getparent",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iscriptnode-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iscriptnode-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iscriptnode-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iscriptscriptlet-geteventname.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iscriptscriptlet-geteventname",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iscriptscriptlet-geteventname",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iscriptscriptlet-getsimpleeventname.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iscriptscriptlet-getsimpleeventname",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iscriptscriptlet-getsimpleeventname",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iscriptscriptlet-getsubitemname.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iscriptscriptlet-getsubitemname",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iscriptscriptlet-getsubitemname",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iscriptscriptlet-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iscriptscriptlet-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iscriptscriptlet-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iscriptscriptlet-seteventname.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iscriptscriptlet-seteventname",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iscriptscriptlet-seteventname",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iscriptscriptlet-setsimpleeventname.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iscriptscriptlet-setsimpleeventname",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iscriptscriptlet-setsimpleeventname",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iscriptscriptlet-setsubitemname.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iscriptscriptlet-setsubitemname",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iscriptscriptlet-setsubitemname",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/isetnextstatement-cansetnextstatement.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/isetnextstatement-cansetnextstatement",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/isetnextstatement-cansetnextstatement",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/isetnextstatement-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/isetnextstatement-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/isetnextstatement-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/isetnextstatement-setnextstatement.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/isetnextstatement-setnextstatement",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/isetnextstatement-setnextstatement",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/isimpleconnectionpoint-advise.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/isimpleconnectionpoint-advise",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/isimpleconnectionpoint-advise",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/isimpleconnectionpoint-describeevents.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/isimpleconnectionpoint-describeevents",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/isimpleconnectionpoint-describeevents",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/isimpleconnectionpoint-geteventcount.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/isimpleconnectionpoint-geteventcount",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/isimpleconnectionpoint-geteventcount",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/isimpleconnectionpoint-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/isimpleconnectionpoint-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/isimpleconnectionpoint-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/isimpleconnectionpoint-unadvise.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/isimpleconnectionpoint-unadvise",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/isimpleconnectionpoint-unadvise",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ivariantchangetype-changetype.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ivariantchangetype-changetype",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ivariantchangetype-changetype",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/ivariantchangetype-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ivariantchangetype-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/ivariantchangetype-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iwebappdiagnosticsobjectinitialization-initialize.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iwebappdiagnosticsobjectinitialization-initialize",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iwebappdiagnosticsobjectinitialization-initialize",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iwebappdiagnosticsobjectinitialization-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iwebappdiagnosticsobjectinitialization-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iwebappdiagnosticsobjectinitialization-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iwebappdiagnosticssetup-createobjectwithsiteatwebapp.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iwebappdiagnosticssetup-createobjectwithsiteatwebapp",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iwebappdiagnosticssetup-createobjectwithsiteatwebapp",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iwebappdiagnosticssetup-diagnosticssupported.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iwebappdiagnosticssetup-diagnosticssupported",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iwebappdiagnosticssetup-diagnosticssupported",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/iwebappdiagnosticssetup-interface.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iwebappdiagnosticssetup-interface",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/iwebappdiagnosticssetup-interface",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/jsdebugpropertyinfo-structure.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/jsdebugpropertyinfo-structure",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/jsdebugpropertyinfo-structure",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/jsdebugreadmemoryflags-enumeration.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/jsdebugreadmemoryflags-enumeration",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/jsdebugreadmemoryflags-enumeration",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/js-native-frame-structure.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/js-native-frame-structure",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/js-native-frame-structure",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/js-property-attributes-enumeration.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/js-property-attributes-enumeration",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/js-property-attributes-enumeration",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/js-property-members-enumeration.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/js-property-members-enumeration",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/js-property-members-enumeration",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/profiler-event-mask-enumeration.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/profiler-event-mask-enumeration",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/profiler-event-mask-enumeration",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/profiler-external-object-address-type.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/profiler-external-object-address-type",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/profiler-external-object-address-type",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/profiler-heap-enum-flags-enumeration.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/profiler-heap-enum-flags-enumeration",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/profiler-heap-enum-flags-enumeration",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/profiler-heap-object-flags-enumeration.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/profiler-heap-object-flags-enumeration",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/profiler-heap-object-flags-enumeration",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/profiler-heap-object-id-type.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/profiler-heap-object-id-type",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/profiler-heap-object-id-type",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/profiler-heap-object-name-id-type.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/profiler-heap-object-name-id-type",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/profiler-heap-object-name-id-type",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/profiler-heap-object-optional-info-structure.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/profiler-heap-object-optional-info-structure",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/profiler-heap-object-optional-info-structure",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/profiler-heap-object-optional-info-type-enumeration.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/profiler-heap-object-optional-info-type-enumeration",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/profiler-heap-object-optional-info-type-enumeration",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/profiler-heap-object-relationship-flags-enumeration.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/profiler-heap-object-relationship-flags-enumeration",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/profiler-heap-object-relationship-flags-enumeration",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/profiler-heap-object-relationship-list-structure.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/profiler-heap-object-relationship-list-structure",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/profiler-heap-object-relationship-list-structure",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/profiler-heap-object-relationship-structure.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/profiler-heap-object-relationship-structure",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/profiler-heap-object-relationship-structure",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/profiler-heap-object-scope-list-structure.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/profiler-heap-object-scope-list-structure",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/profiler-heap-object-scope-list-structure",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/profiler-heap-object-structure.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/profiler-heap-object-structure",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/profiler-heap-object-structure",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/profiler-property-type-substring-info-structure.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/profiler-property-type-substring-info-structure",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/profiler-property-type-substring-info-structure",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/profiler-relationship-info-enumeration.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/profiler-relationship-info-enumeration",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/profiler-relationship-info-enumeration",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/profiler-script-type-enumeration.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/profiler-script-type-enumeration",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/profiler-script-type-enumeration",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/script-debugger-options-enumeration.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/script-debugger-options-enumeration",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/script-debugger-options-enumeration",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/script-e-propagate-error-code.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/script-e-propagate-error-code",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/script-e-propagate-error-code",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/script-e-recorded-error-code.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/script-e-recorded-error-code",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/script-e-recorded-error-code",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/script-e-reported-error-code.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/script-e-reported-error-code",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/script-e-reported-error-code",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/script-error-debug-exception-thrown-kind-enumeration.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/script-error-debug-exception-thrown-kind-enumeration",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/script-error-debug-exception-thrown-kind-enumeration",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/scriptgctype-enumeration.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/scriptgctype-enumeration",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/scriptgctype-enumeration",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/scriptlanguageversion-enumeration.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/scriptlanguageversion-enumeration",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/scriptlanguageversion-enumeration",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/scriptprop-hostkeepalive-property.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/scriptprop-hostkeepalive-property",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/scriptprop-hostkeepalive-property",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/scriptstate-enumeration.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/scriptstate-enumeration",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/scriptstate-enumeration",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/scriptthreadid-constants.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/scriptthreadid-constants",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/scriptthreadid-constants",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/scriptthreadstate-enumeration.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/scriptthreadstate-enumeration",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/scriptthreadstate-enumeration",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/scripttraceinfo-enumeration.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/scripttraceinfo-enumeration",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/scripttraceinfo-enumeration",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/scriptuichandling-enumeration.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/scriptuichandling-enumeration",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/scriptuichandling-enumeration",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/scriptuicitem-enumeration.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/scriptuicitem-enumeration",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/scriptuicitem-enumeration",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/source-text-attr-enumeration.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/source-text-attr-enumeration",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/source-text-attr-enumeration",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/text-doc-attr-constants.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/text-doc-attr-constants",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/text-doc-attr-constants",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/text-document-array-structure.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/text-document-array-structure",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/text-document-array-structure",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/reference/windows-script-interfaces-reference.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/windows-script-interfaces-reference",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/reference/windows-script-interfaces-reference",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/active-script-debugging-overview.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/active-script-debugging-overview",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/active-script-debugging-overview",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/active-script-profiling-overview.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/active-script-profiling-overview",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/active-script-profiling-overview",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/implementing-smart-host-helper-interfaces.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/implementing-smart-host-helper-interfaces",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/implementing-smart-host-helper-interfaces",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/windows-script-engines.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/windows-script-engines",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/windows-script-engines",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/windows-script-hosts.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/windows-script-hosts",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/windows-script-hosts",
       "redirect_document_id": false
     },
     {
       "source_path": "scripting-docs/winscript/windows-script-interfaces.md",
-      "redirect_url": "https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/windows-script-interfaces",
+      "redirect_url": "https://learn.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/windows-script-interfaces",
       "redirect_document_id": false
     },
     {

--- a/docs/snippets/csharp/VS_Snippets_VSSDK/creatingansdkusingwinrt/cs/winrtmathvsix/sdkmanifest.xml
+++ b/docs/snippets/csharp/VS_Snippets_VSSDK/creatingansdkusingwinrt/cs/winrtmathvsix/sdkmanifest.xml
@@ -6,6 +6,6 @@
   TargetFramework=".NETCore,version=v4.5"
   AppliesTo="WindowsAppContainer"
   SupportsMultipleVersions="Error"
-  MoreInfo="https://docs.microsoft.com/">
+  MoreInfo="https://learn.microsoft.com/">
 </FileList>
 <!-- </snippet1> -->

--- a/docs/snippets/visualbasic/VS_Snippets_VSSDK/creatingansdkusingwinrt/vb/winrtmathvsix/sdkmanifest.xml
+++ b/docs/snippets/visualbasic/VS_Snippets_VSSDK/creatingansdkusingwinrt/vb/winrtmathvsix/sdkmanifest.xml
@@ -6,6 +6,6 @@
   TargetFramework=".NETCore,version=v4.5"
   AppliesTo="WindowsAppContainer"
   SupportsMultipleVersions="Error"
-  MoreInfo="https://docs.microsoft.com/">
+  MoreInfo="https://learn.microsoft.com/">
 </FileList>
 <!-- </snippet1> -->


### PR DESCRIPTION
Replaced the old docs.microsoft.com link with the updated learn.microsoft.com version to reflect the current documentation domain.

<!--
Thanks for contributing to the Visual Studio documentation.

Note: Internal Microsoft employees and vendors should use the private repo, https://github.com/MicrosoftDocs/visualstudio-docs-pr. You must be a member of the MicrosoftDocs GitHub organization. To join, see https://review.learn.microsoft.com/help/get-started/setup-github?branch=main#3-join-microsoftdocs-and-other-organizations.

Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for Microsoft Learn, see the [contributor guide](https://learn.microsoft.com/contribute/).

When your PR is ready for review, add a comment with the text #sign-off to the Conversation tab.
-->
