### PR TITLE
Fix regex pattern for input validation

### DIFF
--- a/docs/get-started/csharp/tutorial-console.md
+++ b/docs/get-started/csharp/tutorial-console.md
@@ -567,7 +567,7 @@ Let's get started.
                 string? op = Console.ReadLine();
 
                 // Validate input is not null, and matches the pattern
-                if (op == null || ! Regex.IsMatch(op, "[a|s|m|d]"))
+                if (op == null || ! Regex.IsMatch(op, "^(a|s|m|d)$"))
                 {
                    Console.WriteLine("Error: Unrecognized input.");
                 }
@@ -713,7 +713,7 @@ Let's get started.
                 string? op = Console.ReadLine();
 
                 // Validate input is not null, and matches the pattern
-                if (op == null || ! Regex.IsMatch(op, "[a|s|m|d]"))
+                if (op == null || ! Regex.IsMatch(op, "^(a|s|m|d)$"))
                 {
                    Console.WriteLine("Error: Unrecognized input.");
                 }
@@ -876,7 +876,7 @@ class Program
             string? op = Console.ReadLine();
 
             // Validate input is not null, and matches the pattern
-            if (op == null || ! Regex.IsMatch(op, "[a|s|m|d]"))
+            if (op == null || ! Regex.IsMatch(op, "^(a|s|m|d)$"))
             {
                 Console.WriteLine("Error: Unrecognized input.");
             }


### PR DESCRIPTION
The original Regex `[a|s|m|d]` was logically incorrect because `|` inside a character class `[]` is treated as a literal character, not a logical OR. Also, it lacked anchor tags `^` and `$`.

Fixed by updating it to `^(a|s|m|d)$` to properly enforce the logical OR and exact full-string matching, preventing partial match bugs.


<!--
Thanks for contributing to the Visual Studio documentation.

Note: Internal Microsoft employees and vendors should use the private repo, https://github.com/MicrosoftDocs/visualstudio-docs-pr. You must be a member of the MicrosoftDocs GitHub organization. To join, see https://review.learn.microsoft.com/help/get-started/setup-github?branch=main#3-join-microsoftdocs-and-other-organizations.

Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for Microsoft Learn, see the [contributor guide](https://learn.microsoft.com/contribute/).

When your PR is ready for review, add a comment with the text #sign-off to the Conversation tab.
-->
