### PR TITLE
Enhance template example clarity

### DIFF
--- a/docs/ide/how-to-create-item-templates.md
+++ b/docs/ide/how-to-create-item-templates.md
@@ -66,10 +66,10 @@ You can edit the *.vstemplate* file to specify that your item template appears o
 1. Open the *.vstemplate* file for editing.
 1. Add a [ProjectSubType](../extensibility/projectsubtype-element-visual-studio-templates.md) element immediately after the `ProjectType` element, with value `Windows`, `Office`, `Database`, or `Web`. For example: `<ProjectSubType>Database</ProjectSubType>`.
 
-The following example shows a *.vstemplate* file for `Office` projects.
+The following example shows a *.vstemplate* file for `Office` projects, where `Class.cs` is the default name in the New dialog and `Class1.cs` is the name of the C# class template located alongside the *.vstemplate* file.
 
 ```xml
-<VSTemplate Version="2.0.0" Type="Item">
+<VSTemplate Version="2.0.0" Type="Item" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005">
    <TemplateData>
       <Name>Class</Name>
       <Description>An empty class file</Description>
@@ -79,7 +79,7 @@ The following example shows a *.vstemplate* file for `Office` projects.
       <DefaultName>Class.cs</DefaultName>
    </TemplateData>
    <TemplateContent>
-      <ProjectItem>Class1.cs</ProjectItem>
+      <ProjectItem ReplaceParameters="true">Class1.cs</ProjectItem>
    </TemplateContent>
 </VSTemplate>
 ```


### PR DESCRIPTION
Clarified the example for templates by specifying the default name in the New dialog and the location of the C# class template.

If you don't have the `xmlns` in there, Visual Studio will show an error when you try to use a custom template.

Additionally, I feel like `ReplaceParameters="true"` being in there can help add clarity to whether or not parameters are replaced in the template file. This held me up for a bit when creating my own template. Having it as `true` by default in the example feels like the safer option. 

<!--
Thanks for contributing to the Visual Studio documentation.

Note: Internal Microsoft employees and vendors should use the private repo, https://github.com/MicrosoftDocs/visualstudio-docs-pr. You must be a member of the MicrosoftDocs GitHub organization. To join, see https://review.learn.microsoft.com/help/get-started/setup-github?branch=main#3-join-microsoftdocs-and-other-organizations.

Before creating your pull request, please check your content against these quality criteria:

- Did you consider search engine optimization (SEO) when you chose the title in the metadata section and the H1 heading (i.e. the displayed title that starts with a single #)?
- For new articles, did you add it to the table of contents?
- Did you update the "ms.date" metadata for new or significantly updated articles?
- Are technical terms and concepts introduced and explained, and are acronyms spelled out on first mention?
- Should this page be linked to from other pages or Microsoft web sites?

For more information about creating content for Microsoft Learn, see the [contributor guide](https://learn.microsoft.com/contribute/).

When your PR is ready for review, add a comment with the text #sign-off to the Conversation tab.
-->
