### PR TITLE
Update MSBuild Server docs: enabled by default in .NET 11 SDK

### DIFF
--- a/docs/msbuild/msbuild-server.md
+++ b/docs/msbuild/msbuild-server.md
@@ -1,12 +1,12 @@
 ---
 title: MSBuild Server
 description: Learn how MSBuild Server supports frequent build scenarios by caching build context over multiple builds.
-ms.date: 10/11/2022
+ms.date: 08/11/2026
 ms.topic: overview
 helpviewer_keywords:
 - MSBuild Server
-author: nitinme
-ms.author: nitinme
+author: janprovaznik
+ms.author: janprovaznik
 
 ms.subservice: msbuild
 ---
@@ -18,23 +18,29 @@ MSBuild Server is generally not helpful in CI scenarios such as Azure Pipeline b
 
 ## Enable MSBuild Server
 
-MSBuild server is not enabled by default; to enable it, set the environment variable `DOTNET_CLI_USE_MSBUILD_SERVER` to `true` or `1`.
+Starting with the .NET 11 SDK, MSBuild Server is enabled by default for MSBuild-based .NET CLI commands such as `dotnet build` and `dotnet msbuild`.
 
-Once enabled, for the first time you start a new build process, the build server is launched. When you start the first build, it enables the cache. The cache is persisted after the completion of the first build; the second build therefore proceeds faster since the startup time is significantly reduced due to the cached information. The cache persists after the build is completed, but after an idle time of 15 minutes, it shuts down. Therefore, it is primarily beneficial in repetitive build scenarios where many builds are requested in close succession.
+In earlier .NET SDKs, MSBuild Server was off by default and you enabled it by setting `DOTNET_CLI_USE_MSBUILD_SERVER` to `true` or `1`.
+
+The first time you start a build, the build server is launched and the cache is populated. The cache is persisted after the completion of that build; the second build therefore proceeds faster since the startup time is significantly reduced due to the cached information. The cache persists after the build is completed, but after an idle time of 15 minutes, the server shuts down. Therefore, it is primarily beneficial in repetitive build scenarios where many builds are requested in close succession.
+
+MSBuild Server is also engaged automatically for multithreaded builds (`-mt`), because multithreaded execution runs project work inside the server process.
 
 ## Shut down or disable MSBuild Server
 
 There are a few different ways to disable the use of MSBuild server. If you just want to shut down the running server, you can issue the command `dotnet build-server shutdown`.
 
-To disable the feature for all builds on a machine, you can set the system environment variable `DOTNET_CLI_USE_MSBUILD_SERVER` to `0` or `false`. You could also set this variable on a per-project basis in a tool like VS Code in `launch.json`.
+To disable the feature for all builds on a machine, you can set the system environment variable `DOTNET_CLI_USE_MSBUILD_SERVER` to `false`. You could also set this variable on a per-project basis in a tool like VS Code in `launch.json`.
 
-To disable MSBuild Server for a particular invocation of a command-line build, you can use the option `/nr:false` (or `/node-reuse:false`).
+To disable MSBuild Server for a particular invocation of a command-line build, you can use the option `/nr:false` (or `/node-reuse:false`). MSBuild Server is a form of node reuse, so disabling node reuse also disables the server and the build runs in the launching process.
 
-To disable the feature entirely, you can opt out of the change wave that enabled it; `SET MSBuildDisableFeaturesFromVersion="17.4"`. This disabled other features in the same change wave. For more information about change waves, see [MSBuild change waves](change-waves.md).
+MSBuild Server is not used for invocations that are inherently incompatible with hosting the build in a separate process, such as `-help`, `-version`, and replaying a binary log. Those builds fall back to running in the launching process.
 
 ## Determine the current status of the build server
 
 You can view process status on the machine and look for MSBuild server processes. MSBuild server processes are launched with `dotnet.exe` and show a path to MSBuild.dll and the command option `/nodemode:8`, where `8` indicates MSBuild Server ( `/nodemode:1` indicates the normal MSBuild worker nodes).
+
+Builds that request MSBuild Server also record what happened to it. Run with `-v:diag`, or capture a binary log with `-bl`, to see whether the build started a new server, reused a running one, or fell back to an in-process build and why.
 
 ## See also
 


### PR DESCRIPTION
## Summary

MSBuild Server is enabled by default for MSBuild-based .NET CLI commands (`dotnet build`, `dotnet msbuild`) starting with the .NET 11 SDK. This page still described it as opt-in, and its opt-out guidance is now out of date. See [dotnet/sdk#55231](https://github.com/dotnet/sdk/pull/55231) (milestone `11.0-preview7`), which flips `DOTNET_CLI_USE_MSBUILD_SERVER` to default `true`.

## Changes

- **Default is now on.** `## Enable MSBuild Server` documents the .NET 11 default and keeps a sentence about the previous opt-in behavior for readers on earlier SDKs.
- **Removed the change wave 17.4 opt-out.** This was the most important correction. Wave 17.4 has left the current change wave rotation, so `SET MSBuildDisableFeaturesFromVersion=17.4` is now treated as out of rotation and **enables all features** rather than disabling MSBuild Server. Following the old instruction produces the opposite of the intended effect. MSBuild Server is no longer change-wave gated at all.
- **Corrected the opt-out value.** `DOTNET_CLI_USE_MSBUILD_SERVER` is documented as `false`.
- **Documented `-mt`.** Multithreaded builds engage MSBuild Server, because multithreaded execution runs project work inside the server process.
- **Documented in-process fallback.** Invocations that cannot be hosted in a separate process (`-help`, `-version`, binary log replay) fall back to building in the launching process.
- **Added diagnostics guidance.** Builds that request the server record whether one was started, reused, or not used and why; visible at `-v:diag` or in a binary log.

## Verification

Claims were checked against the MSBuild implementation on `main`:

- Default flip and opt-out precedence: `MSBuildForwardingAppWithoutLogging.cs` in dotnet/sdk (`DOTNET_CLI_USE_MSBUILD_SERVER` defaults to `true`; `MSBUILDUSESERVER` is only set when the user has not set it).
- 15-minute idle shutdown: `CommunicationsUtilities.NodeConnectionTimeout` (`900 * 1000` ms).
- `/nodemode:8`: `NodeMode.OutOfProcServerNode = 8`.
- Change wave rotation: `ChangeWaves.AllWaves` currently starts at 17.10, so 17.4 is out of rotation.
- `-mt` implies server: `XMake.ShouldUseMSBuildServer`.

## Notes for reviewers

- `ms.date` refreshed; `author`/`ms.author` updated to the current owner.
- Only the `.NET 11` timing statement is forward-looking; everything else describes shipped behavior.