### PR TITLE
Fix duplicate Version tag in example

### DIFF
--- a/docs/ide/how-to-create-item-templates.md
+++ b/docs/ide/how-to-create-item-templates.md
@@ -69,7 +69,7 @@ You can edit the *.vstemplate* file to specify that your item template appears o
 The following example shows a *.vstemplate* file for `Office` projects.
 
 ```xml
-<VSTemplate Version="2.0.0" Type="Item" Version="2.0.0">
+<VSTemplate Version="2.0.0" Type="Item">
    <TemplateData>
       <Name>Class</Name>
       <Description>An empty class file</Description>


### PR DESCRIPTION
Fix the duplicate Version tag in the example



<!--
Thanks for contributing to the Visual Studio documentation.

Note: Internal Microsoft employees and vendors should use the private repo, https://github.com/MicrosoftDocs/visualstudio-docs-pr. You must be a member of the MicrosoftDocs GitHub organization. To join, see https://review.learn.microsoft.com/help/get-started/setup-github?branch=main#3-join-microsoftdocs-and-other-organizations.

Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for Microsoft Learn, see the [contributor guide](https://learn.microsoft.com/contribute/).

When your PR is ready for review, add a comment with the text #sign-off to the Conversation tab.
-->
