### PR TITLE
Fix moniker marker

### DIFF
--- a/docs/test/using-code-coverage-to-determine-how-much-code-is-being-tested.md
+++ b/docs/test/using-code-coverage-to-determine-how-much-code-is-being-tested.md
@@ -27,17 +27,10 @@ Code coverage option is available under the Test menu when you run test methods 
 ::: moniker range=">=visualstudio"
 >[!NOTE]
 > Code coverage is available in Visual Studio Enterprise, Community, and Professional editions. In Visual Studio 2022 and previous versions, the code coverage feature was limited to Visual Studio Enterprise edition.
-
 ::: moniker-end
 ::: moniker range="<=vs-2022"
 >[!NOTE]
-> Code coverage is available only with Visual Studio Enterprise.
-
-::: moniker-end
-
->[!NOTE]
-> For .NET code coverage, you can alternatively use the command-line tool, [dotnet-coverage](/dotnet/core/additional-tools/dotnet-coverage).
-
+> Code coverage is available only with Visual Studio Enterprise. For .NET code coverage, you can alternatively use the command-line tool, [dotnet-coverage](/dotnet/core/additional-tools/dotnet-coverage).
 ::: moniker-end
 
 ## Analyze code coverage


### PR DESCRIPTION
There is an incorrect `::: moniker-end` marker which is shown on the page. This PR changes it to be the same as on https://github.com/MicrosoftDocs/visualstudio-docs/blob/main/docs/test/microsoft-code-coverage-console-tool.md and   https://github.com/MicrosoftDocs/visualstudio-docs/blob/main/docs/test/customizing-code-coverage-analysis.md

<img width="890" height="340" alt="image" src="https://github.com/user-attachments/assets/d68671af-ba12-4fe7-8b04-cf1fb4d2abbb" />

<!--
Thanks for contributing to the Visual Studio documentation.

Note: Internal Microsoft employees and vendors should use the private repo, https://github.com/MicrosoftDocs/visualstudio-docs-pr. You must be a member of the MicrosoftDocs GitHub organization. To join, see https://review.learn.microsoft.com/help/get-started/setup-github?branch=main#3-join-microsoftdocs-and-other-organizations.

Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for Microsoft Learn, see the [contributor guide](https://learn.microsoft.com/contribute/).

When your PR is ready for review, add a comment with the text #sign-off to the Conversation tab.
-->
