### PR TITLE
response files: correct component element, remove github as no longer a valid id

### DIFF
--- a/docs/install/automated-installation-with-response-file.md
+++ b/docs/install/automated-installation-with-response-file.md
@@ -132,7 +132,7 @@ The following `response.json` file example initializes a Visual Studio Enterpris
     "fr-FR"
     ],
 
-    "add": [
+    "components": [
         "Microsoft.VisualStudio.Workload.ManagedDesktop",
         "Microsoft.VisualStudio.Workload.Data",
         "Microsoft.VisualStudio.Workload.NativeDesktop",
@@ -170,14 +170,13 @@ The following `response.json` file example initializes a Visual Studio Enterpris
     "fr-FR"
     ],
 
-    "add": [
+    "components": [
         "Microsoft.VisualStudio.Workload.ManagedDesktop",
         "Microsoft.VisualStudio.Workload.Data",
         "Microsoft.VisualStudio.Workload.NativeDesktop",
         "Microsoft.VisualStudio.Workload.NetWeb",
         "Microsoft.VisualStudio.Workload.Office",
-        "Microsoft.VisualStudio.Workload.Universal",
-        "Component.GitHub.VisualStudio"
+        "Microsoft.VisualStudio.Workload.Universal"
     ]
 }
 ```


### PR DESCRIPTION
Greetings

* This changes the response.json samples to have "components" instead of "add"
* it also removes the github component as it's no longer valid

Thanks

<!--
Thanks for contributing to the Visual Studio documentation.

Note: Internal Microsoft employees and vendors should use the private repo, https://github.com/MicrosoftDocs/visualstudio-docs-pr. You must be a member of the MicrosoftDocs GitHub organization. To join, see https://review.learn.microsoft.com/help/get-started/setup-github?branch=main#3-join-microsoftdocs-and-other-organizations.

Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for Microsoft Learn, see the [contributor guide](https://learn.microsoft.com/contribute/).

When your PR is ready for review, add a comment with the text #sign-off to the Conversation tab.
-->
