### PR TITLE
Update VSTest docs: fix archived cross-links, add runsettings CLI override and logger catalog

### DIFF
--- a/docs/test/configure-unit-tests-by-using-a-dot-runsettings-file.md
+++ b/docs/test/configure-unit-tests-by-using-a-dot-runsettings-file.md
@@ -152,7 +152,7 @@ For more information, see [VSTest.Console.exe command-line options](vstest-conso
 
 ## Override run settings from the command line
 
-You can also override some run settings directly from the command line. Specify run settings as name-value pairs after `--`. Include the space after `--`; all arguments after `--` are treated as run settings overrides, so these arguments must be last. Command-line run settings overrides take precedence over values from a file passed with `/Settings`.
+You can also override some run settings directly from the command line. Specify run settings overrides after `--`. Include the space after `--`; all arguments after `--` are treated as run settings overrides, so these arguments must be last. Command-line run settings overrides take precedence over values from a file passed with `/Settings`.
 
 ```cmd
 vstest.console.exe test.dll -- MSTest.MapInconclusiveToFailed=True MSTest.DeploymentEnabled=False
@@ -178,7 +178,7 @@ Parameter values can contain semicolons and other special characters, such as co
 </RunSettings>
 ```
 
-For more command-line examples and shell-specific quoting details, see [Passing runsettings arguments through commandline](https://github.com/microsoft/vstest/blob/main/docs/RunSettingsArguments.md).
+For more command-line examples and shell-specific quoting details, see [Passing runsettings arguments through the command line](https://github.com/microsoft/vstest/blob/main/docs/RunSettingsArguments.md).
 
 ## The *.runsettings file
 

--- a/docs/test/configure-unit-tests-by-using-a-dot-runsettings-file.md
+++ b/docs/test/configure-unit-tests-by-using-a-dot-runsettings-file.md
@@ -152,16 +152,18 @@ For more information, see [VSTest.Console.exe command-line options](vstest-conso
 
 ## Override run settings from the command line
 
-You can also override some run settings directly from the command line. Specify run settings as name-value pairs after `--`. Include the space after `--`; all arguments after `--` are treated as run settings overrides, so these arguments must be last. Command-line run settings overrides take precedence over values from a file passed with `--settings`.
+You can also override some run settings directly from the command line. Specify run settings as name-value pairs after `--`. Include the space after `--`; all arguments after `--` are treated as run settings overrides, so these arguments must be last. Command-line run settings overrides take precedence over values from a file passed with `/Settings`.
 
 ```cmd
-dotnet test -- MSTest.MapInconclusiveToFailed=True MSTest.DeploymentEnabled=False
+vstest.console.exe test.dll -- MSTest.MapInconclusiveToFailed=True MSTest.DeploymentEnabled=False
 ```
 
-Starting with the .NET SDK 5.0, you can set **TestRunParameters** from the command line:
+The same syntax works with `dotnet test` (use `dotnet test -- MSTest.MapInconclusiveToFailed=True`).
+
+You can set **TestRunParameters** from the command line:
 
 ```cmd
-dotnet test -- TestRunParameters.Parameter(name="myParam", value="value")
+vstest.console.exe test.dll -- TestRunParameters.Parameter(name="myParam", value="value")
 ```
 
 Shell quoting rules differ. In Command Prompt, escape quotation marks as needed. In PowerShell 7.3 and later, native command argument handling supports this syntax more directly; in earlier PowerShell versions, or when `$PSNativeCommandArgumentPassing` is set to `legacy`, use the `--%` stop-parsing token. In Bash, escape characters such as parentheses, quotation marks, spaces, and semicolons.

--- a/docs/test/configure-unit-tests-by-using-a-dot-runsettings-file.md
+++ b/docs/test/configure-unit-tests-by-using-a-dot-runsettings-file.md
@@ -1,7 +1,7 @@
 ---
 title: Configure unit tests with a .runsettings file
 description: Learn how to use the .runsettings file in Visual Studio to configure unit tests that are run from the command line, from the IDE, or in a build workflow.
-ms.date: 12/17/2025
+ms.date: 07/13/2026
 ms.topic: how-to
 ms.author: mikejo
 
@@ -149,6 +149,34 @@ To run tests from the command line, use *vstest.console.exe*, and specify the se
    ```
 
 For more information, see [VSTest.Console.exe command-line options](vstest-console-options.md).
+
+## Override run settings from the command line
+
+You can also override some run settings directly from the command line. Specify run settings as name-value pairs after `--`. Include the space after `--`; all arguments after `--` are treated as run settings overrides, so these arguments must be last. Command-line run settings overrides take precedence over values from a file passed with `--settings`.
+
+```cmd
+dotnet test -- MSTest.MapInconclusiveToFailed=True MSTest.DeploymentEnabled=False
+```
+
+Starting with the .NET SDK 5.0, you can set **TestRunParameters** from the command line:
+
+```cmd
+dotnet test -- TestRunParameters.Parameter(name="myParam", value="value")
+```
+
+Shell quoting rules differ. In Command Prompt, escape quotation marks as needed. In PowerShell 7.3 and later, native command argument handling supports this syntax more directly; in earlier PowerShell versions, or when `$PSNativeCommandArgumentPassing` is set to `legacy`, use the `--%` stop-parsing token. In Bash, escape characters such as parentheses, quotation marks, spaces, and semicolons.
+
+Parameter values can contain semicolons and other special characters, such as connection strings, but the shell must pass them through literally. For complex values, consider using a *.runsettings* file instead:
+
+```xml
+<RunSettings>
+  <TestRunParameters>
+    <Parameter name="connectionString" value="Server=localhost;Database=mydb;Trusted_Connection=True" />
+  </TestRunParameters>
+</RunSettings>
+```
+
+For more command-line examples and shell-specific quoting details, see [Passing runsettings arguments through commandline](https://github.com/microsoft/vstest/blob/main/docs/RunSettingsArguments.md).
 
 ## The *.runsettings file
 

--- a/docs/test/configure-unit-tests-by-using-a-dot-runsettings-file.md
+++ b/docs/test/configure-unit-tests-by-using-a-dot-runsettings-file.md
@@ -1,7 +1,7 @@
 ---
 title: Configure unit tests with a .runsettings file
 description: Learn how to use the .runsettings file in Visual Studio to configure unit tests that are run from the command line, from the IDE, or in a build workflow.
-ms.date: 07/13/2026
+ms.date: 07/15/2026
 ms.topic: how-to
 ms.author: mikejo
 
@@ -167,6 +167,12 @@ vstest.console.exe test.dll -- TestRunParameters.Parameter(name="myParam", value
 ```
 
 Shell quoting rules differ. In Command Prompt, escape quotation marks as needed. In PowerShell 7.3 and later, native command argument handling supports this syntax more directly; in earlier PowerShell versions, or when `$PSNativeCommandArgumentPassing` is set to `legacy`, use the `--%` stop-parsing token. In Bash, escape characters such as parentheses, quotation marks, spaces, and semicolons.
+
+In zsh (the default shell on macOS), use the same escaping as Bash: escape quotation marks, spaces, and semicolons. Because zsh also treats unquoted parentheses as globbing and array syntax, always escape or quote the parentheses in `TestRunParameters.Parameter(...)`. For example:
+
+```zsh
+vstest.console.exe test.dll -- TestRunParameters.Parameter\(name=\"myParam\",\ value=\"value\"\)
+```
 
 Parameter values can contain semicolons and other special characters, such as connection strings, but the shell must pass them through literally. For complex values, consider using a *.runsettings* file instead:
 

--- a/docs/test/vstest-console-options.md
+++ b/docs/test/vstest-console-options.md
@@ -119,7 +119,7 @@ In PowerShell, you need to use quotes:
 vstest.console.exe myTestFile.dll /logger:"console;verbosity=detailed"
 ```
 
-For the full list of available loggers — including the built-in console, TRX, and HTML loggers and community loggers for xUnit, NUnit, JUnit, AppVeyor, Azure Pipelines, GitHub Actions, and TeamCity — as well as instructions for authoring your own logger, see [Reporting test results](https://github.com/microsoft/vstest/blob/main/docs/report.md) in the vstest repository.
+For the full list of available loggers, as well as instructions for authoring your own logger, see [Reporting test results](https://github.com/microsoft/vstest/blob/main/docs/report.md) in the vstest repository.
 
 ## UWP example
 

--- a/docs/test/vstest-console-options.md
+++ b/docs/test/vstest-console-options.md
@@ -119,6 +119,8 @@ In PowerShell, you need to use quotes:
 vstest.console.exe myTestFile.dll /logger:"console;verbosity=detailed"
 ```
 
+For the full list of available loggers — including the built-in console, TRX, and HTML loggers and community loggers for xUnit, NUnit, JUnit, AppVeyor, Azure Pipelines, GitHub Actions, and TeamCity — as well as instructions for authoring your own logger, see [Reporting test results](https://github.com/microsoft/vstest/blob/main/docs/report.md) in the vstest repository.
+
 ## UWP example
 
 For UWP, the appxrecipe file must be referenced instead of a DLL.

--- a/docs/test/vstest-console-options.md
+++ b/docs/test/vstest-console-options.md
@@ -1,7 +1,7 @@
 ---
 title: VSTest.Console.exe command-line options
 description: Learn about the VSTest.Console.exe command-line tool that runs tests. This article includes the General command-line options.
-ms.date: 02/28/2025
+ms.date: 07/13/2026
 ms.topic: reference
 helpviewer_keywords:
 - vstest.console.exe
@@ -38,7 +38,7 @@ The following table lists all the options for *VSTest.Console.exe* and short des
 |**/TestAdapterPath:[*path*]**|Forces the *vstest.console.exe* process to use custom test adapters from a specified path (if any) in the test run.<br />Example: `/TestAdapterPath:[pathToCustomAdapters]`|
 |**/Platform:[*platform type*]**|Forces the given platform to be used, instead of the platform determined from the current runtime. This option is able to force only x86, and x64 platforms on Windows. The ARM option is broken and will result in x64 on most systems.<br />Do NOT specify this option to run on runtimes that aren't in the list of valid values such as ARM64.<br />Valid values are x86, x64, and ARM.<br /> 
 |**/Framework: [*framework version*]**|Target .NET version to be used for test execution.<br />Example values are `Framework35`, `Framework40`, `Framework45`, `FrameworkUap10`, `.NETCoreApp,Version=v1.1`.<br />TargetFrameworkAttribute is used to automatically detect this option from your assembly, and defaults to `Framework40` when the attribute isn't present. You must specify this option explicitly if you remove the [TargetFrameworkAttribute](/dotnet/api/system.runtime.versioning.targetframeworkattribute) from your .NET Core assemblies.<br />If the target framework is specified as **Framework35**, the tests run in CLR 4.0 "compatibility mode".<br />Example: `/Framework:framework40`|
-|**/TestCaseFilter:[*expression*]**|Run tests that match the given expression.<br /><Expression\> is of the format <property\>=<value\>[\|<Expression\>].<br />Example: `/TestCaseFilter:"Priority=1"`<br />Example: `/TestCaseFilter:"TestCategory=Nightly|FullyQualifiedName=Namespace.ClassName.MethodName"`<br />The **/TestCaseFilter** command-line option can't be used with the **/Tests** command-line option. <br />For information about creating and using expressions, see [TestCase filter](https://github.com/Microsoft/vstest-docs/blob/main/docs/filter.md).|
+|**/TestCaseFilter:[*expression*]**|Run tests that match the given expression.<br /><Expression\> is of the format <property\>=<value\>[\|<Expression\>].<br />Example: `/TestCaseFilter:"Priority=1"`<br />Example: `/TestCaseFilter:"TestCategory=Nightly|FullyQualifiedName=Namespace.ClassName.MethodName"`<br />The **/TestCaseFilter** command-line option can't be used with the **/Tests** command-line option. <br />For information about creating and using expressions, see [TestCase filter](https://github.com/microsoft/vstest/blob/main/docs/filter.md).|
 |**/?**|Displays usage information.|
 |**/Logger:[*uri/friendlyname*]**|Specify a logger for test results. Specify the parameter multiple times to enable multiple loggers.<br />Example: To log results into a Visual Studio Test Results File (TRX), use<br />**/Logger:trx**<br />**[;LogFileName=\<Defaults to unique file name>]**<br />For more information, see [Logging example](#logging-example).|
 |**/ListTests:[*file name*]**|Lists discovered tests from the given test container.<br />Note: The `/TestCaseFilters` option has no effect when listing tests; it only controls which tests get run.|
@@ -46,12 +46,12 @@ The following table lists all the options for *VSTest.Console.exe* and short des
 |**/ListExecutors**|Lists installed test executors.|
 |**/ListLoggers**|Lists installed test loggers.|
 |**/ListSettingsProviders**|Lists installed test settings providers.|
-|**/Blame**|Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash. When a crash is detected, it creates a sequence file in `TestResults/<Guid>/<Guid>_Sequence.xml` that captures the order of tests that were run before the crash. For more information, see [Blame data collector](https://github.com/Microsoft/vstest-docs/blob/main/docs/extensions/blame-datacollector.md).|
+|**/Blame**|Runs the tests in blame mode. This option is helpful in isolating problematic tests that cause the test host to crash. When a crash is detected, it creates a sequence file in `TestResults/<Guid>/<Guid>_Sequence.xml` that captures the order of tests that were run before the crash. For more information, see [Blame data collector](https://github.com/microsoft/vstest/blob/main/docs/extensions/blame-datacollector.md).|
 |**/Diag:[*file name*]**|Writes diagnostic trace logs to the specified file.|
 |**/ResultsDirectory:[*path*]**|Test results directory will be created in specified path if not exists.<br />Example: `/ResultsDirectory:<pathToResultsDirectory>`|
 |**/ParentProcessId:[*parentProcessId*]**|Process ID of the Parent Process responsible for launching current process.|
 |**/Port:[*port*]**|The Port for socket connection and receiving the event messages.|
-|**/Collect:[*dataCollector friendlyName*]**|Enables data collector for the test run. [More information](https://github.com/Microsoft/vstest-docs/blob/main/docs/analyze.md).|
+|**/Collect:[*dataCollector friendlyName*]**|Enables data collector for the test run. [More information](https://github.com/microsoft/vstest/blob/main/docs/analyze.md).|
 
 > [!TIP]
 > The options and values aren't case-sensitive.


### PR DESCRIPTION
Enrichment of the VSTest documentation on Microsoft Learn (VS docs test area), reconciled against the maintained microsoft/vstest repository.

**Files**
- `docs/test/vstest-console-options.md` — update cross-reference links that pointed at the archived `microsoft/vstest-docs` repo to the maintained `microsoft/vstest` repo (filter, blame data collector, analyze), and add a pointer to the full logger catalog + logger-authoring guide.
- `docs/test/configure-unit-tests-by-using-a-dot-runsettings-file.md` — add an "Override run settings from the command line" section covering the `-- name=value` inline override syntax, `TestRunParameters` via the command line, and shell-specific quoting. Examples use `vstest.console.exe` (the page's context; the `-- name=value` override is a native `vstest.console.exe` feature via `CliRunSettingsArgumentProcessor`), with a note that `dotnet test` uses the same syntax.

Opened from a fork; happy to adjust to match the docs team's conventions.
