### PR TITLE
Add Microsoft Office 2024 to version 10.0.60917

### DIFF
--- a/docs/vsto/visual-studio-tools-for-office-runtime.md
+++ b/docs/vsto/visual-studio-tools-for-office-runtime.md
@@ -52,6 +52,6 @@ The following list contains the VSTO Runtime releases and the corresponding vers
 | 10.0.60828 | 01/12/2018 | Microsoft Office 2019 / <br>Microsoft Office 2021 / <br>Office 365 |
 | 10.0.60910 | 08/08/2023 | Microsoft Office 2013 / <br>Microsoft Office 2016 / <br>Microsoft Office 2019 / <br>Microsoft Office 2021 / <br>Office 365 |
 | 10.0.60912 | 11/01/2023 | Microsoft Office 2019 / <br>Microsoft Office 2021 / <br>Office 365 |
-| 10.0.60917 | 02/28/2024 | Microsoft Office 2019 / <br>Microsoft Office 2021 / <br>Office 365 |
+| 10.0.60917 | 02/28/2024 | Microsoft Office 2019 / <br>Microsoft Office 2021 / <br>Microsoft Office 2024 / <br>Office 365 |
 
 For more information on the Office Support Lifecycle, see [Lifecycle FAQ - Office, Office 365, and Microsoft 365](/lifecycle/faq/office).


### PR DESCRIPTION
Updated the version entry for 10.0.60917 to include Microsoft Office 2024.
As per our experience, VSTO works just fine with Microsoft Office 2024 but our customers security evaluation raises concerns, since the support is not officially documented. 

If Microsoft Office 2024 is supported, it would be great if this would be included in the support schedule. 