### PR TITLE
Update live-unit-testing.md - fixed casing in .lutignore samples.

### DIFF
--- a/docs/test/live-unit-testing.md
+++ b/docs/test/live-unit-testing.md
@@ -71,23 +71,23 @@ For more complex repositories, you might need to specify your own ignore file. S
 The *lutignore* file uses the same format as a *gitignore* file. It should contain rules that match the folders or files generated during the build so that they're not copied into the workspace. For most of the default project templates, the following ignore file is sufficient:
 
 ```
-[BB]IN
-[OO]BJ
+[Bb]in
+[Oo]bj
 # WILL NOT COPY ANY BIN AND OBJ FOLDERS TO THE LIVE UNIT TESTING WORKSPACE
 ```
 
 If your repository has a single build folder, the ignore file should list that folder instead:
 
 ```
-[AA]RTIFACTS/
+[Aa]rtifacts/
 # WILL NOT COPY THE ARTIFACTS FOLDER TO THE LIVE UNIT TESTING WORKSPACE
 ```
 
 If your repository includes some other tools in the build folder, these tools should be excluded in the set of matching patterns:
 
 ```
-[AA]RTIFACTS/
-![AA]RTIFACTS/TOOLS/
+[Aa]rtifacts/
+![Aa]rtifacts/tools/
 # WILL NOT COPY THE ARTIFACTS FOLDER TO THE LIVE UNIT TESTING WORKSPACE
 # HOWEVER IT WILL COPY THE TOOLS SUBFOLDER THAT MIGHT CONTAIN TOOLS AND UTILITIES
 ```


### PR DESCRIPTION
fixed casing in .lutignore samples.

... I wonder why those global-uppercase - transitions came in in the first place - maybe someone should review that and make sure other places aren't affected as well

<!--
Thanks for contributing to the Visual Studio documentation.

Note: Internal Microsoft employees and vendors should use the private repo, https://github.com/MicrosoftDocs/visualstudio-docs-pr. You must be a member of the MicrosoftDocs GitHub organization. To join, see https://review.learn.microsoft.com/help/get-started/setup-github?branch=main#3-join-microsoftdocs-and-other-organizations.

Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for Microsoft Learn, see the [contributor guide](https://learn.microsoft.com/contribute/).

When your PR is ready for review, add a comment with the text #sign-off to the Conversation tab.
-->
