### PR TITLE
Fix file extension reference in tutorial

### DIFF
--- a/docs/containers/tutorial-multicontainer.md
+++ b/docs/containers/tutorial-multicontainer.md
@@ -443,7 +443,7 @@ Congratulations, you're running a Docker Compose application with a custom Docke
    > [!NOTE]
    > If you're using a Linux distro, like Alpine, that doesn't support `apt-get`, try `RUN apk --no-cache add curl` instead.
 
-   These Docker Compose features require a property setting in the Docker Compose project file (`.dcproj`). Set the property `DependencyAwareStart` to true:
+   These Docker Compose features require a property setting in the Docker Compose project file (`.csproj`). Set the property `DependencyAwareStart` to true:
 
    ```xml
    <PropertyGroup>


### PR DESCRIPTION
Corrected the file extension reference from '.dcproj' to '.csproj' in the Docker Compose tutorial.