### PR TITLE
Fix filename reference and correct output result

### DIFF
--- a/docs/msbuild/msbuild-properties.md
+++ b/docs/msbuild/msbuild-properties.md
@@ -195,7 +195,7 @@ The following code example shows the effect of `TreatAsLocalProperty` on an impo
 ```
 
 ```xml
-<!-- import.proj -->
+<!-- import.props -->
 <Project TreatAsLocalProperty="TreatedAsLocalProp">
     <PropertyGroup>
         <TreatedAsLocalProp>ImportOverrideValue</TreatedAsLocalProp>
@@ -214,7 +214,7 @@ dotnet msbuild .\importer.proj -p:TreatedAsLocalProp=GlobalOverrideValue
 The output is:
 
 ```output
-importer.proj(9,9): warning : TreatedAsLocalProp(importer.proj): GlobalOverrideValue
+importer.proj(9,9): warning : TreatedAsLocalProp(importer.proj): ImportOverrideValue
 ```
 
 Now suppose you build with the property `TrySecondOverride` to `true`:


### PR DESCRIPTION
1. Fixed the file name error in the comment. The imported project in file (importer.proj) is "import.props".

2. Corrected the output result. Based on the description below and actual verification, the output result should be changed to “ImportOverrideValue”.



<!--
Thanks for contributing to the Visual Studio documentation.

Note: Internal Microsoft employees and vendors should use the private repo, https://github.com/MicrosoftDocs/visualstudio-docs-pr. You must be a member of the MicrosoftDocs GitHub organization. To join, see https://review.learn.microsoft.com/help/get-started/setup-github?branch=main#3-join-microsoftdocs-and-other-organizations.

Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for Microsoft Learn, see the [contributor guide](https://learn.microsoft.com/contribute/).

When your PR is ready for review, add a comment with the text #sign-off to the Conversation tab.
-->
