### PR TITLE
Update publish-page-project-designer.md

### DIFF
--- a/docs/ide/reference/publish-page-project-designer.md
+++ b/docs/ide/reference/publish-page-project-designer.md
@@ -59,7 +59,7 @@ Opens the Publish Options dialog box, which is used to specify additional advanc
 
  **Publish Version**
 
-Sets the publish version number for the application; when the version number is changed, the application is published as an update. Each part of the publish version (**Major**, **Minor**, **Build**, **Revision**) can have a maximum value of 65355 (<xref:System.UInt16.MaxValue>), the maximum allowed by <xref:System.Version>.
+Sets the publish version number for the application; when the version number is changed, the application is published as an update. Each part of the publish version (**Major**, **Minor**, **Build**, **Revision**) can have a maximum value of 65535 (<xref:System.UInt16.MaxValue>), the maximum allowed by <xref:System.Version>.
 
 When you install more than one version of an application by using ClickOnce, the installation moves earlier versions of the application into a folder named Archive, in the publish location that you specify. Archiving earlier versions in this manner keeps the installation directory clear of folders from the earlier version.
 


### PR DESCRIPTION
I am one of the Security Program Manager at MSRC Microsoft team. We have an external vulnerability submission which highlights that there is human error in this article and the value here must be 65535 instead of 65335 https://learn.microsoft.com/en-us/visualstudio/ide/reference/publish-page-project-designer?view=vs-2019#:~:text=maximum%20value%20of-,65355,-(MaxValue)%2C%20the 

The same was confirmed by the Vulnerability and Assessment team to update the article. Hence, requesting to update the change



<!--
Thanks for contributing to the Visual Studio documentation.

Note: Internal Microsoft employees and vendors should use the private repo, https://github.com/MicrosoftDocs/visualstudio-docs-pr. You must be a member of the MicrosoftDocs GitHub organization. To join, see https://review.learn.microsoft.com/help/get-started/setup-github?branch=main#3-join-microsoftdocs-and-other-organizations.

Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for Microsoft Learn, see the [contributor guide](https://learn.microsoft.com/contribute/).

When your PR is ready for review, add a comment with the text #sign-off to the Conversation tab.
-->
