### PR TITLE
Correct BuildDependsOn in how-to-extend-the-visual-studio-build-proce…

### DIFF
--- a/docs/msbuild/how-to-extend-the-visual-studio-build-process.md
+++ b/docs/msbuild/how-to-extend-the-visual-studio-build-process.md
@@ -81,7 +81,6 @@ This piece of XML indicates that before the `Build` target can run, all the targ
 ```xml
 <PropertyGroup>
     <BuildDependsOn>
-        $(BuildDependsOn);
         BeforeBuild;
         CoreBuild;
         AfterBuild


### PR DESCRIPTION
…ss.md

BuildDependsOn in the default target files does not include $(BuildDependsOn). Remove that line to make it match code at https://github.com/dotnet/msbuild/blob/6680032d11ab4bf746983a0fe791274beaf2864a/src/Tasks/Microsoft.Common.CurrentVersion.targets#L917

