### PR TITLE
Minor phrasing fix in Agent mode file manipulation section

### DIFF
--- a/docs/ide/copilot-agent-mode.md
+++ b/docs/ide/copilot-agent-mode.md
@@ -362,7 +362,7 @@ If you want to align on an approach before making code changes, use the GitHub C
 
 ### What visibility does agent mode have into my files?
 
-Agent mode can manipulate only:
+Agent mode can only manipulate:
 
 - Local files that are part of the solution.
 - Local files that are in the open solution directory or its subdirectories.


### PR DESCRIPTION
Changed the wording from 'can manipulate only...' to 'can only manipulate...' to make the sentence flow slightly better.



<!--
Thanks for contributing to the Visual Studio documentation.

Note: Internal Microsoft employees and vendors should use the private repo, https://github.com/MicrosoftDocs/visualstudio-docs-pr. You must be a member of the MicrosoftDocs GitHub organization. To join, see https://review.learn.microsoft.com/help/get-started/setup-github?branch=main#3-join-microsoftdocs-and-other-organizations.

Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for Microsoft Learn, see the [contributor guide](https://learn.microsoft.com/contribute/).

When your PR is ready for review, add a comment with the text #sign-off to the Conversation tab.
-->
